### PR TITLE
fix(init): preserve and emit failed-step evidence on `awm init --json`

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -5,9 +5,16 @@ import pc from 'picocolors';
 import { renderReport } from './doctor';
 import { gatherContext } from '../core/diagnostics/context';
 import { discoverAllBundles } from '../core/bundles';
-import { contentRoots, listRegistries, seedBaselineRegistry, capabilityRoot } from '../core/registries';
+import {
+    contentRoots, listRegistries, seedBaselineRegistry, capabilityRoot,
+    assertSyncedRegistriesUsable,
+} from '../core/registries';
 import { runInitSteps } from '../core/init/orchestrator';
 import { defaultActions } from '../core/init/steps';
+import {
+    InitStepsFailedError, buildInitFailureOutput, transactionNote,
+    type InitFailureTransaction,
+} from '../core/init/failure';
 import { planInitMutationTargets } from '../core/init/mutation-targets';
 import { gatherProviderFacts, assertClaudeBaselinePreserved } from '../core/init/provider-facts';
 import { beginBackupSession } from '../core/install-transaction';
@@ -63,6 +70,43 @@ export function renderInitOutcome(o: InitOutcome): string {
 }
 
 // ---------------------------------------------------------------------------
+// Failure reporting
+// ---------------------------------------------------------------------------
+
+/**
+ * Single exit point for every failed `awm init`. Honours `--json`'s contract on
+ * the error path — the whole point of the flag for a headless bootstrap is to
+ * learn WHICH step failed — and, in human mode, renders the same evidence
+ * through the normal init dashboard instead of discarding it.
+ *
+ * stdout carries the machine-readable document (JSON mode) or the dashboard
+ * (human mode); stderr always carries the one-line summary plus the
+ * transaction verdict, so `2>&1`-free scripts still see a reason.
+ */
+function reportInitFailure(o: {
+    error: Error;
+    outcome?: InitOutcome;
+    transaction?: InitFailureTransaction;
+    json?: boolean;
+}): number {
+    const payload = buildInitFailureOutput({
+        error: o.error,
+        outcome: o.outcome,
+        transaction: o.transaction,
+    });
+
+    if (o.json) {
+        process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+    } else if (o.outcome) {
+        process.stdout.write(renderInitOutcome(o.outcome) + '\n');
+    }
+
+    process.stderr.write(`awm init: ${payload.error}\n`);
+    process.stderr.write(`awm init: ${payload.transaction.note}\n`);
+    return 2;
+}
+
+// ---------------------------------------------------------------------------
 // RunInit
 // ---------------------------------------------------------------------------
 
@@ -111,6 +155,11 @@ export async function runInit(opts: RunInitOptions = {}): Promise<number> {
     const beforeClaudeFacts = agent === 'claude-code' ? null : gatherProviderFacts('claude-code');
 
     let outcome: InitOutcome;
+    // Populated as soon as each becomes available, so the failure reporter can
+    // emit whatever evidence THIS run got far enough to produce.
+    let pipelineOutcome: InitOutcome | undefined;
+    let transaction: InitFailureTransaction | undefined;
+
     try {
         const mergedActions: InitActions = {
             ...defaultActions,
@@ -144,7 +193,11 @@ export async function runInit(opts: RunInitOptions = {}): Promise<number> {
 
             seedBaselineRegistry();
             if (listRegistries().some((r) => !fs.existsSync(r.contentRoot))) {
-                await mergedActions.syncCache();
+                // `syncRegistries()` reports per-registry failures as RESULTS,
+                // never as throws (core/registries.ts) — swallowing them here
+                // let an unavailable registry degrade silently into some later
+                // step's failure instead of being reported as its own cause.
+                assertSyncedRegistriesUsable((await mergedActions.syncCache()) ?? []);
             }
 
             const bundles = discoverAllBundles();
@@ -170,8 +223,13 @@ export async function runInit(opts: RunInitOptions = {}): Promise<number> {
                 confirmExtensions,
                 actions: mergedActions,
             });
+            pipelineOutcome = outcome;
             if (outcome.failed > 0) {
-                throw new Error('one or more init steps failed');
+                // Typed so the outcome — the only record of WHICH step failed
+                // and why — survives the rollback below and reaches the
+                // reporter. A bare Error here is what made `--json` emit
+                // nothing on the one path that most needed it.
+                throw new InitStepsFailedError(outcome);
             }
 
             if (beforeClaudeFacts) {
@@ -182,21 +240,49 @@ export async function runInit(opts: RunInitOptions = {}): Promise<number> {
             outcome.transactionId = backup.transactionId;
             outcome.modifiedFiles = backup.targetPaths;
         } catch (error) {
-            backup.rollback();
+            // Rollback is best-effort and must never mask the original failure
+            // (same policy as applyInstallPlan's own rollback loop): the
+            // operator needs the step that failed, not the restore that also did.
+            let rollbackError: string | undefined;
+            try {
+                backup.rollback();
+            } catch (e) {
+                rollbackError = e instanceof Error ? e.message : String(e);
+            }
+            transaction = {
+                committed: false,
+                rolledBack: rollbackError === undefined,
+                transactionId: backup.transactionId,
+                restoredFiles: backup.targetPaths,
+                ...(rollbackError === undefined ? {} : { rollbackError }),
+                note: transactionNote(rollbackError === undefined),
+            };
             throw error;
         }
     } catch (err) {
-        process.stderr.write(`awm init: internal error: ${(err as Error).message}\n`);
-        return 2;
+        // The typed error carries its own outcome (so it stays self-sufficient
+        // for any caller of runInit); `pipelineOutcome` covers the other way a
+        // run can fail *after* the pipeline produced one — e.g. the R19
+        // Claude-baseline assertion.
+        return reportInitFailure({
+            error: err as Error,
+            outcome: err instanceof InitStepsFailedError ? err.outcome : pipelineOutcome,
+            transaction,
+            json: opts.json,
+        });
     }
 
+    // `result` mirrors the exit code, so a consumer can branch on one field
+    // instead of correlating stdout with $?: ok → 0, degraded → 1, failed → 2.
+    const result = outcome.after.overall === 'healthy' ? 'ok' : 'degraded';
+
     if (opts.json) {
-        process.stdout.write(JSON.stringify(outcome, null, 2) + '\n');
+        process.stdout.write(JSON.stringify({ result, ...outcome }, null, 2) + '\n');
     } else {
         process.stdout.write(renderInitOutcome(outcome) + '\n');
     }
 
-    return outcome.after.overall === 'healthy' ? 0 : 1;
+    return result === 'ok' ? 0 : 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -237,7 +323,7 @@ export function registerInitCommand(program: Command): void {
         .option('-y, --yes', 'Skip confirmation prompts')
         .option('-a, --agent <agent>', 'Target agent (default: claude-code)')
         .option('--machine-only', 'Only run machine-level steps (skip project steps)')
-        .option('--json', 'Emit the InitOutcome as JSON')
+        .option('--json', 'Emit the InitOutcome as JSON — on success and on failure (failed steps + rollback)')
         .action(async (options: { yes?: boolean; agent?: string; machineOnly?: boolean; json?: boolean }) => {
             warnIfUnsupportedPlatform((m) => console.warn(pc.yellow(`⚠ ${m}`)));
             const code = await runInit({

--- a/cli/src/core/init/failure.ts
+++ b/cli/src/core/init/failure.ts
@@ -1,0 +1,121 @@
+// src/core/init/failure.ts
+//
+// Failure evidence for `awm init`.
+//
+// `awm init` is transactional: any failure rolls every write back. That part
+// was always right — what was missing is the EVIDENCE. `runInitSteps` already
+// records, per step, `{ id, action: 'failed', error }` (orchestrator.ts's
+// `wrapStep`), but commands/init.ts used to collapse the whole outcome into a
+// bare `new Error('one or more init steps failed')`, so `--json` — whose only
+// job is to emit that outcome — printed nothing at all on the exact path an
+// operator needs it: a headless cloud bootstrap that just aborted.
+//
+// `InitStepsFailedError` carries the outcome across the rollback boundary, and
+// `buildInitFailureOutput` shapes it into the JSON envelope the CLI emits.
+// The envelope is deliberately self-describing (`result`, `failedSteps`,
+// `transaction`) so a bootstrap script can branch on it without re-deriving
+// anything from prose on stderr.
+
+import type { CheckReport } from '../diagnostics/types';
+import type { InitOutcome, StepResult } from './types';
+
+/** Only the steps that actually failed — the subset an operator needs first. */
+export function failedSteps(outcome: InitOutcome): StepResult[] {
+    return outcome.steps.filter((s) => s.action === 'failed');
+}
+
+/**
+ * Thrown when the step pipeline ran to completion but ≥1 step failed. Carries
+ * the full `InitOutcome` so the rollback path can still emit it, and builds a
+ * message that names every failed step instead of the old generic sentence.
+ */
+export class InitStepsFailedError extends Error {
+    readonly outcome: InitOutcome;
+
+    constructor(outcome: InitOutcome) {
+        const detail = failedSteps(outcome)
+            .map((s) => `${s.id}: ${s.error ?? 'no error recorded'}`)
+            .join('; ');
+        super(`one or more init steps failed — ${detail || 'no failed step recorded'}`);
+        this.name = 'InitStepsFailedError';
+        this.outcome = outcome;
+    }
+}
+
+/** Transaction evidence for a failed run. Init is all-or-nothing: never committed. */
+export interface InitFailureTransaction {
+    /** Always false — a failed init never commits its backup session. */
+    committed: false;
+    /** True when every path in `restoredFiles` was restored to its pre-run state. */
+    rolledBack: boolean;
+    /** Backup-session id under ~/.awm/backups, or null when the run failed before one opened. */
+    transactionId: string | null;
+    /** Every path the backup session covered. Restored when `rolledBack` is true. */
+    restoredFiles: string[];
+    /** Set only when the rollback itself failed; the backup directory stays for manual recovery. */
+    rollbackError?: string;
+    /** Plain-language statement of what the two flags above mean for the machine's state. */
+    note: string;
+}
+
+/** The JSON document `awm init --json` writes to stdout when the run fails. */
+export interface InitFailureOutput {
+    result: 'failed';
+    /** Top-level message — names the failed steps when the pipeline produced an outcome. */
+    error: string;
+    /** Every step the pipeline recorded; empty when it failed before the pipeline ran. */
+    steps: StepResult[];
+    /** `steps` filtered to `action: 'failed'`, so callers need no client-side filtering. */
+    failedSteps: StepResult[];
+    applied: number;
+    pending: number;
+    failed: number;
+    /** Pre-run harness snapshot. Null when the run failed before the pipeline ran. */
+    before: CheckReport | null;
+    /**
+     * State observed at the END of the step pipeline — that is, BEFORE the
+     * rollback restored anything. Null when the pipeline never ran.
+     */
+    after: CheckReport | null;
+    transaction: InitFailureTransaction;
+}
+
+const NO_TRANSACTION_NOTE =
+    'init failed before a backup session was opened — nothing was written, so there was nothing to roll back.';
+
+/** The note explaining what a given rollback outcome means for the machine. */
+export function transactionNote(rolledBack: boolean): string {
+    return rolledBack
+        ? 'the transaction was NOT committed: every path in restoredFiles was restored to its pre-init state. '
+          + '`after` reflects the state observed at the end of the step pipeline, BEFORE this rollback ran.'
+        : 'the transaction was NOT committed and the rollback did not complete — see rollbackError and '
+          + 'restore manually with `awm backup restore <transactionId>`.';
+}
+
+export function buildInitFailureOutput(o: {
+    error: Error;
+    /** Present whenever the step pipeline produced an outcome before the failure. */
+    outcome?: InitOutcome;
+    /** Present whenever a backup session was opened before the failure. */
+    transaction?: InitFailureTransaction;
+}): InitFailureOutput {
+    const steps = o.outcome?.steps ?? [];
+    return {
+        result: 'failed',
+        error: o.error.message,
+        steps,
+        failedSteps: steps.filter((s) => s.action === 'failed'),
+        applied: o.outcome?.applied ?? 0,
+        pending: o.outcome?.pending ?? 0,
+        failed: o.outcome?.failed ?? 0,
+        before: o.outcome?.before ?? null,
+        after: o.outcome?.after ?? null,
+        transaction: o.transaction ?? {
+            committed: false,
+            rolledBack: false,
+            transactionId: null,
+            restoredFiles: [],
+            note: NO_TRANSACTION_NOTE,
+        },
+    };
+}

--- a/cli/src/core/init/steps.ts
+++ b/cli/src/core/init/steps.ts
@@ -6,7 +6,10 @@
 //
 // defaultActions wires the real I/O implementations; tests inject spies.
 
-import { syncRegistries } from '../registries';
+import {
+    syncRegistries, registrySyncErrors, describeRegistrySyncErrors, unusableSyncedRegistries,
+    type RegistrySyncResult,
+} from '../registries';
 import { installHook as realInstallHook } from '../../commands/hooks/install';
 import { installBundle as realInstallBundle, syncProfile as realSyncProfile } from '../bundle-install';
 import { initSensors as realInitSensors } from '../../commands/sensors/init';
@@ -30,7 +33,7 @@ import { CodexAgentsStrategy } from '../context/strategies/codex-agents';
 const realInjectionOrchestrator = new InjectionOrchestrator();
 
 export const defaultActions: InitActions = {
-    syncCache: async () => { await syncRegistries(); },
+    syncCache: async () => syncRegistries(),
 
     installHook: (o) => realInstallHook({
         agent: o.agent,
@@ -142,13 +145,33 @@ export async function stepCache(d: InitDeps): Promise<StepResult> {
     const needsSync = !registryCache.present || registryCache.gitState === 'behind';
     if (!needsSync) return ok('machine.cache', 'machine', 'skipped');
 
+    let results: RegistrySyncResult[];
     try {
-        await d.actions.syncCache();
-        return ok('machine.cache', 'machine', 'applied');
+        results = (await d.actions.syncCache()) ?? [];
     } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : String(e);
         return failed('machine.cache', 'machine', msg);
     }
+
+    // `syncRegistries()` reports per-registry failures as RESULTS, not throws
+    // (registries.ts), so the `try` above catches none of them. Ignoring them
+    // is what let an unavailable base registry degrade silently into some
+    // later step's failure — with its own cause already gone.
+    const errors = registrySyncErrors(results);
+    if (errors.length === 0) return ok('machine.cache', 'machine', 'applied');
+
+    // A registry that errored and has no content on disk is unusable, and every
+    // later step that reads it will fail for a reason that no longer names this
+    // cause — so machine.cache owns it here. One that errored but still has
+    // content is stale, not broken: record it and carry on.
+    const unusable = unusableSyncedRegistries(results);
+    if (unusable.length > 0) {
+        return failed(
+            'machine.cache', 'machine',
+            `registry unavailable — ${describeRegistrySyncErrors(unusable)}`,
+        );
+    }
+    return ok('machine.cache', 'machine', 'applied', `stale registries — ${describeRegistrySyncErrors(errors)}`);
 }
 
 /** Step 2 – Install the session-start hook for the target agent. */

--- a/cli/src/core/init/types.ts
+++ b/cli/src/core/init/types.ts
@@ -6,6 +6,7 @@ import type { InstallMethod, InstallSummary, SyncResult } from '../bundle-instal
 import type { ContextOp } from '../context/orchestrator';
 import type { InjectionState } from '../context/types';
 import type { ConstitutionInjectResult } from '../context/project-constitution-inject';
+import type { RegistrySyncResult } from '../registries';
 
 export type StepAction = 'applied' | 'skipped' | 'pending' | 'failed';
 
@@ -33,7 +34,13 @@ export interface InitOutcome {
 // Efectos de I/O inyectables — defaultActions delega en las funciones reales;
 // los tests pasan espías. Mantiene los steps puros respecto de la UI y testeables.
 export interface InitActions {
-    syncCache: () => Promise<void>;
+    /**
+     * Returns `syncRegistries()`'s per-registry results so the caller can see
+     * WHICH registry failed — that function reports failures as results, never
+     * as throws. `void` stays allowed for the many test stubs that only care
+     * that a sync was attempted.
+     */
+    syncCache: () => Promise<RegistrySyncResult[] | void>;
     installHook: (o: { agent: AgentTarget; registryRoot: string; installMethod: InstallMethod }) => { status: string };
     installBundle: (o: {
         bundleName: string; bundles: BundleDefinition[]; agents: AgentTarget[];

--- a/cli/src/core/registries.ts
+++ b/cli/src/core/registries.ts
@@ -146,6 +146,54 @@ export async function syncRegistries(): Promise<RegistrySyncResult[]> {
     return results;
 }
 
+/** The errored entries of a `syncRegistries()` run, in `listRegistries()` order. */
+export function registrySyncErrors(
+    results: RegistrySyncResult[],
+): { name: string; error: string }[] {
+    return results
+        .filter((r): r is Extract<RegistrySyncResult, { action: 'error' }> => r.action === 'error')
+        .map((r) => ({ name: r.name, error: r.error }));
+}
+
+/** `name: reason; name: reason` — the shape both init and stepCache report errors in. */
+export function describeRegistrySyncErrors(errors: { name: string; error: string }[]): string {
+    return errors.map((e) => `${e.name}: ${e.error}`).join('; ');
+}
+
+/**
+ * Registries that both errored during sync AND have no content on disk
+ * afterwards — i.e. genuinely unusable, as opposed to merely stale.
+ *
+ * `syncRegistries()` deliberately reports per-registry failures as results
+ * rather than throwing, so a flaky secondary registry never aborts a whole
+ * run. Callers that go on to READ registry content (init) still need to know
+ * whether what they are about to read exists: otherwise a missing registry
+ * resurfaces much later as an unrelated step's failure, with its real cause
+ * already discarded. Note that "usable" is deliberately about content on disk,
+ * not about being a healthy git clone — a seeded content root with no `.git`
+ * fails to sync every time and is still perfectly readable.
+ */
+export function unusableSyncedRegistries(
+    results: RegistrySyncResult[],
+): { name: string; error: string }[] {
+    const errors = registrySyncErrors(results);
+    if (errors.length === 0) return [];
+    const roots = new Map(listRegistries().map((r) => [r.name, r.contentRoot]));
+    return errors.filter((e) => {
+        const root = roots.get(e.name);
+        return root === undefined || !fs.existsSync(root);
+    });
+}
+
+/** `unusableSyncedRegistries` as a guard: throws naming every unusable registry. */
+export function assertSyncedRegistriesUsable(results: RegistrySyncResult[]): void {
+    const unusable = unusableSyncedRegistries(results);
+    if (unusable.length === 0) return;
+    throw new Error(
+        `registry sync failed and left no content on disk — ${describeRegistrySyncErrors(unusable)}`,
+    );
+}
+
 export const REGISTRY_MANIFEST_NAME = 'awm-registry.json';
 
 export interface RegistryManifest {

--- a/cli/tests/commands/init.test.ts
+++ b/cli/tests/commands/init.test.ts
@@ -90,6 +90,7 @@ describe('runInit', () => {
         const parsed = JSON.parse(written);
         expect(Array.isArray(parsed.steps)).toBe(true);
         expect(parsed.after.overall).toBe('degraded');
+        expect(parsed.result).toBe('degraded'); // success envelope is self-describing too
         expect(code).toBe(1);
     });
 
@@ -315,5 +316,105 @@ describe('runInit', () => {
         // settings.json WAS genuinely modified mid-run (real installHook ran) —
         // rollback must restore its exact pre-run content, not just leave it be.
         expect(JSON.parse(fs.readFileSync(settingsPath, 'utf8'))).toEqual({ pristine: true, unrelated: 'keep' });
+    });
+
+    // -----------------------------------------------------------------------
+    // Failure evidence — `--json` must honour its contract on the ERROR path
+    // -----------------------------------------------------------------------
+
+    describe('failure evidence', () => {
+        let errSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            errSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        });
+        afterEach(() => errSpy.mockRestore());
+
+        const stdout = () => writeSpy.mock.calls.map((c) => c[0]).join('');
+        const stderr = () => errSpy.mock.calls.map((c) => c[0]).join('');
+
+        /** InitActions whose `machine.hook` step blows up inside the step pipeline. */
+        function actionsWithFailingHook() {
+            const actions = fakeActions([]);
+            actions.installHook = () => { throw new Error('hook boom'); };
+            return actions;
+        }
+
+        it('--json emits parseable JSON carrying the failed step id and error', async () => {
+            const { runInit } = require('../../src/commands/init');
+            const code = await runInit({
+                cwd: tmpHome,
+                yes: true,
+                json: true,
+                actions: actionsWithFailingHook(),
+            });
+
+            expect(code).not.toBe(0);
+            expect(code).toBe(2);
+
+            const parsed = JSON.parse(stdout());
+            expect(parsed.result).toBe('failed');
+
+            const failedStep = parsed.steps.find((s: { action: string }) => s.action === 'failed');
+            expect(failedStep.id).toBe('machine.hook');
+            expect(failedStep.error).toBe('hook boom');
+            expect(parsed.failedSteps).toEqual([failedStep]);
+            expect(parsed.failed).toBe(1);
+
+            // The top-level message names the step too — no generic "internal error".
+            expect(parsed.error).toContain('machine.hook');
+            expect(parsed.error).toContain('hook boom');
+
+            // `before` is the pre-run snapshot the issue asks for.
+            expect(parsed.before.results.length).toBeGreaterThan(0);
+        });
+
+        it('--json reports the transaction as not committed and rolled back', async () => {
+            const { runInit } = require('../../src/commands/init');
+            await runInit({ cwd: tmpHome, yes: true, json: true, actions: actionsWithFailingHook() });
+
+            const { transaction } = JSON.parse(stdout());
+            expect(transaction.committed).toBe(false);
+            expect(transaction.rolledBack).toBe(true);
+            expect(typeof transaction.transactionId).toBe('string');
+            expect(Array.isArray(transaction.restoredFiles)).toBe(true);
+            expect(transaction.note).toBeTruthy();
+
+            // The backup manifest on disk agrees: nothing was committed.
+            const { listBackups } = require('../../src/core/install-transaction');
+            const backups = listBackups();
+            expect(backups.length).toBeGreaterThan(0);
+            expect(backups.every((b: { committed: boolean }) => b.committed)).toBe(false);
+            // …and the run really did not persist anything.
+            expect(fs.existsSync(prefsFile())).toBe(false);
+        });
+
+        it('--json still emits a failure envelope when init fails before the step pipeline', async () => {
+            const actions = fakeActions([]);
+            actions.syncCache = async () => { throw new Error('registry unreachable'); };
+
+            const { runInit } = require('../../src/commands/init');
+            const code = await runInit({ cwd: tmpHome, yes: true, json: true, actions });
+
+            expect(code).toBe(2);
+            const parsed = JSON.parse(stdout());
+            expect(parsed.result).toBe('failed');
+            expect(parsed.error).toContain('registry unreachable');
+            expect(parsed.steps).toEqual([]);
+            expect(parsed.before).toBeNull();
+            expect(parsed.transaction.committed).toBe(false);
+        });
+
+        it('human mode renders the failed outcome instead of swallowing it', async () => {
+            const { runInit } = require('../../src/commands/init');
+            const code = await runInit({ cwd: tmpHome, yes: true, actions: actionsWithFailingHook() });
+
+            expect(code).toBe(2);
+            expect(stdout()).toContain('AWM · init');
+            expect(stdout()).toContain('machine.hook');
+            expect(stdout()).toContain('hook boom');
+            expect(stderr()).toContain('machine.hook');
+            expect(stderr()).toContain('hook boom');
+        });
     });
 });

--- a/cli/tests/core/init/steps-registry-sync.test.ts
+++ b/cli/tests/core/init/steps-registry-sync.test.ts
@@ -1,0 +1,115 @@
+// stepCache vs. syncRegistries()'s RESULT-shaped failures.
+//
+// `syncRegistries()` never throws on a per-registry failure — it returns
+// `{ action: 'error', error }` for that registry and keeps going. stepCache
+// used to `await` it and report a blanket 'applied', so a registry that never
+// landed on disk degraded silently into some later step's failure with its own
+// cause already gone.
+//
+// Isolated in its own file (not steps.test.ts) because these assertions reach
+// `listRegistries()`, which resolves AWM_HOME at module require time — the env
+// override therefore has to happen before the module is required, which means
+// `jest.resetModules()` + `require`, not a static import.
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { InitDeps, InitActions, StepResult } from '../../../src/core/init/types';
+import type { HarnessContext } from '../../../src/core/diagnostics/types';
+import type { RegistrySyncResult } from '../../../src/core/registries';
+
+describe('stepCache — registry sync error results', () => {
+    let tmpHome: string;
+    let originalHome: string | undefined;
+    let originalAwmHome: string | undefined;
+
+    beforeEach(() => {
+        tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-stepcache-'));
+        originalHome = process.env.HOME;
+        originalAwmHome = process.env.AWM_HOME;
+        process.env.HOME = tmpHome;
+        process.env.AWM_HOME = path.join(tmpHome, '.awm');
+        jest.resetModules();
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+        if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+        if (originalAwmHome === undefined) delete process.env.AWM_HOME; else process.env.AWM_HOME = originalAwmHome;
+    });
+
+    const awmHome = () => process.env.AWM_HOME as string;
+
+    /** Declares `names` in registries.json; creates a content root only for `withContent`. */
+    function configureRegistries(names: string[], withContent: string[]): void {
+        fs.mkdirSync(awmHome(), { recursive: true });
+        fs.writeFileSync(
+            path.join(awmHome(), 'registries.json'),
+            JSON.stringify(names.map((name) => ({ name, remote: `https://example.com/${name}.git` })), null, 2),
+        );
+        for (const name of withContent) {
+            const skills = path.join(awmHome(), 'registries', name, 'skills');
+            fs.mkdirSync(skills, { recursive: true });
+            fs.writeFileSync(path.join(skills, 'placeholder.md'), '# placeholder\n');
+        }
+    }
+
+    /** InitDeps just complete enough for stepCache: a machine with no registry cache yet. */
+    function deps(results: RegistrySyncResult[]): InitDeps {
+        const ctx: HarnessContext = {
+            machine: {
+                registryCache: { present: false },
+                hook: { present: true, degraded: false },
+                devCore: { present: true, brokenLinks: [] },
+                ambient: { wanted: [], installed: [] },
+                contextInjection: [],
+                globalSkills: { valid: [], repairable: [], dead: [] },
+            },
+            project: null,
+        };
+        const actions = { syncCache: async () => results } as unknown as InitActions;
+        return {
+            cwd: tmpHome, ctx, bundles: [], agent: 'claude-code', enabledAgents: ['claude-code'],
+            installMethod: 'symlink', registryRoot: '', contentDir: '', sensorPacksRoot: '',
+            confirmExtensions: async (p: string[]) => p, actions,
+        };
+    }
+
+    async function run(results: RegistrySyncResult[]): Promise<StepResult> {
+        const { stepCache } = require('../../../src/core/init/steps');
+        return stepCache(deps(results));
+    }
+
+    it('fails, naming the registry, when a sync error left no content on disk', async () => {
+        configureRegistries(['baseline'], []);
+        const r = await run([{ name: 'baseline', action: 'error', error: 'could not clone' }]);
+        expect(r.action).toBe('failed');
+        expect(r.error).toContain('baseline');
+        expect(r.error).toContain('could not clone');
+    });
+
+    it('stays applied but records the error when content is already on disk', async () => {
+        configureRegistries(['baseline'], ['baseline']);
+        const r = await run([{ name: 'baseline', action: 'error', error: 'pull timed out' }]);
+        expect(r.action).toBe('applied');
+        expect(r.detail).toContain('baseline');
+        expect(r.detail).toContain('pull timed out');
+    });
+
+    it('fails on a secondary registry that never landed, even when the base one synced', async () => {
+        configureRegistries(['baseline', 'documentation'], ['baseline']);
+        const r = await run([
+            { name: 'baseline', action: 'pulled', version: 'v1.0.0' },
+            { name: 'documentation', action: 'error', error: 'host unreachable' },
+        ]);
+        expect(r.action).toBe('failed');
+        expect(r.error).toContain('documentation');
+        expect(r.error).not.toContain('baseline');
+    });
+
+    it('reports applied with no detail when every registry synced', async () => {
+        configureRegistries(['baseline'], ['baseline']);
+        const r = await run([{ name: 'baseline', action: 'pulled', version: 'v1.0.0' }]);
+        expect(r.action).toBe('applied');
+        expect(r.detail).toBeUndefined();
+    });
+});

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -27,7 +27,20 @@ awm init [--agent <agent>] [--machine-only] [--yes] [--json]
 | `-a, --agent <agent>` | Target agent. Default `claude-code`. |
 | `--machine-only` | Run only machine-level steps; skip all project steps. |
 | `-y, --yes` | Skip confirmation prompts (for scripts). |
-| `--json` | Emit the full `InitOutcome` as JSON instead of the rendered report. |
+| `--json` | Emit the full `InitOutcome` as JSON instead of the rendered report — on success **and** on failure. |
+
+**Exit codes:** `0` healthy · `1` degraded (ran to completion, some checks still missing) · `2` failed (one or more steps failed; every write was rolled back).
+
+**`--json` contract.** Both documents carry a `result` field mirroring the exit code, so a bootstrap script can branch on one value:
+
+| `result` | Exit | Document |
+|---|---|---|
+| `ok` / `degraded` | 0 / 1 | The `InitOutcome`: `steps`, `applied`/`pending`/`failed`, `before`, `after`, `transactionId`, `modifiedFiles`. |
+| `failed` | 2 | A failure envelope: `error` (names the failed steps), `steps`, `failedSteps` (the `action: "failed"` subset, each with `id` and `error`), `before`, `after`, and `transaction`. |
+
+On `result: "failed"`, `transaction` records what happened to the machine: `committed` is always `false`, `rolledBack` says whether every path in `restoredFiles` was restored to its pre-init state, and `rollbackError` appears only if the restore itself failed (recover with `awm backup restore <transactionId>`). `after` is the state observed at the end of the step pipeline — *before* the rollback ran — so it describes what the failing run produced, not what is on disk now.
+
+Human mode renders the same evidence: on failure the three-panel report is printed as usual, with the failing step marked `✖` and its error inline, followed by the summary on stderr.
 
 **What it does:** syncs the registry cache · installs the agent's context mechanism (Claude: `SessionStart` hook; OpenCode: global `opencode.json` `instructions[]`) · installs the `dev` **baseline** skill pack · bootstraps `.awm/profile.json` · detects the stack and writes `.awm/sensors.json` · wires `CONSTITUTION.md` into the repo-local `opencode.json` (OpenCode). It **flags** (but does not perform) the steps that need an agent or a deliberate choice: generating `CONSTITUTION.md` / agent context, and installing the Claude per-edit sensor hook.
 


### PR DESCRIPTION
## Problema

`--json` declara en `--help` que emite el `InitOutcome`, pero no emitía **nada** en la única ruta donde un operador más lo necesita: una corrida fallida. Un bootstrap cloud headless abortando bajo `set -e` recibía solo:

```
awm init: internal error: one or more init steps failed
```

…sin forma de saber si falló `machine.cache`, `machine.hook`, `machine.contextInjection`, `machine.devCore`, `machine.globalSkills` o `machine.ambient`.

`runInitSteps` ya registraba, por paso, `{ id, action: 'failed', error }` (el `wrapStep` de `orchestrator.ts`). `commands/init.ts` la descartaba tres veces: un `Error` genérico en el chequeo `outcome.failed > 0`, la línea genérica de stderr en el catch externo, y la serialización JSON ubicada *después* del try/catch — inalcanzable en la ruta de error.

Reportado con repro completo en un VPS Ubuntu 24.04 (Node v24.18.0, Codex CLI 0.145.0, AWM 3.3.0).

## Cambios

El rollback sigue siendo exactamente tan transaccional como antes; lo único nuevo es que la evidencia lo sobrevive.

- **`cli/src/core/init/failure.ts` (nuevo)** — `InitStepsFailedError` transporta el `InitOutcome` a través de la frontera del rollback y nombra cada paso fallido en su mensaje. `buildInitFailureOutput()` arma el envelope JSON.
- **`--json` en fallo** emite `result: "failed"`, `error`, `steps`, `failedSteps` (el subconjunto `action: "failed"`, cada uno con `id` y `error`), `before`, `after`, y un bloque `transaction` que declara que nada se commiteó, qué se restauró, y que `after` es previo al rollback. También emite cuando la corrida falla *antes* de que el pipeline produzca un outcome, así `--json` nunca imprime vacío.
- **Modo humano** renderiza `renderInitOutcome(outcome)` antes del resumen en stderr, en vez de descartarlo.
- **El documento de éxito** gana `result: "ok" | "degraded"`, simétrico con el código de salida, para que un consumidor ramifique sobre un solo campo. Códigos de salida sin cambios: 0/1/2.
- **El rollback pasa a ser best-effort** y nunca enmascara el fallo original (misma política que el loop de rollback de `applyInstallPlan`); un rollback que falla se reporta vía `transaction.rollbackError`.

### Observación secundaria del reporte — confirmada y corregida

`syncRegistries()` reporta fallos por-registry como resultados, nunca lanza, y tanto `runInit` como `stepCache` los descartaban: un registry no disponible degradaba en silencio hacia el fallo de algún paso posterior, con su propia causa ya perdida. Ambos sitios ahora chequean — un registry que falló y **no dejó contenido en disco** falla ruidosamente y por nombre; uno que falló pero conserva contenido se registra como stale y la corrida continúa.

La distinción importa: `registryCache.present` verifica `.git`, no contenido usable. Tratar un content root sembrado sin git como fatal rompía dos fixtures reales de integración hasta que el predicado pasó a ser "contenido en disco".

## Contrato de `--json`

| `result` | Exit | Documento |
|---|---|---|
| `ok` / `degraded` | 0 / 1 | El `InitOutcome`: `steps`, `applied`/`pending`/`failed`, `before`, `after`, `transactionId`, `modifiedFiles`. |
| `failed` | 2 | Envelope de fallo: `error`, `steps`, `failedSteps`, `before`, `after`, `transaction`. |

`after` en el envelope de fallo es el estado observado al final del pipeline — *antes* del rollback. Describe lo que produjo la corrida fallida, no lo que hay en disco ahora. Recalcularlo post-rollback requeriría otro `gatherContext` que podría lanzar por su cuenta, así que el orden queda documentado en `transaction.note` y en `docs/cli-reference.md`.

## Verificación

`npx tsc --noEmit` limpio · **981/981 tests pasan** en 111 suites.

Dos smoke tests end-to-end contra el CLI compilado, con `HOME`/`AWM_HOME` aislados:

**Registry base inalcanzable** (el escenario reportado) → exit 2:
```json
{
  "result": "failed",
  "error": "registry sync failed and left no content on disk — baseline: …",
  "transaction": { "committed": false, "rolledBack": true, "transactionId": "2026-07-28T11-09-32-226Z" }
}
```
La causa que antes era invisible ahora es el titular.

**Registry sembrado con `machine.hook` fallando** → exit 2:
```json
{
  "result": "failed",
  "error": "one or more init steps failed — machine.hook: AWM registry not found at hooks. …",
  "failedSteps": [{ "id": "machine.hook", "level": "machine", "action": "failed", "error": "AWM registry not found at hooks. …" }],
  "applied": 2, "pending": 0, "failed": 1
}
```

### Tests de regresión

- `awm init --json` produce JSON parseable con el `id` y el `error` del paso fallido, y código de salida no cero.
- La transacción no se confirma — aseverado contra el manifest de backup en disco, no solo contra el payload.
- La ruta de fallo previa al pipeline igual emite un envelope válido.
- Modo humano renderiza el outcome fallido en vez de tragárselo.
- Cada caso de resultado de sync de registry (sin contenido → falla; con contenido → stale; registry secundario que nunca aterrizó → falla por nombre).

Los tests nuevos usan tmpdirs aislados con `HOME`/`AWM_HOME` sobreescritos; ninguno toca el `~/.awm` real. Los que alcanzan `listRegistries()` viven en su propio archivo porque `AWM_HOME` se resuelve en require-time y el override necesita `jest.resetModules()` + `require`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYcP9LX3A3R6ncU6kiY7vc)_