### PR TITLE
fix: don't let unrelated project degradation fail a --machine-only init

### DIFF
--- a/cli/src/core/init/orchestrator.ts
+++ b/cli/src/core/init/orchestrator.ts
@@ -48,7 +48,26 @@ export async function runInitSteps(deps: InitDeps): Promise<InitOutcome> {
         steps.push(await wrapStep('project.context', 'project', () => stepContext(deps)));
     }
 
+    // Re-gather fresh so the report reflects whatever the steps above just
+    // installed. `results` deliberately keeps every check — including project
+    // ones — so the render still shows real project state (e.g. "run awm sync")
+    // when one exists; only `overall`, the exit-code verdict, needs scoping.
+    //
+    // If this run started with project scope nulled — `--machine-only`
+    // (init.ts's effectiveCtx), or genuinely no project at this cwd — `overall`
+    // must reflect only what THIS run attempted. `runChecks` otherwise mixes
+    // machine + project results into one flat `overall` (checks.ts), so a
+    // `--machine-only` bootstrap into an already-initialized project with
+    // unrelated unsynced bundles reports "degraded" and callers gating on it
+    // (`runInit`'s exit code) fail a run that fully succeeded at everything it
+    // was asked to do — the exact shape of a real Codex Cloud bootstrap script
+    // aborting under `set -euo pipefail` right after `awm init`.
     const after = runChecks(gatherContext({ cwd: deps.cwd, bundles: deps.bundles, agent: deps.agent }));
+    if (deps.ctx.project === null) {
+        after.overall = after.results
+            .filter((r) => r.level === 'machine')
+            .some((r) => r.status === 'missing') ? 'degraded' : 'healthy';
+    }
 
     return {
         steps,

--- a/cli/tests/core/init/orchestrator.test.ts
+++ b/cli/tests/core/init/orchestrator.test.ts
@@ -95,6 +95,38 @@ describe('runInitSteps — orchestrator', () => {
         }
     });
 
+    it('machine-only inside an already-initialized project with unsynced bundles still reaches overall healthy', async () => {
+        // Reproduces a real Codex Cloud bootstrap: `awm init --agent codex --yes
+        // --machine-only` run with cwd inside an existing, previously-initialized
+        // project (its own `.awm/profile.json` already committed, declaring bundles
+        // this machine-only run was never asked to sync). The bare-cwd test above
+        // can't catch this — there, `ctx.project` is null for two reasons at once
+        // (machineOnly AND no project exists), so it never exercises "machineOnly
+        // nulled a project that actually has real, degraded content."
+        const root = path.join(tmpHome, 'existing-project');
+        fs.mkdirSync(path.join(root, '.awm'), { recursive: true });
+        fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ dependencies: { next: '14.0.0' } }));
+        // Declares the "dev" bundle active, but its skills were never symlinked —
+        // exactly `active bundles (N missing)` in the real report the user saw.
+        fs.writeFileSync(path.join(root, '.awm', 'profile.json'), JSON.stringify({ extensions: ['dev'] }));
+
+        const deps = buildDeps(root);
+        deps.ctx.project = null; // what init.ts's effectiveCtx does for --machine-only
+
+        const { runInitSteps } = require('../../../src/core/init/orchestrator');
+        const out = await runInitSteps(deps);
+
+        // The steps this run actually attempted (machine-only) all succeeded —
+        // that must be reflected in the caller's exit code.
+        expect(out.steps.every((s: any) => s.action !== 'failed')).toBe(true);
+        expect(out.after.results.find((r: any) => r.id === 'machine.devCore')?.status).toBe('ok');
+        // Project state exists and IS genuinely degraded, and it must stay visible
+        // in the report (the CLI's own render still shows it) — but it must not
+        // drag down the overall verdict for a run that never touched project scope.
+        expect(out.after.results.some((r: any) => r.id === 'project.activation' && r.status === 'missing')).toBe(true);
+        expect(out.after.overall).toBe('healthy');
+    });
+
     it('project repo: applies activation/sensors, flags constitution+context as pending', async () => {
         const root = path.join(tmpHome, 'repo');
         fs.mkdirSync(path.join(root, '.awm'), { recursive: true });


### PR DESCRIPTION
Segundo bloqueante encontrado al validar el fix de [`#15`](https://github.com/Kodria/agentic-workflow/pull/15) (ya mergeado, `v3.2.1`) en un contenedor real de Codex Cloud contra el repo `notion-tracker` del dueño.

## El bug

`awm init --agent codex --yes --machine-only` retornaba `exit 1` dentro de un proyecto **ya inicializado** (con `.awm/profile.json` committeado declarando bundles que este run machine-only nunca fue instruido a sincronizar). El script de bootstrap cloud usa `set -euo pipefail`, así que abortaba justo después de `awm init` — antes de `update`, del loop de bundles, de `sync` y de `doctor`.

Salida real del usuario:

```
Final state
  ✔ CLI
  ✔ hook SessionStart
  ✔ dev-core (baseline)
  ✔ global skills

Project: notion-tracker
  ✔ .awm/profile.json (frontend)
  ✖ active bundles (30 missing, 0 broken) → awm sync
  ✔ sensors
  ✔ CONSTITUTION.md
  ✔ AGENTS.md

status: degraded · 1 suggested actions
```

Nivel *machine* completamente sano — el fix de ayer funcionó. Pero el veredicto general seguía degradado por un estado de *proyecto* que `--machine-only` explícitamente nunca intentó tocar.

## Causa raíz

`runInitSteps` (`core/init/orchestrator.ts`) construye su reporte "after" con un `gatherContext()` fresco y sin acotar, ignorando que `--machine-only` (el `effectiveCtx` de `init.ts`) anuló deliberadamente el proyecto para los steps que sí ejecutó. `runChecks` mezcla resultados de machine + project en un solo `overall` plano (`diagnostics/checks.ts`), así que cualquier degradación de proyecto preexistente que este run nunca tocó —symlinks de bundle faltantes, sin `sensors.json`, sin `CONSTITUTION.md`— arrastraba el `overall` a `'degraded'` y con él el exit code de `runInit`, aun cuando cada step de nivel machine había tenido éxito.

## El fix

`after.results` se mantiene completo — el render sigue necesitando mostrar el estado real del proyecto ("corré `awm sync`" es información genuinamente útil). Pero cuando el run arrancó con el scope de proyecto anulado, `overall` se recalcula solo a partir de los resultados de nivel machine.

## Por qué se escapó por la misma razón que ayer

El único test existente de machine-only usa un cwd vacío, donde `ctx.project` es `null` por dos razones a la vez (machineOnly Y "no existe ningún proyecto") — nunca ejercita un proyecto real y degradado por debajo de un run machine-only. Agregué un test que siembra un proyecto real con un bundle sin sincronizar y confirma que sigue visible en el reporte mientras `overall` reporta `healthy`; confirmado por mutación que falla sin el fix.

Suite completa: **958 tests, 108 suites, verde**.

## Verificación end-to-end

Contra un fixture con la forma exacta de `notion-tracker` (repo git real, `.awm/profile.json` declarando un bundle sin sincronizar) con `codex-cli 0.145.0` real y el CLI compilado — `init`/`update`/`add` (los tres bundles)/`sync`/`doctor` llegan todos a `exit 0`, replicando el script de bootstrap cloud exacto que falló.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wkz2Jn6rG8iSFBevhp1ud1)_