### PR TITLE
fix(cli): default agent to claude-code + persist agent on init (#7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ Lecciones y patrones confirmados en este repo. Todo agente que trabaje aquí deb
 
 - **runbook-as-script:** para workstreams que combinan documentación + verificación manual, escribir el doc como hipótesis y ejecutarlo literalmente como test. Las divergencias se corrigen en el doc (no en el tool); el entregable es un doc verificado contra realidad. Confirmado en WS-5: §4.4 (error messages), §4.5 (pin mechanics) y §4.7 (onboarding sequence) se corrigieron durante la Fase C. Tres hallazgos de QA (doctor example stale, sync footnote, onboarding incompleto) también apuntan al mismo patrón: escribir ejemplos de output de CLI sin verificar contra el binario real.
 
+## Release / publish
+
+- **El release del CLI es automático en `main` — no hay paso manual de `npm publish`.** `.github/workflows/release.yml` (trigger `push` a `main`) buildea `cli/` y corre `cli/src/release/index.js`: bump por conventional commits + `npm publish` vía OIDC Trusted Publisher + commit de bump con `[skip ci]`. **Antes de decir "publicá a mano" o de proponer/crear un workflow de release, verificá que `release.yml` ya lo cubre** — ya existe y es completo (esta nota nace de haber afirmado por error que el publish era manual, contradiciendo el propio `release.yml`). El nivel de versión sale del prefijo de conventional commit del merge; regla no-negociable en `CONSTITUTION.md` → "Release del CLI".
+
 ## Layout del repo y de la instalación
 
 - **Este repo** contiene solo el CLI TypeScript (`cli/`). El contenido (skills, bundles, sensor-packs, hooks) vive en repos externos: `awm-baseline-registry` y `awm-documentation-registry`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ This document codifies architectural and design principles for the Agentic Workf
 
 **El flujo correcto para contenido:** editar en el repo de registry correspondiente → commit → tag `vX.Y.Z` → `awm update` en las máquinas que usen ese registry. Los skills instalados en `~/.claude/skills/` son symlinks hacia `~/.awm/registries/<name>/skills/`, así que reflejan el registry instalado, no el working copy — la latencia entre editar el registry y verlo instalado es esperada y correcta; no se "atajea" editando la instalación.
 
-**El flujo correcto para el CLI:** todo cambio de CLI se hace en `cli/` → se commitea → se publica vía `npm publish` desde `cli/`. Los usuarios reciben la nueva versión con `npm i -g agentic-workflow-manager`.
+**El flujo correcto para el CLI:** todo cambio de CLI se hace en `cli/` → se commitea → se mergea a `main`. El publish a npm es **automático**: `.github/workflows/release.yml` corre en cada push a `main`, buildea `cli/` y ejecuta `cli/src/release/index.js` (bump de versión por conventional commits + `npm publish` vía OIDC Trusted Publisher, con `[skip ci]` en el commit de bump para no re-dispararse). **No se corre `npm publish` a mano, ni se crea un workflow paralelo de publish.** El nivel de release sale del prefijo de conventional commit del merge (`feat`→minor, `fix`→patch, `!`/`BREAKING`→major). Los usuarios reciben la nueva versión con `npm i -g agentic-workflow-manager`.
 
 **Tests:** ningún test puede tocar el `~/.awm` real. Todos usan tmpdirs aislados con `process.env.HOME` y `process.env.AWM_HOME` sobreescritos (patrón de `cli/tests/commands/hooks/install.test.ts`).
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -10,6 +10,10 @@ Reglas de proceso del proyecto. Todo agente que trabaje en este repo debe leerla
 
 - **Al escribir un guard de nombre/componente de path, rechazar el conjunto completo de entradas peligrosas: string vacío, `.`, `..`, `/`, `\\`.** Nunca enumerar solo los patrones que se te ocurran. Un guard que rechaza `..` y `/` pero deja pasar `.` sigue siendo una vulnerabilidad de path traversal — `path.join('registries', '.')` resuelve al directorio padre. Usar siempre `name === '.' || name.includes('..') || /[/\\]/.test(name) || !name` como base.
 
+## Release del CLI
+
+- **El publish del CLI a npm es automático y exclusivo de la CI — nunca se corre `npm publish` a mano ni se crea un workflow paralelo de publish.** `.github/workflows/release.yml` dispara en cada push a `main`: buildea `cli/` y corre `cli/src/release/index.js`, que bumpea la versión por conventional commits, publica vía OIDC Trusted Publisher (`id-token: write`, sin token de npm en secrets) y commitea el bump con `[skip ci]`. Un `npm publish` manual saltea el bump y el OIDC, y desincroniza la versión publicada del historial. Corolario: el nivel de release depende del prefijo de conventional commit del merge (`feat`→minor, `fix`→patch, `!`/`BREAKING`→major) — escribí el título del PR/commit de merge en consecuencia. Antes de proponer cualquier automatización de release, verificá que `release.yml` ya la cubre.
+
 ## Implementación
 
 - **Al conectar una función nueva que reemplaza un call directo en múltiples puntos (p.ej. un resolver que reemplaza una constante hardcodeada), buscar TODOS los call-sites con `grep` antes de marcar el task completo.** El plan puede no listar módulos secundarios. En WS-2, `init/steps.ts` quedó sin wiring porque el plan solo mencionaba `index.ts`; el spec-reviewer lo detectó pero solo después del commit. Comando de referencia: `grep -rn "syncRegistry\b" src/ --include="*.ts"`.

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -11,6 +11,7 @@ import { defaultActions } from '../core/init/steps';
 import type { InitOutcome, InitActions, StepResult } from '../core/init/types';
 import type { AgentTarget } from '../providers';
 import { warnIfUnsupportedPlatform } from '../core/paths';
+import { getPreferences, savePreferences, preferencesExist } from '../utils/config';
 
 // ---------------------------------------------------------------------------
 // Rendering
@@ -72,6 +73,15 @@ export interface RunInitOptions {
 export async function runInit(opts: RunInitOptions = {}): Promise<number> {
     const cwd = opts.cwd ?? process.cwd();
     const agent: AgentTarget = (opts.agent as AgentTarget) ?? 'claude-code';
+
+    // #7: make init the source of truth for the default agent. Persist the resolved
+    // agent so later `awm add`/`awm sync` (which read preferences.defaultAgent) target
+    // the right agent instead of stamping the static default. Do NOT clobber an existing
+    // explicit preference on a bare re-init: only write when an agent was passed via -a,
+    // or when no preferences file exists yet.
+    if (opts.agent != null || !preferencesExist()) {
+        savePreferences({ ...getPreferences(), defaultAgent: agent });
+    }
 
     let outcome: InitOutcome;
     try {

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -17,13 +17,25 @@ export interface AwmPreferences {
 }
 
 const DEFAULT_PREFS: AwmPreferences = {
-    defaultAgent: 'antigravity',
+    // claude-code matches `awm init`'s own documented default (see init.ts / `awm init --help`).
+    // Previously 'antigravity', which silently mis-installed bundles in claude-code
+    // environments when `awm add` (the first getPreferences caller) stamped it to disk (#7).
+    defaultAgent: 'claude-code',
     installMethod: 'symlink',
     defaultScope: 'local'
 };
 
 function prefsDir(): string {
     return awmHome();
+}
+
+function prefsFile(): string {
+    return path.join(prefsDir(), 'preferences.json');
+}
+
+/** True if preferences.json is already on disk (no side effect — does NOT create it). */
+export function preferencesExist(): boolean {
+    return fs.existsSync(prefsFile());
 }
 
 export function getPreferences(): AwmPreferences {

--- a/cli/tests/commands/init.test.ts
+++ b/cli/tests/commands/init.test.ts
@@ -83,4 +83,28 @@ describe('runInit', () => {
         expect(parsed.after.overall).toBe('degraded');
         expect(code).toBe(1);
     });
+
+    const prefsFile = () => path.join(process.env.AWM_HOME as string, 'preferences.json');
+    const readAgent = () => JSON.parse(fs.readFileSync(prefsFile(), 'utf-8')).defaultAgent;
+
+    it('#7: first init (no -a) persists claude-code as the default agent', async () => {
+        const { runInit } = require('../../src/commands/init');
+        expect(fs.existsSync(prefsFile())).toBe(false);
+        await runInit({ cwd: tmpHome, yes: true, actions: { syncCache: async () => {} } });
+        expect(readAgent()).toBe('claude-code');
+    });
+
+    it('#7: init -a opencode persists the explicit agent', async () => {
+        const { runInit } = require('../../src/commands/init');
+        await runInit({ cwd: tmpHome, yes: true, agent: 'opencode', actions: { syncCache: async () => {} } });
+        expect(readAgent()).toBe('opencode');
+    });
+
+    it('#7: re-init without -a does NOT clobber an existing explicit preference', async () => {
+        const { savePreferences } = require('../../src/utils/config');
+        savePreferences({ defaultAgent: 'opencode', installMethod: 'symlink', defaultScope: 'local' });
+        const { runInit } = require('../../src/commands/init');
+        await runInit({ cwd: tmpHome, yes: true, actions: { syncCache: async () => {} } });
+        expect(readAgent()).toBe('opencode');
+    });
 });

--- a/cli/tests/utils/config.test.ts
+++ b/cli/tests/utils/config.test.ts
@@ -1,5 +1,5 @@
 // tests/utils/config.test.ts
-import { getPreferences, savePreferences } from '../../src/utils/config';
+import { getPreferences, savePreferences, preferencesExist } from '../../src/utils/config';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -17,9 +17,15 @@ describe('Preferences Manager', () => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it('creates default preferences if none exist', () => {
+    it('creates default preferences if none exist (default agent is claude-code)', () => {
         const prefs = getPreferences();
-        expect(prefs.defaultAgent).toBe('antigravity');
+        expect(prefs.defaultAgent).toBe('claude-code');
+    });
+
+    it('preferencesExist reflects whether the file is on disk', () => {
+        expect(preferencesExist()).toBe(false);
+        getPreferences(); // side-effect: persists defaults
+        expect(preferencesExist()).toBe(true);
     });
 
     it('saves and loads preferences correctly', () => {

--- a/docs/plans/2026-07-22-fix-default-agent-design.md
+++ b/docs/plans/2026-07-22-fix-default-agent-design.md
@@ -1,0 +1,51 @@
+# Fix: default agent incorrecto (antigravity) al instalar bundles — Design
+
+Resuelve [agentic-workflow#7](https://github.com/Kodria/agentic-workflow/issues/7).
+
+## Problema (causa raíz, verificada en el código)
+
+En un entorno claude-code, `awm add <bundle> --yes` (sin `-a`) instala los bundles para el agente equivocado (`antigravity`), dejando `awm doctor` en `degraded` desde la primera sesión y las skills invisibles para Claude Code.
+
+- `DEFAULT_PREFS.defaultAgent = 'antigravity'` (`cli/src/utils/config.ts:20`), y `getPreferences()` **persiste** ese default a `~/.awm/preferences.json` la primera vez que se lo llama si el archivo no existe.
+- `awm init` resuelve su agente como `opts.agent ?? 'claude-code'` (`cli/src/commands/init.ts:74`) pero **nunca llama a `getPreferences`/`savePreferences`** — no deja rastro del agente en preferences.
+- Entonces `awm add` es la **primera** llamada a `getPreferences()` en el flujo del setup script → stampea `antigravity` en disco y lo usa como target de instalación.
+
+## Requirements
+
+- R1: THE default de `AwmPreferences.defaultAgent` SHALL ser `claude-code` (coincidiendo con el default documentado de `awm init --help`), no `antigravity`.
+- R2: WHEN `awm init` corre con `-a <agent>` explícito, THE init SHALL persistir ese agente como `defaultAgent` en `preferences.json`.
+- R3: WHEN `awm init` corre AND no existe `preferences.json` todavía, THE init SHALL persistir el agente resuelto (default `claude-code`) a `preferences.json`.
+- R4: IF `preferences.json` YA existe AND no se pasó `-a`, THEN `awm init` SHALL NO sobrescribir el `defaultAgent` guardado (no pisar una elección explícita previa).
+- R5: THE fix SHALL NO tocar el `~/.awm` real; todos los tests usan tmpdirs aislados con `AWM_HOME`/`HOME` sobreescritos (patrón del CLAUDE.md).
+
+## Approach (A + B)
+
+**A — default correcto** (`cli/src/utils/config.ts`): `DEFAULT_PREFS.defaultAgent: 'antigravity' → 'claude-code'`. Arregla el síntoma reportado (el add stampea claude-code) y alinea con el default que init ya documenta. (R1)
+
+**B — init como fuente de verdad** (`cli/src/commands/init.ts`): tras resolver `agent`, persistir la preferencia — pero **sin pisar** una elección previa:
+
+```ts
+// pseudocódigo
+if (opts.agent != null || !preferencesExist()) {
+    savePreferences({ ...getPreferences(), defaultAgent: agent });
+}
+```
+
+- `-a` explícito → persiste ese agente (R2).
+- Primer init sin archivo → persiste el resuelto (default claude-code) (R3).
+- Re-init sin `-a` con archivo existente → no toca nada (R4). **Esto evita la regresión** de resetear a claude-code una preferencia que el usuario fijó a opencode/antigravity.
+
+Helper nuevo en `config.ts`: `preferencesExist(): boolean` — mantiene el conocimiento de la ruta del archivo dentro de `config.ts` (init no calcula paths de `~/.awm`).
+
+## Descartado
+
+- **C (detección por env)**: más frágil (nombres de env var varían entre versiones/superficies) y más código. Deja como enhancement futuro si se quiere robustez extra.
+- **D (exigir `-a` en `--yes`)**: rompería la ergonomía del setup script documentado.
+
+## Testing
+
+`cli/tests/utils/config.test.ts` **afirma** `defaultAgent === 'antigravity'` (línea ~24) — hay que actualizarlo a `claude-code` (si no, R1 lo rompe). Tests nuevos:
+- `config.test.ts`: default es `claude-code`; `preferencesExist()` false→true.
+- `init` (nuevo o en el test suite de init): primer init persiste claude-code (R3); `init -a opencode` persiste opencode (R2); re-init sin `-a` no pisa una preferencia opencode existente (R4).
+
+Todos con `AWM_HOME` tmpdir aislado (R5). Verificación: `npm test` en `cli/` en verde.


### PR DESCRIPTION
Resuelve #7.

## Causa raíz

En un entorno claude-code, `awm add <bundle> --yes` (sin `-a`) instalaba los bundles para `antigravity`, dejando `awm doctor` en `degraded` y las skills invisibles para Claude Code:

- `DEFAULT_PREFS.defaultAgent = 'antigravity'` (`cli/src/utils/config.ts`), y `getPreferences()` **persiste** ese default la primera vez que se lo llama.
- `awm init` resuelve su agente como `opts.agent ?? 'claude-code'` pero **nunca lo persistía** — el primer `getPreferences()` (desde `awm add`) stampeaba `antigravity`.

## Fix (A + B)

**A — default correcto:** `DEFAULT_PREFS.defaultAgent` → `claude-code`, alineado con el default que `awm init --help` ya documenta.

**B — init como fuente de verdad:** tras resolver el agente, `awm init` lo persiste en `preferences.json`, **sin pisar** una elección previa:
```ts
if (opts.agent != null || !preferencesExist()) {
    savePreferences({ ...getPreferences(), defaultAgent: agent });
}
```
- `awm init -a opencode` → persiste `opencode`.
- Primer init sin `-a` → persiste `claude-code`.
- Re-init sin `-a` con preferencia previa → **no la toca**.

Nuevo helper `preferencesExist()` en `config.ts` (sin efecto colateral, no crea el archivo).

## Docs (segundo commit, `docs:`)

Actualiza `CLAUDE.md` / `CONSTITUTION.md` / `AGENTS.md` para documentar que el **publish del CLI es automático** vía `.github/workflows/release.yml` (bump por conventional commits + `npm publish` OIDC en cada push a `main`) — **no manual**. La línea previa de `CLAUDE.md` ("se publica vía `npm publish` desde `cli/`") inducía a error. Regla no-negociable agregada en CONSTITUTION ("Release del CLI"): nunca publish a mano ni workflow paralelo.

## Test Plan

- [x] `npx jest tests/utils/config.test.ts tests/commands/init.test.ts` → **11/11 verde**.
- [x] Suite completa: **626 passing**. Los 2 fallos restantes (`tests/commands/doctor.test.ts`) son **pre-existentes** — fallan idéntico en `main` sin este cambio (verificado con `git stash`); problema de aislamiento del doctor test en entornos con `awm` global, no relacionado con #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)