### PR TITLE
fix: allow a Codex-only bootstrap to pass the R19 Claude-baseline guard

### DIFF
--- a/cli/src/core/init/provider-facts.ts
+++ b/cli/src/core/init/provider-facts.ts
@@ -85,18 +85,34 @@ function hashDirectoryTree(dir: string, exclude: Set<string>): string {
     return parts.join('|');
 }
 
+/** Canonical digest for "this agent owns nothing here" — see hashPath. */
+const NO_CONTENT = 'absent';
+
 function hashPath(target: string, exclude: Set<string>): string {
     let stat: fs.Stats;
     try {
         stat = fs.lstatSync(target);
     } catch {
-        return 'absent';
+        return NO_CONTENT;
     }
     if (stat.isSymbolicLink()) {
         return `symlink:${fs.readlinkSync(target)}`;
     }
     if (stat.isDirectory()) {
-        return `dir:${hashDirectoryTree(target, exclude)}`;
+        const tree = hashDirectoryTree(target, exclude);
+        // A managed directory that exists but holds nothing this agent owns is
+        // indistinguishable, for R19's purposes, from one that doesn't exist:
+        // either way Claude has no hook, no skill and no agent installed there.
+        // Collapsing both to one digest is what makes a Codex-only bootstrap
+        // possible — Codex's scriptsDir (~/.awm/hooks/codex) is nested inside
+        // Claude's (~/.awm/hooks), so installing the Codex hook necessarily
+        // creates Claude's directory via `mkdirSync(..., {recursive: true})`
+        // (commands/hooks/shared.ts). On a machine that never ran a Claude
+        // init, that flipped Claude's digest from absent to `dir:` and aborted
+        // every `awm init --agent codex` — the exact fresh-cloud-box scenario
+        // Codex Cloud boots into. Genuine changes still register: content
+        // appearing here, or being emptied out, both move the digest.
+        return tree === '' ? NO_CONTENT : `dir:${tree}`;
     }
     return `file:${hashFileContent(target)}`;
 }

--- a/cli/tests/core/init/provider-facts.test.ts
+++ b/cli/tests/core/init/provider-facts.test.ts
@@ -122,6 +122,68 @@ describe('gatherProviderFacts / assertClaudeBaselinePreserved', () => {
         expect(() => assertClaudeBaselinePreserved(before, afterModify)).not.toThrow();
     });
 
+    // -----------------------------------------------------------------------
+    // Codex-only bootstrap: Claude's scriptsDir has NEVER existed.
+    //
+    // Every nested-exclusion test above seeds ~/.awm/hooks first, so they only
+    // ever exercise the present→present transition. On a fresh Codex-only
+    // machine (a cloud box, the actual rollout target) that directory does not
+    // exist, and installing the Codex hook creates it as a side effect of
+    // `mkdirSync(dirname, {recursive:true})` in syncExecutable — flipping
+    // Claude's own scriptsDir from absent to present-but-empty. That is not a
+    // change to anything Claude owns, but it moved the hash and aborted init.
+    // -----------------------------------------------------------------------
+
+    it('does NOT flag Codex creating its nested scriptsDir when Claude\'s has never existed', () => {
+        const { gatherProviderFacts, assertClaudeBaselinePreserved } = require('../../../src/core/init/provider-facts');
+
+        const claudeScripts = path.join(tmpHome, '.awm', 'hooks');
+        expect(fs.existsSync(claudeScripts)).toBe(false);
+
+        const before = gatherProviderFacts('claude-code');
+
+        // Exactly what syncExecutable does for the Codex hook: one recursive
+        // mkdir that necessarily materializes Claude's hooks/ as the parent.
+        const codexScripts = path.join(claudeScripts, 'codex');
+        fs.mkdirSync(codexScripts, { recursive: true });
+        fs.writeFileSync(path.join(codexScripts, 'session-start'), '#!/bin/sh\necho codex\n');
+
+        const after = gatherProviderFacts('claude-code');
+        expect(after.hash).toBe(before.hash);
+        expect(() => assertClaudeBaselinePreserved(before, after)).not.toThrow();
+    });
+
+    it('still flags real Claude content appearing where the directory did not exist', () => {
+        const { gatherProviderFacts, assertClaudeBaselinePreserved } = require('../../../src/core/init/provider-facts');
+
+        const before = gatherProviderFacts('claude-code');
+
+        // The guard must not be relaxed into blindness: an absent directory
+        // gaining Claude-owned content is still a genuine baseline change.
+        const claudeScripts = path.join(tmpHome, '.awm', 'hooks');
+        fs.mkdirSync(claudeScripts, { recursive: true });
+        fs.writeFileSync(path.join(claudeScripts, 'session-start'), '#!/bin/sh\n');
+
+        const after = gatherProviderFacts('claude-code');
+        expect(after.hash).not.toBe(before.hash);
+        expect(() => assertClaudeBaselinePreserved(before, after)).toThrow(/must never happen \(R19\)/);
+    });
+
+    it('still flags Claude content being emptied out of an existing directory', () => {
+        const { gatherProviderFacts, assertClaudeBaselinePreserved } = require('../../../src/core/init/provider-facts');
+
+        const claudeScripts = path.join(tmpHome, '.awm', 'hooks');
+        fs.mkdirSync(claudeScripts, { recursive: true });
+        fs.writeFileSync(path.join(claudeScripts, 'session-start'), '#!/bin/sh\n');
+
+        const before = gatherProviderFacts('claude-code');
+        fs.rmSync(path.join(claudeScripts, 'session-start'));
+
+        const after = gatherProviderFacts('claude-code');
+        expect(after.hash).not.toBe(before.hash);
+        expect(() => assertClaudeBaselinePreserved(before, after)).toThrow(/must never happen \(R19\)/);
+    });
+
     it('still flags a genuinely Claude-owned change alongside an untouched Codex nested dir', () => {
         const { gatherProviderFacts, assertClaudeBaselinePreserved } = require('../../../src/core/init/provider-facts');
 

--- a/cli/tests/integration/codex-provider-isolated.test.ts
+++ b/cli/tests/integration/codex-provider-isolated.test.ts
@@ -213,6 +213,41 @@ describe('codex provider — isolated home E2E (Task 9)', () => {
         expect(snapshotTree(path.join(tmpHome, '.claude'))).toEqual(claudeBefore);
     });
 
+    it('initializes Codex on a machine that has never run a Claude Code init', async () => {
+        // The E2E above inits claude-code FIRST, so ~/.awm/hooks always exists
+        // by the time Codex runs — which is precisely why it never caught this.
+        // A fresh Codex Cloud box has no Claude install at all, and installing
+        // the Codex hook creates ~/.awm/hooks as a side effect of the recursive
+        // mkdir for its own nested ~/.awm/hooks/codex. That flipped Claude's
+        // R19 baseline digest from absent to present-but-empty and aborted init
+        // with "Claude Code baseline changed during a non-Claude init".
+        seedPublicRegistryFixture(path.join(tmpHome, '.awm/registries/baseline'));
+
+        const { runInit } = require('../../src/commands/init');
+
+        expect(fs.existsSync(path.join(tmpHome, '.awm/hooks'))).toBe(false);
+        expect(fs.existsSync(path.join(tmpHome, '.claude'))).toBe(false);
+
+        const codex = await runInit({
+            cwd: tmpWork,
+            yes: true,
+            agent: 'codex',
+            machineOnly: true,
+            assertProviderSupported: () => ({ provider: 'codex' as const, version: '0.150.0' }),
+        });
+
+        // Exit 2 is the internal-error path the R19 guard aborts through.
+        expect(codex).toBeLessThanOrEqual(1);
+        expect(readPrefs().enabledAgents).toEqual(['codex']);
+
+        // The Codex hook really installed, and Claude gained no content of its own.
+        const hooksJson = JSON.parse(fs.readFileSync(path.join(tmpHome, '.codex/hooks.json'), 'utf8'));
+        expect(hooksJson.hooks.SessionStart).toHaveLength(1);
+        expect(fs.existsSync(path.join(tmpHome, '.awm/hooks/codex/session-start'))).toBe(true);
+        expect(fs.readdirSync(path.join(tmpHome, '.awm/hooks'))).toEqual(['codex']);
+        expect(fs.existsSync(path.join(tmpHome, '.claude/settings.json'))).toBe(false);
+    });
+
     it('doctor reports the isolated Codex install as supported/healthy, not against the real ~/.awm', () => {
         seedPublicRegistryFixture(path.join(tmpHome, '.awm/registries/baseline'));
         writePrefs(prefsWith(['claude-code', 'codex']));

--- a/docs/plans/2026-07-24-codex-baseline-portability-plan.md
+++ b/docs/plans/2026-07-24-codex-baseline-portability-plan.md
@@ -1,4 +1,5 @@
 # Codex Baseline Portability Implementation Plan
+<!-- awm-qa-complete: 2026-07-25 -->
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/docs/plans/2026-07-24-codex-baseline-portability-plan.md
+++ b/docs/plans/2026-07-24-codex-baseline-portability-plan.md
@@ -1,5 +1,6 @@
 # Codex Baseline Portability Implementation Plan
 <!-- awm-qa-complete: 2026-07-25 -->
+<!-- awm-retro-complete: 2026-07-25 -->
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 


### PR DESCRIPTION
Desbloquea el NO-GO reportado en [`Kodria/awm-baseline-registry#15`](https://github.com/Kodria/awm-baseline-registry/issues/15) — el baseline (PR #16, tag `v1.7.0`) ya estaba sano; el bloqueante vivía acá.

## El bug

`awm init --agent codex --yes --machine-only` abortaba con:

```
awm init: internal error: Claude Code baseline changed during a non-Claude init
— this must never happen (R19). Inspected: <AWM_HOME>/hooks, <HOME>/.claude/agents,
<HOME>/.claude/settings.json, <HOME>/.claude/skills
```

...en **cualquier máquina que nunca corrió un init de Claude Code antes** — exactamente el caso de una máquina Codex Cloud fresca, el escenario que este rollout necesita. Reproducido 3/3 en entornos completamente aislados (`HOME`/`AWM_HOME`/cwd frescos cada vez).

## Causa raíz

El `scriptsDir` de Codex (`~/.awm/hooks/codex`) está anidado dentro del de Claude (`~/.awm/hooks` — `providers/index.ts`). `syncExecutable` (`commands/hooks/shared.ts`) crea el destino con `fs.mkdirSync(path.dirname(dest), { recursive: true })`, y ese mkdir recursivo, al crear `hooks/codex/`, materializa `hooks/` como efecto secundario si no existía.

El guard R19 (`assertClaudeBaselinePreserved`) hashea ese directorio antes/después: `hashPath` en un path inexistente devuelve `'absent'`; el mismo path tras el mkdir devuelve `'dir:'` (árbol vacío — la exclusión existente sí filtra correctamente la entrada `codex` nombrada *dentro*, pero no cubre que el directorio padre mismo pase de no-existir a existir-vacío). `'absent' !== 'dir:'` → el guard interpreta esto como "el baseline de Claude cambió" y aborta.

## El fix

Colapsar "el directorio existe pero no contiene nada que este agente posea" y "el directorio no existe" al mismo dígito canónico en `hashPath` (`core/init/provider-facts.ts`). Los cambios genuinos siguen registrándose: contenido apareciendo bajo un path gestionado, o siendo vaciado de uno, ambos mueven el dígito — cubierto explícitamente por dos tests nuevos que fijan que el guard no se relaja de más.

## Por qué se escapó

Los 6 tests existentes de R19 siembran `~/.awm/hooks` antes de actuar, y el E2E inicializa `claude-code` primero — todos ejercitaban solo la transición presente→presente. Ninguno cubría absent→presente-vacío, que es la única transición que ocurre en una máquina Codex-only.

## Tests

4 tests nuevos (`provider-facts.test.ts` ×3, `codex-provider-isolated.test.ts` ×1 — E2E que inicializa Codex sin ningún init previo de Claude). Los dos que reproducen el bug fueron confirmados en rojo revirtiendo el fix (mutation check) antes de confirmarlos en verde con el fix aplicado — no son aserciones vacuas.

Suite completa: **957 tests, 108 suites, verde**.

## Verificación end-to-end (fuera de la suite)

Contra el tag publicado `v1.7.0` del baseline, con `codex-cli 0.145.0` real (el mínimo exacto que exige el CLI) y `HOME`/`AWM_HOME`/cwd totalmente aislados — el comando que fallaba 3/3 ahora corre limpio:

```
awm init --agent codex --yes --machine-only   → EXIT=0, machine: healthy
awm update --agent codex                      → EXIT=0
awm add product|frontend|authoring (global)   → EXIT=0 cada uno
awm doctor --agent codex --json               → overall: healthy (hook.trust: healthy tras un disparo real)
```

`~/.awm/hooks/` terminó conteniendo únicamente `codex`; `~/.claude` nunca se creó — confirmando que el baseline de Claude queda genuinamente intacto, no solo que el guard dejó de dispararse.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wkz2Jn6rG8iSFBevhp1ud1)_