### PR TITLE
feat(sensors): kill the process tree on timeout, keep partial findings, run sensors in parallel

### DIFF
--- a/cli/src/commands/sensors/exec.ts
+++ b/cli/src/commands/sensors/exec.ts
@@ -1,0 +1,140 @@
+import { spawn, execFile } from 'child_process';
+
+/** Outcome of a sensor command. Never throws — every failure mode is a field. */
+export type ExecResult = {
+    stdout: string;
+    stderr: string;
+    /** Exit code, or null when the process was killed by a signal or never started. */
+    code: number | null;
+    signal: NodeJS.Signals | null;
+    /** The deadline fired and the process group was killed. */
+    timedOut: boolean;
+    /** Collected output hit `maxBuffer`; the process group was killed. */
+    overflowed: boolean;
+    /** The shell itself could not be spawned (bad cwd, no shell). */
+    spawnError?: NodeJS.ErrnoException;
+};
+
+export type ExecOptions = {
+    timeout: number;
+    cwd: string;
+    maxBuffer?: number;
+    /** SIGTERM → SIGKILL grace for the process group. */
+    killGraceMs?: number;
+};
+
+const DEFAULT_MAX_BUFFER = 64 * 1024 * 1024;
+const DEFAULT_KILL_GRACE_MS = 2_000;
+/** After SIGKILL, resolve regardless. A sensor must never hang the gate. */
+const POST_KILL_GRACE_MS = 1_000;
+
+/**
+ * Kill an entire process tree, not just its root.
+ *
+ * This is the reason `execSync` had to go. `execSync(cmd, { timeout })` spawns
+ * `/bin/sh -c cmd` and, on the deadline, SIGTERMs *that shell only*. A sensor
+ * command is almost always a wrapper (`npx tsc --noEmit`, `npm test`), so the
+ * tool doing the actual work is a grandchild: it survives, gets reparented to
+ * init, and keeps burning CPU. Every timeout then leaves a full tsc/eslint
+ * running, which makes the next run slower, which makes it time out too. The
+ * leak compounds — a repo that was fine at 200 files becomes ungateable at 2000
+ * for reasons that have nothing to do with its size.
+ *
+ * `detached: true` puts the child in its own process group (pgid === pid) so a
+ * negative-pid kill reaches every descendant at once.
+ */
+function killTree(pid: number, signal: NodeJS.Signals): void {
+    if (process.platform === 'win32') {
+        // Windows has no process groups in the POSIX sense; taskkill /T walks the tree.
+        try { execFile('taskkill', ['/pid', String(pid), '/T', '/F'], () => { /* best effort */ }); } catch { /* ignore */ }
+        return;
+    }
+    try {
+        process.kill(-pid, signal);   // negative pid → the whole group
+    } catch {
+        // Group already gone (normal race with a process exiting on its own),
+        // or we never became a group leader. Fall back to the direct child.
+        try { process.kill(pid, signal); } catch { /* already dead */ }
+    }
+}
+
+/**
+ * Run a shell command to completion, a deadline, or an output cap — whichever
+ * comes first — and always return what was collected.
+ *
+ * Two guarantees `execSync` could not give:
+ *  1. Cutting a run short kills the whole process tree (see `killTree`).
+ *  2. Output produced before the cut is returned, not discarded. A timeout that
+ *     throws away 60s of eslint output costs double: the wall clock, and then
+ *     the re-run the caller has to do to learn anything at all.
+ */
+export function runCommand(cmd: string, opts: ExecOptions): Promise<ExecResult> {
+    const maxBuffer = opts.maxBuffer ?? DEFAULT_MAX_BUFFER;
+    const killGraceMs = opts.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
+
+    return new Promise<ExecResult>((resolve) => {
+        let stdout = '';
+        let stderr = '';
+        let timedOut = false;
+        let overflowed = false;
+        let settled = false;
+        const timers: NodeJS.Timeout[] = [];
+
+        const child = spawn(cmd, {
+            shell: true,
+            cwd: opts.cwd,
+            detached: process.platform !== 'win32',
+            // stdin closed: a sensor must never block waiting for input, and the
+            // EOF also tells watch-mode-capable tools (vitest, jest) to run once.
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+
+        const later = (fn: () => void, ms: number) => {
+            const t = setTimeout(fn, ms);
+            t.unref?.();
+            timers.push(t);
+            return t;
+        };
+
+        const finish = (extra: Partial<ExecResult>) => {
+            if (settled) return;
+            settled = true;
+            timers.forEach(clearTimeout);
+            resolve({ stdout, stderr, code: null, signal: null, timedOut, overflowed, ...extra });
+        };
+
+        /** Cut the run short: kill the tree, escalate, and never hang waiting for it. */
+        const cutShort = () => {
+            if (settled || child.pid === undefined) return;
+            const pid = child.pid;
+            killTree(pid, 'SIGTERM');
+            later(() => killTree(pid, 'SIGKILL'), killGraceMs);
+            // If `close` still has not fired after the escalation, stop waiting.
+            // Whatever is holding the pipe open is no longer our problem to block on.
+            later(() => { child.unref(); finish({ signal: 'SIGKILL' }); }, killGraceMs + POST_KILL_GRACE_MS);
+        };
+
+        const collect = (into: 'out' | 'err') => (chunk: Buffer | string) => {
+            if (settled || overflowed) return;
+            const text = String(chunk);
+            const current = into === 'out' ? stdout : stderr;
+            const room = maxBuffer - current.length;
+            const next = current + (text.length > room ? text.slice(0, room) : text);
+            if (into === 'out') stdout = next; else stderr = next;
+            if (next.length >= maxBuffer) {
+                overflowed = true;
+                cutShort();
+            }
+        };
+
+        child.stdout?.on('data', collect('out'));
+        child.stderr?.on('data', collect('err'));
+        child.stdout?.on('error', () => { /* pipe torn down by our own kill */ });
+        child.stderr?.on('error', () => { /* pipe torn down by our own kill */ });
+
+        child.on('error', (err: NodeJS.ErrnoException) => finish({ spawnError: err }));
+        child.on('close', (code, signal) => finish({ code, signal }));
+
+        later(() => { timedOut = true; cutShort(); }, opts.timeout);
+    });
+}

--- a/cli/src/commands/sensors/index.ts
+++ b/cli/src/commands/sensors/index.ts
@@ -26,8 +26,8 @@ export function registerSensorsCommand(program: Command): void {
         .option('--fast', 'run fast sensors only (tsc, lint)')
         .option('--slow', 'run slow sensors only (semgrep, mutation)')
         .option('--all', 'run all sensors regardless of speed')
-        .action((opts) => {
-            const output = runSensors({ fast: opts.fast, slow: opts.slow, all: opts.all });
+        .action(async (opts) => {
+            const output = await runSensors({ fast: opts.fast, slow: opts.slow, all: opts.all });
             // Emit the verdict ALWAYS — an empty `sensors` with overall:'not_certified'
             // must be visible, never a silent exit-0 that reads as "clean".
             process.stdout.write(JSON.stringify(output, null, 2) + '\n');
@@ -51,9 +51,9 @@ export function registerSensorsCommand(program: Command): void {
     sensors
         .command('baseline')
         .description('snapshot current findings as accepted — sensors then fail only on NEW ones')
-        .action(() => {
+        .action(async () => {
             const manifestDir = findManifestDir(process.cwd());
-            const output = runSensors({ all: true, ignoreBaseline: true });
+            const output = await runSensors({ all: true, ignoreBaseline: true });
             const baseline = buildBaseline(output.sensors.map(s => ({ name: s.name, errors: s.errors })));
             const writeDir = manifestDir ?? process.cwd();
             writeBaseline(writeDir, baseline);

--- a/cli/src/commands/sensors/run.ts
+++ b/cli/src/commands/sensors/run.ts
@@ -1,6 +1,7 @@
-import { execSync } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
+import { runCommand, ExecResult } from './exec';
 import { SensorManifest, SensorResult, RunOutput, SensorError } from './types';
 import { parseTscOutput } from './formatters/tsc';
 import { parseEslintOutput } from './formatters/eslint';
@@ -15,9 +16,11 @@ const MANIFEST_FILE = '.awm/sensors.json';
 const DEFAULT_FAST_TIMEOUT = 10_000;
 const DEFAULT_SLOW_TIMEOUT = 120_000;
 // Sensor JSON output can be several MB on large repos (e.g. `eslint --format json`
-// with thousands of findings). execSync defaults to a 1MB buffer and kills the
-// child with SIGTERM when exceeded — which previously surfaced as a false "timeout".
+// with thousands of findings). A 1MB cap killed the child with SIGTERM when
+// exceeded — which previously surfaced as a false "timeout".
 const MAX_BUFFER = 64 * 1024 * 1024;
+/** Hard ceiling on parallel sensors: past this, they only contend for the same cores. */
+const MAX_CONCURRENCY = 4;
 
 export type RunOptions = {
     fast?: boolean;
@@ -118,75 +121,123 @@ function isExitCodeSensor(name: string): boolean {
     return name === 'test';
 }
 
-function runSensor(name: string, cmd: string, timeout: number, cwd: string): SensorResult {
-    try {
-        const raw = execSync(cmd, { encoding: 'utf-8', timeout, cwd, maxBuffer: MAX_BUFFER, stdio: ['pipe', 'pipe', 'pipe'] });
-        const errors = getFormatter(name)(raw);
-        return { name, status: errors.length > 0 ? 'fail' : 'pass', errors };
-    } catch (err: any) {
-        // Output exceeded maxBuffer — child is killed before output can be read.
-        // Check this BEFORE the SIGTERM branch (ENOBUFS kills with SIGTERM too).
-        // Nothing could be read, so nothing was certified.
-        if (err.code === 'ENOBUFS') {
-            return { name, status: 'inconclusive', errors: [], skipReason: `output exceeded ${MAX_BUFFER} bytes` };
-        }
-        // Genuine timeout: execSync kills with SIGTERM after `timeout` ms. The
-        // sensor produced no verdict — inconclusive, not a benign skip.
-        if (err.code === 'ETIMEDOUT' || (err.killed && err.signal === 'SIGTERM')) {
-            return { name, status: 'inconclusive', errors: [], skipReason: `timeout after ${timeout}ms` };
-        }
-        // Non-zero exit — the normal path for linters/typecheckers that found
-        // findings. Parse the output; if it yields findings, that's a fail.
-        const raw = String((err.stdout ?? '') + (err.stderr ?? ''));
-        const errors = getFormatter(name)(raw);
-        if (errors.length > 0) return { name, status: 'fail', errors };
-        // A missing tool (binary not installed) must NOT pass silently — the gate
-        // cannot certify what it could not run. Treat it as a fail with a clear message.
-        //
-        // Exit 127 is the POSIX signal for "command not found" and is the only check
-        // here that holds across shells and locales: bash writes `command not found`
-        // but dash — `/bin/sh` on Debian/Ubuntu, hence most CI runners and containers
-        // — writes `not found`, so matching shell text alone read an absent tool as a
-        // benign skip. `err.code` does not cover it either: that is ENOENT only when
-        // spawning the shell itself fails, not when the shell starts and the command
-        // inside it is missing. The ENOBUFS and timeout branches are evaluated above,
-        // so reaching here with status 127 means the command did not exist.
-        //
-        // A wrapper (`npm test`, `npx …`) that exits 127 because a binary it invokes
-        // is absent is classified the same way, deliberately: the gate still ran
-        // nothing and still cannot certify anything.
-        const lower = raw.toLowerCase();
-        const toolMissing =
-            err.status === 127 ||                          // POSIX: command not found
-            (err as any).code === 'ENOENT' ||               // execSync spawn failure (no shell)
-            lower.includes('command not found') ||          // bash, zsh
-            // cmd.exe reports an absent binary with exit 1, so 127 does not cover
-            // Windows; this exact phrase does. Kept narrow on purpose — a loose
-            // `not found` would also match a tool that ran and said "not found"
-            // for reasons of its own.
-            lower.includes('is not recognized as an internal or external command') ||
-            lower.includes('enoent') ||
-            lower.includes('could not determine executable');
-        if (toolMissing) {
+async function runSensor(name: string, cmd: string, timeout: number, cwd: string): Promise<SensorResult> {
+    const res: ExecResult = await runCommand(cmd, { timeout, cwd, maxBuffer: MAX_BUFFER });
+    const format = getFormatter(name);
+
+    // The shell itself never started (bad cwd, no shell). Nothing ran.
+    if (res.spawnError) {
+        return {
+            name,
+            status: 'fail',
+            errors: [{ message: `sensor could not be started: ${res.spawnError.message}` }],
+        };
+    }
+
+    // Cut short by the deadline or the output cap. The run is NOT a verdict — but
+    // whatever it printed before being cut is still evidence, and throwing it away
+    // is what forced the caller to re-run the same command by hand to learn
+    // anything. Findings in the partial output are real findings; their absence
+    // proves nothing, so a clean partial can never be `pass`.
+    if (res.timedOut || res.overflowed) {
+        const reason = res.timedOut
+            ? `timeout after ${timeout}ms`
+            : `output exceeded ${MAX_BUFFER} bytes`;
+        const errors = format(res.stdout + res.stderr);
+        if (errors.length > 0) {
             return {
                 name,
                 status: 'fail',
-                errors: [{ message: `sensor tool not available: ${raw.slice(0, 200)}` }],
+                errors,
+                incomplete: `${reason} — findings below are from partial output; the run did not finish`,
             };
         }
-        // Exit-code sensors (tests): any genuine non-zero exit is a real failure,
-        // even when no per-line findings can be parsed from the output.
-        if (isExitCodeSensor(name)) {
-            return { name, status: 'fail', errors: [{ message: `SENSOR[${name}] failed (exit ${err.status})` }] };
-        }
-        // Residual case: it exited non-zero, the tool exists, and no finding
-        // could be parsed. We do not know what happened — say so instead of
-        // reporting a benign skip.
-        return { name, status: 'inconclusive', errors: [], skipReason: `exit ${err.status}: ${raw.slice(0, 200)}` };
+        return { name, status: 'inconclusive', errors: [], skipReason: reason };
     }
+
+    if (res.code === 0) {
+        const errors = format(res.stdout);
+        return { name, status: errors.length > 0 ? 'fail' : 'pass', errors };
+    }
+
+    // Non-zero exit — the normal path for linters/typecheckers that found
+    // findings. Parse the output; if it yields findings, that's a fail.
+    const raw = res.stdout + res.stderr;
+    const errors = format(raw);
+    if (errors.length > 0) return { name, status: 'fail', errors };
+
+    // A missing tool (binary not installed) must NOT pass silently — the gate
+    // cannot certify what it could not run. Treat it as a fail with a clear message.
+    //
+    // Exit 127 is the POSIX signal for "command not found" and is the only check
+    // here that holds across shells and locales: bash writes `command not found`
+    // but dash — `/bin/sh` on Debian/Ubuntu, hence most CI runners and containers
+    // — writes `not found`, so matching shell text alone read an absent tool as a
+    // benign skip. A failure to spawn the shell itself is a different thing and
+    // is handled above via `spawnError`. The cut-short branches are evaluated
+    // above too, so reaching here with status 127 means the command did not exist.
+    //
+    // A wrapper (`npm test`, `npx …`) that exits 127 because a binary it invokes
+    // is absent is classified the same way, deliberately: the gate still ran
+    // nothing and still cannot certify anything.
+    const lower = raw.toLowerCase();
+    const toolMissing =
+        res.code === 127 ||                             // POSIX: command not found
+        lower.includes('command not found') ||          // bash, zsh
+        // cmd.exe reports an absent binary with exit 1, so 127 does not cover
+        // Windows; this exact phrase does. Kept narrow on purpose — a loose
+        // `not found` would also match a tool that ran and said "not found"
+        // for reasons of its own.
+        lower.includes('is not recognized as an internal or external command') ||
+        lower.includes('enoent') ||
+        lower.includes('could not determine executable');
+    if (toolMissing) {
+        return {
+            name,
+            status: 'fail',
+            errors: [{ message: `sensor tool not available: ${raw.slice(0, 200)}` }],
+        };
+    }
+    // Exit-code sensors (tests): any genuine non-zero exit is a real failure,
+    // even when no per-line findings can be parsed from the output.
+    if (isExitCodeSensor(name)) {
+        return { name, status: 'fail', errors: [{ message: `SENSOR[${name}] failed (exit ${res.code})` }] };
+    }
+    // Residual case: it exited non-zero, the tool exists, and no finding
+    // could be parsed. We do not know what happened — say so instead of
+    // reporting a benign skip.
+    return { name, status: 'inconclusive', errors: [], skipReason: `exit ${res.code}: ${raw.slice(0, 200)}` };
 }
 
-export function runSensors(opts: RunOptions = {}): RunOutput {
+/**
+ * How many sensors may run at once. Sensors are separate processes over the same
+ * tree, so they parallelise cleanly — but each one (tsc, eslint, depcruise) is
+ * largely single-threaded, and oversubscribing the box just makes every sensor
+ * slower and more likely to hit its own deadline. Leave a core for the agent.
+ */
+export function resolveConcurrency(manifest: SensorManifest, sensorCount: number): number {
+    const configured = Number(process.env.AWM_SENSORS_CONCURRENCY ?? manifest.concurrency);
+    if (Number.isFinite(configured) && configured >= 1) return Math.min(Math.floor(configured), sensorCount);
+    const cores = os.cpus()?.length ?? 2;
+    return Math.max(1, Math.min(MAX_CONCURRENCY, cores - 1, sensorCount));
+}
+
+/** Run `tasks` with at most `limit` in flight, preserving input order in the output. */
+async function pooled<T>(tasks: Array<() => Promise<T>>, limit: number): Promise<T[]> {
+    const results = new Array<T>(tasks.length);
+    let next = 0;
+    const worker = async () => {
+        while (true) {
+            const i = next++;
+            if (i >= tasks.length) return;
+            results[i] = await tasks[i]();
+        }
+    };
+    await Promise.all(Array.from({ length: Math.min(limit, tasks.length) }, worker));
+    return results;
+}
+
+export async function runSensors(opts: RunOptions = {}): Promise<RunOutput> {
     const startCwd = opts.cwd ?? process.cwd();
     const manifestDir = findManifestDir(startCwd);
     if (!manifestDir) return { sensors: [], overall: 'not_certified' };
@@ -196,32 +247,42 @@ export function runSensors(opts: RunOptions = {}): RunOutput {
     const activeManifest = reconciled.manifest;
     const cwd = manifestDir; // ejecutar sensores y baseline desde donde vive el manifest
 
-    const results: SensorResult[] = [];
     // Baseline suppresses already-accepted findings so sensors fail only on NEW
     // ones (essential on repos with a large pre-existing baseline). Absent file or
     // --ignore-baseline → every finding counts (backward-compatible).
     const baseline = opts.ignoreBaseline ? null : readBaseline(cwd);
+
+    // Sensors are independent processes over the same tree, so they run
+    // concurrently rather than one-after-another: wall clock becomes the slowest
+    // sensor instead of the sum of all of them. Tasks are built — and dispatched —
+    // in manifest order, so the reported order stays stable.
+    const tasks: Array<() => Promise<SensorResult>> = [];
+    const settled = (r: SensorResult) => () => Promise.resolve(r);
 
     for (const [name, config] of Object.entries(activeManifest.sensors)) {
         const isFast = config.fast ?? false;
         if (!shouldRun(isFast, opts)) continue;
 
         if (config.enabled === false) {
-            results.push({ name, status: 'skipped', errors: [], skipReason: 'disabled' });
+            tasks.push(settled({ name, status: 'skipped', errors: [], skipReason: 'disabled' }));
             continue;
         }
         if (!config.cmd) {
             // Enabled but with nothing to run: broken config, not a deliberate
             // opt-out. `enabled: false` is how a sensor is turned off.
-            results.push({ name, status: 'inconclusive', errors: [], skipReason: 'no cmd configured' });
+            tasks.push(settled({ name, status: 'inconclusive', errors: [], skipReason: 'no cmd configured' }));
             continue;
         }
 
+        const cmd = config.cmd;
         const timeout = config.timeout ?? (isFast ? DEFAULT_FAST_TIMEOUT : DEFAULT_SLOW_TIMEOUT);
-        let result = runSensor(name, config.cmd, timeout, cwd);
-        if (baseline) result = applyBaseline(result, baseline[name]);
-        results.push(result);
+        tasks.push(async () => {
+            const result = await runSensor(name, cmd, timeout, cwd);
+            return baseline ? applyBaseline(result, baseline[name]) : result;
+        });
     }
+
+    const results = await pooled(tasks, resolveConcurrency(activeManifest, tasks.length));
 
     // `fail` outranks `inconclusive`: when something is broken AND something
     // could not be measured, the broken thing is the actionable verdict.

--- a/cli/src/commands/sensors/types.ts
+++ b/cli/src/commands/sensors/types.ts
@@ -8,6 +8,8 @@ export type SensorConfig = {
 export type SensorManifest = {
     pack: string;
     sensors: Record<string, SensorConfig>;
+    /** How many sensors may run at once. Defaults to a core-count-derived cap. */
+    concurrency?: number;
 };
 
 export type SensorError = {
@@ -42,6 +44,13 @@ export type SensorResult = {
     status: 'pass' | 'fail' | 'inconclusive' | 'skipped';
     errors: SensorError[];
     skipReason?: string;
+    /**
+     * The run was cut short (timeout, output cap) but the partial output still
+     * yielded findings. The findings listed are real; their *absence* proves
+     * nothing, so this can never accompany a `pass`. Holds the reason, so the
+     * caller can tell "clean" from "clean as far as we got".
+     */
+    incomplete?: string;
     /** New findings (not in baseline). Present only when a baseline is applied. */
     newCount?: number;
     /** Findings suppressed by the baseline. Present only when a baseline is applied. */

--- a/cli/tests/commands/sensors/exec-fixtures.ts
+++ b/cli/tests/commands/sensors/exec-fixtures.ts
@@ -1,0 +1,24 @@
+import type { ExecResult } from '../../../src/commands/sensors/exec';
+
+/**
+ * Builders for the `ExecResult` shape that `runCommand` returns. Sensor tests
+ * mock the exec boundary rather than `child_process` directly: `runCommand`
+ * never throws, so a mocked run is a value, not an exception.
+ */
+
+const base = { stdout: '', stderr: '', code: null as number | null, signal: null as NodeJS.Signals | null, timedOut: false, overflowed: false };
+
+/** Clean run: exit 0. */
+export const ok = (stdout = ''): ExecResult => ({ ...base, stdout, code: 0 });
+
+/** Ran to completion with a non-zero exit code. */
+export const exited = (code: number, stdout = '', stderr = ''): ExecResult => ({ ...base, stdout, stderr, code });
+
+/** Cut short by the deadline. `stdout` is whatever it managed to print first. */
+export const timedOut = (stdout = '', stderr = ''): ExecResult => ({ ...base, stdout, stderr, signal: 'SIGKILL', timedOut: true });
+
+/** Cut short by the output cap. */
+export const overflowed = (stdout = ''): ExecResult => ({ ...base, stdout, signal: 'SIGKILL', overflowed: true });
+
+/** The shell itself never started. */
+export const spawnFailed = (message = 'ENOENT'): ExecResult => ({ ...base, spawnError: Object.assign(new Error(message), { code: 'ENOENT' }) });

--- a/cli/tests/commands/sensors/exec.test.ts
+++ b/cli/tests/commands/sensors/exec.test.ts
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { runCommand } from '../../../src/commands/sensors/exec';
+
+const onPosix = process.platform !== 'win32' ? describe : describe.skip;
+
+/** Poll until `fn()` is true or the budget runs out. Avoids fixed sleeps. */
+async function until(fn: () => boolean, budgetMs = 4000): Promise<boolean> {
+    const deadline = Date.now() + budgetMs;
+    while (Date.now() < deadline) {
+        if (fn()) return true;
+        await new Promise(r => setTimeout(r, 25));
+    }
+    return fn();
+}
+
+describe('runCommand — exit codes and output', () => {
+    it('returns stdout and code 0 for a clean command', async () => {
+        const r = await runCommand('echo hello', { timeout: 5000, cwd: process.cwd() });
+        expect(r.code).toBe(0);
+        expect(r.stdout.trim()).toBe('hello');
+        expect(r.timedOut).toBe(false);
+        expect(r.overflowed).toBe(false);
+    });
+
+    it('captures stderr and a non-zero exit code without throwing', async () => {
+        const r = await runCommand('echo oops 1>&2; exit 3', { timeout: 5000, cwd: process.cwd() });
+        expect(r.code).toBe(3);
+        expect(r.stderr).toMatch(/oops/);
+        expect(r.timedOut).toBe(false);
+    });
+
+    it('reports 127 for a command that does not exist', async () => {
+        const r = await runCommand('awm-definitely-not-a-real-binary-xyz', { timeout: 5000, cwd: process.cwd() });
+        expect(r.code).toBe(127);
+    });
+});
+
+describe('runCommand — output cap', () => {
+    it('stops at maxBuffer, flags overflow, and keeps what it read', async () => {
+        // 200 lines of ~50 bytes each, capped at 1KB.
+        const r = await runCommand(`for i in $(seq 1 200); do echo "line-$i-padding-padding-padding-padding"; done`, {
+            timeout: 10_000, cwd: process.cwd(), maxBuffer: 1024,
+        });
+        expect(r.overflowed).toBe(true);
+        expect(r.stdout.length).toBeLessThanOrEqual(1024);
+        // The point of the cap change: what was read is still usable, not discarded.
+        expect(r.stdout).toMatch(/line-1-/);
+    });
+});
+
+onPosix('runCommand — timeout', () => {
+    it('flags the timeout and returns the output produced before the deadline', async () => {
+        const r = await runCommand('echo partial-finding; sleep 30', { timeout: 700, cwd: process.cwd() });
+        expect(r.timedOut).toBe(true);
+        // This is the whole point of dropping execSync: 700ms of work is not thrown away.
+        expect(r.stdout).toMatch(/partial-finding/);
+    });
+
+    it('kills the grandchild process, not just the shell it spawned', async () => {
+        // Models `npx tsc --noEmit`: the sensor command is a wrapper that spawns the
+        // real tool. execSync SIGTERMs only the shell it started, leaving the tool
+        // running and reparented to init — the leak that compounds across retries.
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-exec-group-'));
+        const beat = path.join(dir, 'beat');
+        const worker = path.join(dir, 'worker.js');
+        fs.writeFileSync(worker, `
+            const fs = require('fs');
+            setInterval(() => fs.writeFileSync(${JSON.stringify(beat)}, String(Date.now())), 30);
+            setTimeout(() => {}, 60000);
+        `);
+
+        try {
+            const r = await runCommand(`sh -c "node ${worker} & wait"`, { timeout: 800, cwd: dir });
+            expect(r.timedOut).toBe(true);
+
+            // The worker must have been alive before the kill, or the test proves nothing.
+            expect(await until(() => fs.existsSync(beat))).toBe(true);
+
+            const atKill = fs.readFileSync(beat, 'utf-8');
+            const stillBeating = await until(() => fs.readFileSync(beat, 'utf-8') !== atKill, 1000);
+            expect(stillBeating).toBe(false);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    }, 15_000);
+});
+
+describe('runCommand — spawn failure', () => {
+    it('surfaces a spawn error instead of hanging', async () => {
+        const r = await runCommand('echo hi', { timeout: 5000, cwd: path.join(os.tmpdir(), 'awm-no-such-dir-xyz') });
+        expect(r.spawnError).toBeDefined();
+        expect(r.code).not.toBe(0);
+    });
+});

--- a/cli/tests/commands/sensors/run-inconclusive.test.ts
+++ b/cli/tests/commands/sensors/run-inconclusive.test.ts
@@ -2,10 +2,12 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-const mockExecSyncFn = jest.fn();
-jest.mock('child_process', () => ({
-    execSync: (...args: any[]) => mockExecSyncFn(...args),
+const mockRunCommand = jest.fn();
+jest.mock('../../../src/commands/sensors/exec', () => ({
+    runCommand: (...args: any[]) => mockRunCommand(...args),
 }));
+
+const { ok, exited, timedOut, overflowed } = require('./exec-fixtures');
 
 /** Sensors run in manifest insertion order, so mocks are queued in that order. */
 const MANIFEST = {
@@ -16,7 +18,7 @@ const MANIFEST = {
     },
 };
 
-const timeoutError = () => { throw Object.assign(new Error('killed'), { code: 'ETIMEDOUT' }); };
+const timeoutError = () => timedOut();
 
 describe('runSensors — inconclusive: a sensor that could not certify is never green', () => {
     let root: string;
@@ -25,7 +27,7 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
 
     beforeEach(() => {
         jest.resetModules();
-        mockExecSyncFn.mockReset();
+        mockRunCommand.mockReset();
         root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-inconclusive-'));
         fs.mkdirSync(path.join(root, '.awm'), { recursive: true });
         fs.writeFileSync(path.join(root, '.awm', 'sensors.json'), JSON.stringify(MANIFEST));
@@ -43,38 +45,38 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
 
     const load = () => require('../../../src/commands/sensors/run');
 
-    it('reports a timed-out sensor as inconclusive, keeping its reason', () => {  // verifies R2, R7
-        mockExecSyncFn
-            .mockReturnValueOnce('' as any)          // typecheck: clean
-            .mockImplementationOnce(timeoutError);   // security: times out
+    it('reports a timed-out sensor as inconclusive, keeping its reason', async () => {  // verifies R2, R7
+        mockRunCommand
+            .mockResolvedValueOnce(ok())          // typecheck: clean
+            .mockResolvedValueOnce(timeoutError());   // security: times out
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         const security = out.sensors.find((s: any) => s.name === 'security');
         expect(security.status).toBe('inconclusive');
         expect(security.skipReason).toMatch(/timeout/);
     });
 
-    it('does not let a healthy sensor carry the run to pass while another could not certify', () => {  // verifies R8
-        mockExecSyncFn
-            .mockReturnValueOnce('' as any)
-            .mockImplementationOnce(timeoutError);
+    it('does not let a healthy sensor carry the run to pass while another could not certify', async () => {  // verifies R8
+        mockRunCommand
+            .mockResolvedValueOnce(ok())
+            .mockResolvedValueOnce(timeoutError());
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         expect(out.sensors.find((s: any) => s.name === 'typecheck').status).toBe('pass');
         expect(out.overall).toBe('not_certified');
     });
 
-    it('reports a sensor whose output was truncated as inconclusive', () => {  // verifies R3
-        mockExecSyncFn
-            .mockReturnValueOnce('' as any)
-            .mockImplementationOnce(() => { throw Object.assign(new Error('too big'), { code: 'ENOBUFS' }); });
+    it('reports a sensor whose output was truncated as inconclusive', async () => {  // verifies R3
+        mockRunCommand
+            .mockResolvedValueOnce(ok())
+            .mockResolvedValueOnce(overflowed());
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         const security = out.sensors.find((s: any) => s.name === 'security');
         expect(security.status).toBe('inconclusive');
@@ -82,20 +84,16 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
         expect(out.overall).toBe('not_certified');
     });
 
-    it('reports an uninterpretable non-zero exit as inconclusive', () => {  // verifies R4
-        mockExecSyncFn
-            .mockReturnValueOnce('' as any)
-            .mockImplementationOnce(() => {
-                // semgrep formatter yields no findings for non-JSON output, the
-                // tool is present (exit 2, not 127), and `security` is not an
-                // exit-code sensor — the residual "I don't know" case.
-                throw Object.assign(new Error('failed'), {
-                    stdout: '', stderr: 'internal error: rule engine crashed\n', status: 2,
-                });
-            });
+    it('reports an uninterpretable non-zero exit as inconclusive', async () => {  // verifies R4
+        mockRunCommand
+            .mockResolvedValueOnce(ok())
+            // semgrep formatter yields no findings for non-JSON output, the
+            // tool is present (exit 2, not 127), and `security` is not an
+            // exit-code sensor — the residual "I don't know" case.
+            .mockResolvedValueOnce(exited(2, '', 'internal error: rule engine crashed\n'));
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         const security = out.sensors.find((s: any) => s.name === 'security');
         expect(security.status).toBe('inconclusive');
@@ -103,7 +101,7 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
         expect(out.overall).toBe('not_certified');
     });
 
-    it('reports an enabled sensor with no cmd as inconclusive', () => {  // verifies R5
+    it('reports an enabled sensor with no cmd as inconclusive', async () => {  // verifies R5
         fs.writeFileSync(path.join(root, '.awm', 'sensors.json'), JSON.stringify({
             pack: 'js-ts',
             sensors: {
@@ -111,10 +109,10 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
                 depcheck: { fast: false },   // enabled, but nothing to run
             },
         }));
-        mockExecSyncFn.mockReturnValueOnce('' as any);   // typecheck: clean
+        mockRunCommand.mockResolvedValueOnce(ok());   // typecheck: clean
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         const depcheck = out.sensors.find((s: any) => s.name === 'depcheck');
         expect(depcheck.status).toBe('inconclusive');
@@ -122,24 +120,20 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
         expect(out.overall).toBe('not_certified');
     });
 
-    it('reports fail, not not_certified, when something is broken and something could not run', () => {  // verifies R9
-        mockExecSyncFn
-            .mockImplementationOnce(() => {   // typecheck: real findings
-                throw Object.assign(new Error(), {
-                    stdout: 'src/a.ts(1,1): error TS0001: Bad type.', stderr: '', status: 1,
-                });
-            })
-            .mockImplementationOnce(timeoutError);   // security: times out
+    it('reports fail, not not_certified, when something is broken and something could not run', async () => {  // verifies R9
+        mockRunCommand
+            .mockResolvedValueOnce(exited(1, 'src/a.ts(1,1): error TS0001: Bad type.'))   // typecheck: real findings
+            .mockResolvedValueOnce(timeoutError());   // security: times out
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         expect(out.sensors.find((s: any) => s.name === 'typecheck').status).toBe('fail');
         expect(out.sensors.find((s: any) => s.name === 'security').status).toBe('inconclusive');
         expect(out.overall).toBe('fail');
     });
 
-    it('never emits an overall value outside the published domain', () => {  // verifies R11
+    it('never emits an overall value outside the published domain', async () => {  // verifies R11
         // `inconclusive` is a per-sensor status only. External consumers (the
         // registry skills) read `overall`, whose domain must not grow — this
         // pins that invariant at runtime on a three-sensor pass+fail+inconclusive
@@ -159,23 +153,19 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
         }));
         const DOMAIN = ['pass', 'fail', 'skipped', 'not_certified'];
 
-        mockExecSyncFn
-            .mockImplementationOnce(() => {              // typecheck: real findings → fail
-                throw Object.assign(new Error(), {
-                    stdout: 'src/a.ts(1,1): error TS0001: Bad type.', stderr: '', status: 1,
-                });
-            })
-            .mockReturnValueOnce('' as any)               // lint: clean → pass
-            .mockImplementationOnce(timeoutError);         // security: times out → inconclusive
+        mockRunCommand
+            .mockResolvedValueOnce(exited(1, 'src/a.ts(1,1): error TS0001: Bad type.'))  // typecheck: real findings → fail
+            .mockResolvedValueOnce(ok())               // lint: clean → pass
+            .mockResolvedValueOnce(timeoutError());         // security: times out → inconclusive
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         expect(DOMAIN).toContain(out.overall);
         expect(out.overall).not.toBe('inconclusive');
     });
 
-    it('keeps a deliberately disabled sensor apart from one that could not certify', () => {  // verifies R1, R6
+    it('keeps a deliberately disabled sensor apart from one that could not certify', async () => {  // verifies R1, R6
         fs.writeFileSync(path.join(root, '.awm', 'sensors.json'), JSON.stringify({
             pack: 'js-ts',
             sensors: {
@@ -183,11 +173,11 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
                 mutation: { cmd: 'npx stryker run', enabled: false },
             },
         }));
-        mockExecSyncFn.mockImplementationOnce(timeoutError);   // security: times out
+        mockRunCommand.mockResolvedValueOnce(timeoutError());   // security: times out
                                                                 // mutation: never invoked
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         // Same run, two different meanings — the whole point of the split.
         expect(out.sensors.find((s: any) => s.name === 'mutation').status).toBe('skipped');
@@ -196,7 +186,7 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
         expect(out.overall).toBe('not_certified');
     });
 
-    it('does not degrade the verdict for a disabled sensor alongside healthy ones', () => {  // verifies R6
+    it('does not degrade the verdict for a disabled sensor alongside healthy ones', async () => {  // verifies R6
         fs.writeFileSync(path.join(root, '.awm', 'sensors.json'), JSON.stringify({
             pack: 'js-ts',
             sensors: {
@@ -204,15 +194,15 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
                 mutation: { cmd: 'npx stryker run', enabled: false },
             },
         }));
-        mockExecSyncFn.mockReturnValueOnce('' as any);
+        mockRunCommand.mockResolvedValueOnce(ok());
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         expect(out.overall).toBe('pass');
     });
 
-    it('still refuses to certify a tree whose sensors are all disabled', () => {  // verifies R10
+    it('still refuses to certify a tree whose sensors are all disabled', async () => {  // verifies R10
         fs.writeFileSync(path.join(root, '.awm', 'sensors.json'), JSON.stringify({
             pack: 'js-ts',
             sensors: {
@@ -223,23 +213,23 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
         fs.writeFileSync(path.join(root, 'package.json'), '{}');   // real stack indicator
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         expect(out.sensors.every((s: any) => s.status === 'skipped')).toBe(true);
         expect(out.overall).toBe('not_certified');
-        expect(mockExecSyncFn).not.toHaveBeenCalled();
+        expect(mockRunCommand).not.toHaveBeenCalled();
     });
 
-    it('leaves an inconclusive result untouched when a baseline is applied', () => {  // verifies R14
+    it('leaves an inconclusive result untouched when a baseline is applied', async () => {  // verifies R14
         const { writeBaseline } = require('../../../src/commands/sensors/baseline');
         writeBaseline(root, { security: ['some-accepted-fingerprint'] });
 
-        mockExecSyncFn
-            .mockReturnValueOnce('' as any)
-            .mockImplementationOnce(timeoutError);
+        mockRunCommand
+            .mockResolvedValueOnce(ok())
+            .mockResolvedValueOnce(timeoutError());
 
         const { runSensors } = load();
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         const security = out.sensors.find((s: any) => s.name === 'security');
         expect(security.status).toBe('inconclusive');
@@ -247,7 +237,7 @@ describe('runSensors — inconclusive: a sensor that could not certify is never 
         expect(out.overall).toBe('not_certified');
     });
 
-    it('applyBaseline leaves an inconclusive result untouched even if it somehow carried findings', () => {  // verifies R14 (discriminating unit test)
+    it('applyBaseline leaves an inconclusive result untouched even if it somehow carried findings', async () => {  // verifies R14 (discriminating unit test)
         // Every current `inconclusive` producer sets `errors: []`, so a test built
         // on the public `runSensors()` API can't tell "the explicit guard fired"
         // apart from "fell through to partition() and incidentally suppressed 0

--- a/cli/tests/commands/sensors/run-partial.test.ts
+++ b/cli/tests/commands/sensors/run-partial.test.ts
@@ -1,0 +1,263 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const mockRunCommand = jest.fn();
+jest.mock('../../../src/commands/sensors/exec', () => ({
+    runCommand: (...args: any[]) => mockRunCommand(...args),
+}));
+
+const { ok, timedOut, overflowed } = require('./exec-fixtures');
+
+const TS_FINDING = 'src/a.ts(1,1): error TS0001: Bad type.';
+
+function project(sensors: Record<string, unknown>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-partial-'));
+    fs.mkdirSync(path.join(dir, '.awm'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.awm', 'sensors.json'), JSON.stringify({ pack: 'js-ts', sensors }));
+    return dir;
+}
+
+describe('runSensors — a cut-short run keeps the findings it did produce', () => {
+    let dir: string;
+    let prevAwmHome: string | undefined;
+    let fakeAwmHome: string;
+
+    beforeEach(() => {
+        jest.resetModules();
+        mockRunCommand.mockReset();
+        // CLAUDE.md: no test may reach the real ~/.awm.
+        fakeAwmHome = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-home-'));
+        prevAwmHome = process.env.AWM_HOME;
+        process.env.AWM_HOME = fakeAwmHome;
+    });
+
+    afterEach(() => {
+        process.env.AWM_HOME = prevAwmHome;
+        if (dir) fs.rmSync(dir, { recursive: true, force: true });
+        fs.rmSync(fakeAwmHome, { recursive: true, force: true });
+    });
+
+    const load = () => require('../../../src/commands/sensors/run');
+
+    it('reports findings from partial output as fail instead of discarding them', async () => {
+        // The regression this guards: the old runner threw away everything a
+        // timed-out sensor had printed, so a 60s lint run that had already found
+        // real errors reported zero — and the caller re-ran it by hand to learn
+        // what it had just paid for.
+        dir = project({ typecheck: { cmd: 'npx tsc --noEmit', fast: true } });
+        mockRunCommand.mockResolvedValueOnce(timedOut(TS_FINDING));
+
+        const { runSensors } = load();
+        const out = await runSensors({ cwd: dir });
+
+        const tc = out.sensors.find((s: any) => s.name === 'typecheck');
+        expect(tc.status).toBe('fail');
+        expect(tc.errors).toHaveLength(1);
+        expect(tc.errors[0].message).toMatch(/Bad type/);
+        expect(out.overall).toBe('fail');
+    });
+
+    it('marks the partial fail as incomplete so absence of findings is not read as coverage', async () => {
+        dir = project({ typecheck: { cmd: 'npx tsc --noEmit', fast: true, timeout: 30000 } });
+        mockRunCommand.mockResolvedValueOnce(timedOut(TS_FINDING));
+
+        const { runSensors } = load();
+        const out = await runSensors({ cwd: dir });
+
+        const tc = out.sensors.find((s: any) => s.name === 'typecheck');
+        expect(tc.incomplete).toMatch(/timeout after 30000ms/);
+        expect(tc.incomplete).toMatch(/did not finish/);
+    });
+
+    it('still refuses to certify when the partial output is clean', async () => {
+        // A clean partial proves nothing — the findings could all be in the part
+        // that never ran. This must stay inconclusive, never pass.
+        dir = project({ typecheck: { cmd: 'npx tsc --noEmit', fast: true } });
+        mockRunCommand.mockResolvedValueOnce(timedOut('Checking 400 files...\n'));
+
+        const { runSensors } = load();
+        const out = await runSensors({ cwd: dir });
+
+        const tc = out.sensors.find((s: any) => s.name === 'typecheck');
+        expect(tc.status).toBe('inconclusive');
+        expect(tc.skipReason).toMatch(/timeout/);
+        expect(tc.incomplete).toBeUndefined();
+        expect(out.overall).toBe('not_certified');
+    });
+
+    it('applies the same rule to output-cap overflow', async () => {
+        dir = project({ typecheck: { cmd: 'npx tsc --noEmit', fast: true } });
+        mockRunCommand.mockResolvedValueOnce(overflowed(TS_FINDING));
+
+        const { runSensors } = load();
+        const out = await runSensors({ cwd: dir });
+
+        const tc = out.sensors.find((s: any) => s.name === 'typecheck');
+        expect(tc.status).toBe('fail');
+        expect(tc.incomplete).toMatch(/exceeded/);
+    });
+
+    it('fails the sensor when the shell could not be started', async () => {
+        const { spawnFailed } = require('./exec-fixtures');
+        dir = project({ typecheck: { cmd: 'npx tsc --noEmit', fast: true } });
+        mockRunCommand.mockResolvedValueOnce(spawnFailed('spawn /bin/sh ENOENT'));
+
+        const { runSensors } = load();
+        const out = await runSensors({ cwd: dir });
+
+        const tc = out.sensors.find((s: any) => s.name === 'typecheck');
+        expect(tc.status).toBe('fail');
+        expect(tc.errors[0].message).toMatch(/could not be started/);
+        expect(out.overall).toBe('fail');
+    });
+
+    it('lets the baseline suppress a finding that came from partial output', async () => {
+        dir = project({ typecheck: { cmd: 'npx tsc --noEmit', fast: true } });
+        const { buildBaseline, writeBaseline } = require('../../../src/commands/sensors/baseline');
+        const { parseTscOutput } = require('../../../src/commands/sensors/formatters/tsc');
+        writeBaseline(dir, buildBaseline([{ name: 'typecheck', errors: parseTscOutput(TS_FINDING) }]));
+
+        mockRunCommand.mockResolvedValueOnce(timedOut(TS_FINDING));
+        const { runSensors } = load();
+        const out = await runSensors({ cwd: dir });
+
+        const tc = out.sensors.find((s: any) => s.name === 'typecheck');
+        expect(tc.status).toBe('pass');
+        expect(tc.baselineCount).toBe(1);
+    });
+});
+
+describe('runSensors — sensors run concurrently', () => {
+    let dir: string;
+    let prevAwmHome: string | undefined;
+    let prevConcurrency: string | undefined;
+    let fakeAwmHome: string;
+
+    beforeEach(() => {
+        jest.resetModules();
+        mockRunCommand.mockReset();
+        fakeAwmHome = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-home-'));
+        prevAwmHome = process.env.AWM_HOME;
+        prevConcurrency = process.env.AWM_SENSORS_CONCURRENCY;
+        process.env.AWM_HOME = fakeAwmHome;
+    });
+
+    afterEach(() => {
+        process.env.AWM_HOME = prevAwmHome;
+        if (prevConcurrency === undefined) delete process.env.AWM_SENSORS_CONCURRENCY;
+        else process.env.AWM_SENSORS_CONCURRENCY = prevConcurrency;
+        if (dir) fs.rmSync(dir, { recursive: true, force: true });
+        fs.rmSync(fakeAwmHome, { recursive: true, force: true });
+    });
+
+    const load = () => require('../../../src/commands/sensors/run');
+
+    /** Resolves after `ms`, recording when it started and finished. */
+    const timed = (log: Array<[string, number]>, label: string, ms: number) => () =>
+        new Promise((resolve) => {
+            log.push([`${label}:start`, Date.now()]);
+            setTimeout(() => { log.push([`${label}:end`, Date.now()]); resolve(ok()); }, ms);
+        });
+
+    const THREE = {
+        typecheck: { cmd: 'a', fast: true },
+        lint: { cmd: 'b', fast: true },
+        security: { cmd: 'c', fast: true },
+    };
+
+    it('starts every sensor before the first one finishes', async () => {
+        process.env.AWM_SENSORS_CONCURRENCY = '3';
+        dir = project(THREE);
+        const log: Array<[string, number]> = [];
+        mockRunCommand
+            .mockImplementationOnce(timed(log, 'typecheck', 120))
+            .mockImplementationOnce(timed(log, 'lint', 120))
+            .mockImplementationOnce(timed(log, 'security', 120));
+
+        const { runSensors } = load();
+        await runSensors({ cwd: dir });
+
+        const order = log.map(([label]) => label);
+        // All three starts precede the first end — that is what serial execution
+        // could not do, and the reason wall clock stops being the sum.
+        expect(order.slice(0, 3)).toEqual(['typecheck:start', 'lint:start', 'security:start']);
+        expect(order[3]).toMatch(/:end$/);
+    });
+
+    it('honours a concurrency of 1 by running them strictly one at a time', async () => {
+        process.env.AWM_SENSORS_CONCURRENCY = '1';
+        dir = project(THREE);
+        const log: Array<[string, number]> = [];
+        mockRunCommand
+            .mockImplementationOnce(timed(log, 'typecheck', 30))
+            .mockImplementationOnce(timed(log, 'lint', 30))
+            .mockImplementationOnce(timed(log, 'security', 30));
+
+        const { runSensors } = load();
+        await runSensors({ cwd: dir });
+
+        expect(log.map(([label]) => label)).toEqual([
+            'typecheck:start', 'typecheck:end',
+            'lint:start', 'lint:end',
+            'security:start', 'security:end',
+        ]);
+    });
+
+    it('reports results in manifest order regardless of which sensor finishes first', async () => {
+        process.env.AWM_SENSORS_CONCURRENCY = '3';
+        dir = project(THREE);
+        const log: Array<[string, number]> = [];
+        // Deliberately inverted durations: security finishes first, typecheck last.
+        mockRunCommand
+            .mockImplementationOnce(timed(log, 'typecheck', 90))
+            .mockImplementationOnce(timed(log, 'lint', 50))
+            .mockImplementationOnce(timed(log, 'security', 10));
+
+        const { runSensors } = load();
+        const out = await runSensors({ cwd: dir });
+
+        expect(out.sensors.map((s: any) => s.name)).toEqual(['typecheck', 'lint', 'security']);
+    });
+});
+
+describe('resolveConcurrency', () => {
+    const load = () => require('../../../src/commands/sensors/run');
+    let prev: string | undefined;
+
+    beforeEach(() => { jest.resetModules(); prev = process.env.AWM_SENSORS_CONCURRENCY; });
+    afterEach(() => {
+        if (prev === undefined) delete process.env.AWM_SENSORS_CONCURRENCY;
+        else process.env.AWM_SENSORS_CONCURRENCY = prev;
+    });
+
+    it('never exceeds the number of sensors to run', () => {
+        delete process.env.AWM_SENSORS_CONCURRENCY;
+        const { resolveConcurrency } = load();
+        expect(resolveConcurrency({ pack: 'js-ts', sensors: {} }, 1)).toBe(1);
+    });
+
+    it('caps at 4 even on a large box', () => {
+        delete process.env.AWM_SENSORS_CONCURRENCY;
+        const { resolveConcurrency } = load();
+        expect(resolveConcurrency({ pack: 'js-ts', sensors: {} }, 32)).toBeLessThanOrEqual(4);
+    });
+
+    it('lets the manifest pin it', () => {
+        delete process.env.AWM_SENSORS_CONCURRENCY;
+        const { resolveConcurrency } = load();
+        expect(resolveConcurrency({ pack: 'js-ts', sensors: {}, concurrency: 2 }, 8)).toBe(2);
+    });
+
+    it('lets the environment override the manifest', () => {
+        process.env.AWM_SENSORS_CONCURRENCY = '1';
+        const { resolveConcurrency } = load();
+        expect(resolveConcurrency({ pack: 'js-ts', sensors: {}, concurrency: 4 }, 8)).toBe(1);
+    });
+
+    it('ignores nonsense and falls back to the derived cap', () => {
+        process.env.AWM_SENSORS_CONCURRENCY = 'banana';
+        const { resolveConcurrency } = load();
+        expect(resolveConcurrency({ pack: 'js-ts', sensors: {} }, 8)).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/cli/tests/commands/sensors/run-tool-missing.test.ts
+++ b/cli/tests/commands/sensors/run-tool-missing.test.ts
@@ -39,29 +39,29 @@ describe('runSensors — an absent tool never reads as green (real /bin/sh)', ()
         return root;
     };
 
-    it('marks a sensor whose binary is absent as fail, not skipped', () => {
+    it('marks a sensor whose binary is absent as fail, not skipped', async () => {
         const root = project({ security: { cmd: `${MISSING_BIN} .`, fast: true } });
 
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         const security = out.sensors.find(s => s.name === 'security');
         expect(security!.status).toBe('fail');
         expect(security!.errors[0].message).toMatch(/not available/i);
     });
 
-    it('does not let a healthy sensor carry the run to pass while another tool is absent', () => {
+    it('does not let a healthy sensor carry the run to pass while another tool is absent', async () => {
         const root = project({
             typecheck: { cmd: 'node -e ""', fast: true },
             security: { cmd: `${MISSING_BIN} .`, fast: true },
         });
 
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         expect(out.sensors.find(s => s.name === 'typecheck')!.status).toBe('pass');
         expect(out.overall).toBe('fail');
     });
 
-    it('does not misread a tool that ran and merely printed "not found" as an absent tool', () => {
+    it('does not misread a tool that ran and merely printed "not found" as an absent tool', async () => {
         // Exits 1, not 127: the binary existed and reported something of its own.
         // Classifying this as a missing tool would be a false accusation. It also
         // must not read as a benign 'skipped': the formatter parsed no findings
@@ -71,7 +71,7 @@ describe('runSensors — an absent tool never reads as green (real /bin/sh)', ()
             security: { cmd: `node -e "console.error('rule pack not found'); process.exit(1)"`, fast: true },
         });
 
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
 
         const security = out.sensors.find(s => s.name === 'security');
         expect(security!.status).toBe('inconclusive');

--- a/cli/tests/commands/sensors/run.test.ts
+++ b/cli/tests/commands/sensors/run.test.ts
@@ -8,11 +8,13 @@ function mkTmp(): string {
 }
 
 // Define stable mock before jest.mock hoisting
-const mockExecSyncFn = jest.fn();
+const mockRunCommand = jest.fn();
 
-jest.mock('child_process', () => ({
-    execSync: (...args: any[]) => mockExecSyncFn(...args),
+jest.mock('../../../src/commands/sensors/exec', () => ({
+    runCommand: (...args: any[]) => mockRunCommand(...args),
 }));
+
+const { ok, exited, timedOut } = require('./exec-fixtures');
 
 const MANIFEST = {
     pack: 'js-ts',
@@ -34,108 +36,108 @@ describe('runSensors', () => {
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-run-test-'));
         fs.mkdirSync(path.join(tmpDir, '.awm'), { recursive: true });
         fs.writeFileSync(path.join(tmpDir, '.awm', 'sensors.json'), JSON.stringify(MANIFEST));
-        mockExecSyncFn.mockReset();
+        mockRunCommand.mockReset();
     });
     afterEach(() => { fs.rmSync(tmpDir, { recursive: true }); });
 
     const load = () => require('../../../src/commands/sensors/run');
 
-    it('returns not_certified output when manifest does not exist', () => {
+    it('returns not_certified output when manifest does not exist', async () => {
         const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-empty-'));
         try {
             const { runSensors } = load();
-            const result = runSensors({ fast: true, cwd: emptyDir });
+            const result = await runSensors({ fast: true, cwd: emptyDir });
             expect(result.overall).toBe('not_certified');
             expect(result.sensors).toHaveLength(0);
         } finally { fs.rmSync(emptyDir, { recursive: true }); }
     });
 
-    it('runs only fast sensors with --fast flag', () => {
-        mockExecSyncFn.mockReturnValue('' as any);
+    it('runs only fast sensors with --fast flag', async () => {
+        mockRunCommand.mockResolvedValue(ok());
         const { runSensors } = load();
-        const result = runSensors({ fast: true, cwd: tmpDir });
-        expect(mockExecSyncFn).toHaveBeenCalledTimes(2); // typecheck + lint (security disabled, mutation disabled)
+        const result = await runSensors({ fast: true, cwd: tmpDir });
+        expect(mockRunCommand).toHaveBeenCalledTimes(2); // typecheck + lint (security disabled, mutation disabled)
         expect(result.sensors.some((s: any) => s.name === 'security')).toBe(false);
         expect(result.overall).toBe('pass');
     });
 
-    it('returns fail when a fast sensor has errors', () => {
-        mockExecSyncFn
-            .mockImplementationOnce(() => { throw Object.assign(new Error(), { stdout: "src/a.ts(1,1): error TS0001: Bad type.", stderr: '', status: 1 }); })
-            .mockReturnValueOnce('' as any);
+    it('returns fail when a fast sensor has errors', async () => {
+        mockRunCommand
+            .mockResolvedValueOnce(exited(1, 'src/a.ts(1,1): error TS0001: Bad type.'))
+            .mockResolvedValueOnce(ok());
         const { runSensors } = load();
-        const result = runSensors({ fast: true, cwd: tmpDir });
+        const result = await runSensors({ fast: true, cwd: tmpDir });
         expect(result.overall).toBe('fail');
         const tc = result.sensors.find((s: any) => s.name === 'typecheck');
         expect(tc!.status).toBe('fail');
         expect(tc!.errors[0].message).toMatch('SENSOR[typecheck]');
     });
 
-    it('marks sensor as inconclusive on timeout', () => {
-        mockExecSyncFn.mockImplementationOnce(() => { throw Object.assign(new Error('killed'), { code: 'ETIMEDOUT' }); });
-        mockExecSyncFn.mockReturnValueOnce('' as any);
+    it('marks sensor as inconclusive on timeout', async () => {
+        mockRunCommand.mockResolvedValueOnce(timedOut());
+        mockRunCommand.mockResolvedValueOnce(ok());
         const { runSensors } = load();
-        const result = runSensors({ fast: true, cwd: tmpDir });
+        const result = await runSensors({ fast: true, cwd: tmpDir });
         const tc = result.sensors.find((s: any) => s.name === 'typecheck');
         expect(tc!.status).toBe('inconclusive');
         expect(tc!.skipReason).toMatch('timeout');
     });
 
-    it('skips disabled sensors', () => {
-        mockExecSyncFn.mockReturnValue('' as any);
+    it('skips disabled sensors', async () => {
+        mockRunCommand.mockResolvedValue(ok());
         const { runSensors } = load();
-        const result = runSensors({ all: true, cwd: tmpDir });
+        const result = await runSensors({ all: true, cwd: tmpDir });
         const sec = result.sensors.find((s: any) => s.name === 'security');
         expect(sec!.status).toBe('skipped');
         expect(sec!.skipReason).toBe('disabled');
     });
 
-    const tcError = () => { throw Object.assign(new Error(), { stdout: 'src/a.ts(1,1): error TS0001: Bad type.', stderr: '', status: 1 }); };
+    const tcError = () => exited(1, 'src/a.ts(1,1): error TS0001: Bad type.');
 
-    it('baseline suppresses accepted findings — sensor passes on no NEW findings', () => {
+    it('baseline suppresses accepted findings — sensor passes on no NEW findings', async () => {
         const { runSensors } = load();
         const { buildBaseline, writeBaseline } = require('../../../src/commands/sensors/baseline');
 
         // Run 1 (no baseline): typecheck reports a TS error → fail.
-        mockExecSyncFn.mockImplementationOnce(tcError).mockReturnValueOnce('' as any);
-        const first = runSensors({ fast: true, cwd: tmpDir });
+        mockRunCommand.mockResolvedValueOnce(tcError()).mockResolvedValueOnce(ok());
+        const first = await runSensors({ fast: true, cwd: tmpDir });
         expect(first.overall).toBe('fail');
 
         // Accept the current findings as baseline.
         writeBaseline(tmpDir, buildBaseline(first.sensors.map((s: any) => ({ name: s.name, errors: s.errors }))));
 
         // Run 2 (same finding): baseline-suppressed → pass.
-        mockExecSyncFn.mockImplementationOnce(tcError).mockReturnValueOnce('' as any);
-        const second = runSensors({ fast: true, cwd: tmpDir });
+        mockRunCommand.mockResolvedValueOnce(tcError()).mockResolvedValueOnce(ok());
+        const second = await runSensors({ fast: true, cwd: tmpDir });
         const tc = second.sensors.find((s: any) => s.name === 'typecheck');
         expect(tc!.status).toBe('pass');
         expect(tc!.baselineCount).toBe(1);
         expect(second.overall).toBe('pass');
     });
 
-    it('baseline lets NEW findings through (still fails)', () => {
+    it('baseline lets NEW findings through (still fails)', async () => {
         const { runSensors } = load();
         const { writeBaseline } = require('../../../src/commands/sensors/baseline');
         writeBaseline(tmpDir, { typecheck: ['some-unrelated-fingerprint'] });
 
-        mockExecSyncFn.mockImplementationOnce(tcError).mockReturnValueOnce('' as any);
-        const result = runSensors({ fast: true, cwd: tmpDir });
+        mockRunCommand.mockResolvedValueOnce(tcError()).mockResolvedValueOnce(ok());
+        const result = await runSensors({ fast: true, cwd: tmpDir });
         const tc = result.sensors.find((s: any) => s.name === 'typecheck');
         expect(tc!.status).toBe('fail');
         expect(result.overall).toBe('fail');
     });
 
-    it('--ignore-baseline reports all findings even when a baseline exists', () => {
+    it('--ignore-baseline reports all findings even when a baseline exists', async () => {
         const { runSensors } = load();
         const { buildBaseline, writeBaseline } = require('../../../src/commands/sensors/baseline');
         // First capture + accept the finding.
-        mockExecSyncFn.mockImplementationOnce(tcError).mockReturnValueOnce('' as any);
-        const first = runSensors({ fast: true, cwd: tmpDir });
+        mockRunCommand.mockResolvedValueOnce(tcError()).mockResolvedValueOnce(ok());
+        const first = await runSensors({ fast: true, cwd: tmpDir });
         writeBaseline(tmpDir, buildBaseline(first.sensors.map((s: any) => ({ name: s.name, errors: s.errors }))));
 
         // With ignoreBaseline, the accepted finding still counts → fail.
-        mockExecSyncFn.mockImplementationOnce(tcError).mockReturnValueOnce('' as any);
-        const result = runSensors({ fast: true, cwd: tmpDir, ignoreBaseline: true });
+        mockRunCommand.mockResolvedValueOnce(tcError()).mockResolvedValueOnce(ok());
+        const result = await runSensors({ fast: true, cwd: tmpDir, ignoreBaseline: true });
         expect(result.overall).toBe('fail');
     });
 });
@@ -148,18 +150,14 @@ describe('runSensors — missing tool is a fail, not a skip', () => {
     });
 
     beforeEach(() => {
-        mockExecSyncFn.mockReset();
+        mockRunCommand.mockReset();
         // What Node's execSync actually throws when the binary is absent and `/bin/sh`
         // is dash (Debian/Ubuntu, hence most CI runners): status 127, `not found`
         // rather than bash's `command not found`, and no `code` — ENOENT is set only
         // when spawning the shell itself fails, not the command inside it.
-        mockExecSyncFn.mockImplementation(() => {
-            throw Object.assign(new Error('Command failed: awm-nonexistent-binary-xyz .'), {
-                stdout: '',
-                stderr: '/bin/sh: 1: awm-nonexistent-binary-xyz: not found\n',
-                status: 127,
-            });
-        });
+        mockRunCommand.mockResolvedValue(
+            exited(127, '', '/bin/sh: 1: awm-nonexistent-binary-xyz: not found\n'),
+        );
     });
 
     // The sensor is named `security` so it uses the semgrep formatter, which returns
@@ -167,7 +165,7 @@ describe('runSensors — missing tool is a fail, not a skip', () => {
     // tool-missing branch. Under the generic formatter any stderr becomes a finding,
     // so a sensor named `ghost` would report `fail` without that branch ever running —
     // green for a reason unrelated to what this test claims to cover.
-    it('marks a sensor whose binary is missing as fail', () => {
+    it('marks a sensor whose binary is missing as fail', async () => {
         root = mkTmp();
         fs.mkdirSync(path.join(root, '.awm'));
         fs.writeFileSync(
@@ -177,7 +175,7 @@ describe('runSensors — missing tool is a fail, not a skip', () => {
                 sensors: { security: { cmd: 'awm-nonexistent-binary-xyz .', fast: true } },
             }),
         );
-        const out = runSensors({ cwd: root });
+        const out = await runSensors({ cwd: root });
         const security = out.sensors.find((s) => s.name === 'security');
         expect(security?.status).toBe('fail');
         expect(security?.errors[0].message).toMatch(/not available/i);
@@ -189,8 +187,8 @@ describe('runSensors — not_certified + auto-discovery', () => {
     let tmpDir: string | undefined;
 
     beforeEach(() => {
-        mockExecSyncFn.mockReset();
-        mockExecSyncFn.mockReturnValue('' as any);
+        mockRunCommand.mockReset();
+        mockRunCommand.mockResolvedValue(ok());
     });
 
     afterEach(() => {
@@ -200,14 +198,14 @@ describe('runSensors — not_certified + auto-discovery', () => {
         }
     });
 
-    it('returns not_certified when no manifest exists anywhere up the tree', () => {
+    it('returns not_certified when no manifest exists anywhere up the tree', async () => {
         tmpDir = mkTmp();
-        const out = runSensors({ cwd: tmpDir });
+        const out = await runSensors({ cwd: tmpDir });
         expect(out.overall).toBe('not_certified');
         expect(out.sensors).toEqual([]);
     });
 
-    it('discovers .awm/sensors.json in a parent directory (walk-up)', () => {
+    it('discovers .awm/sensors.json in a parent directory (walk-up)', async () => {
         tmpDir = mkTmp();
         fs.mkdirSync(path.join(tmpDir, '.awm'));
         fs.writeFileSync(
@@ -216,7 +214,7 @@ describe('runSensors — not_certified + auto-discovery', () => {
         );
         const nested = path.join(tmpDir, 'a', 'b');
         fs.mkdirSync(nested, { recursive: true });
-        const out = runSensors({ cwd: nested });
+        const out = await runSensors({ cwd: nested });
         expect(out.overall).toBe('pass');
         expect(out.sensors.length).toBe(1);
     });
@@ -268,7 +266,7 @@ describe('reconcilePack', () => {
         return dir;
     }
 
-    it('upgrades generic→js-ts when package.json is present', () => {
+    it('upgrades generic→js-ts when package.json is present', async () => {
         const { reconcilePack } = require('../../../src/commands/sensors/run');
         const dir = tmpProject('generic', true);
         try {
@@ -285,7 +283,7 @@ describe('reconcilePack', () => {
         } finally { fs.rmSync(dir, { recursive: true }); }
     });
 
-    it('is a no-op when pack is already real (idempotent)', () => {
+    it('is a no-op when pack is already real (idempotent)', async () => {
         const { reconcilePack } = require('../../../src/commands/sensors/run');
         const dir = tmpProject('js-ts', true);
         try {
@@ -296,7 +294,7 @@ describe('reconcilePack', () => {
         } finally { fs.rmSync(dir, { recursive: true }); }
     });
 
-    it('does not upgrade a truly generic project (no indicators)', () => {
+    it('does not upgrade a truly generic project (no indicators)', async () => {
         const { reconcilePack } = require('../../../src/commands/sensors/run');
         const dir = tmpProject('generic', false);
         try {
@@ -317,51 +315,39 @@ describe('runSensors — test sensor (exit-code)', () => {
         jest.resetModules();
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-run-test-'));
         fs.mkdirSync(path.join(tmpDir, '.awm'), { recursive: true });
-        mockExecSyncFn.mockReset();
+        mockRunCommand.mockReset();
     });
     afterEach(() => { fs.rmSync(tmpDir, { recursive: true }); });
 
     const load = () => require('../../../src/commands/sensors/run');
 
-    it('test sensor: passing run (exit 0 with output) is pass, not fail', () => {
+    it('test sensor: passing run (exit 0 with output) is pass, not fail', async () => {
         fs.writeFileSync(path.join(tmpDir, '.awm', 'sensors.json'),
             JSON.stringify({ pack: 'js-ts', sensors: { test: { cmd: 'npm test', fast: false } } }));
-        mockExecSyncFn.mockReturnValue('Tests: 6 passed, 6 total\n'); // runner prints on success
+        mockRunCommand.mockResolvedValue(ok('Tests: 6 passed, 6 total\n')); // runner prints on success
         const { runSensors } = load();
-        const result = runSensors({ all: true, cwd: tmpDir });
+        const result = await runSensors({ all: true, cwd: tmpDir });
         const test = result.sensors.find((s: any) => s.name === 'test');
         expect(test.status).toBe('pass');
     });
 
-    it('test sensor: failing run (non-zero exit) is fail, not skipped', () => {
+    it('test sensor: failing run (non-zero exit) is fail, not skipped', async () => {
         fs.writeFileSync(path.join(tmpDir, '.awm', 'sensors.json'),
             JSON.stringify({ pack: 'js-ts', sensors: { test: { cmd: 'npm test', fast: false } } }));
-        mockExecSyncFn.mockImplementation(() => {
-            const err: any = new Error('jest failed');
-            err.status = 1;
-            err.stdout = 'Tests: 1 failed, 5 passed\n';
-            err.stderr = '';
-            throw err;
-        });
+        mockRunCommand.mockResolvedValue(exited(1, 'Tests: 1 failed, 5 passed\n'));
         const { runSensors } = load();
-        const result = runSensors({ all: true, cwd: tmpDir });
+        const result = await runSensors({ all: true, cwd: tmpDir });
         const test = result.sensors.find((s: any) => s.name === 'test');
         expect(test.status).toBe('fail');
         expect(result.overall).toBe('fail');
     });
 
-    it('test sensor: missing npm test script exits non-zero → fail, not skipped', () => {
+    it('test sensor: missing npm test script exits non-zero → fail, not skipped', async () => {
         fs.writeFileSync(path.join(tmpDir, '.awm', 'sensors.json'),
             JSON.stringify({ pack: 'js-ts', sensors: { test: { cmd: 'npm test', fast: false } } }));
-        mockExecSyncFn.mockImplementation(() => {
-            const err: any = new Error('npm test: missing script');
-            err.status = 1;
-            err.stdout = 'npm error Missing script: test\n';
-            err.stderr = '';
-            throw err;
-        });
+        mockRunCommand.mockResolvedValue(exited(1, 'npm error Missing script: test\n'));
         const { runSensors } = load();
-        const result = runSensors({ all: true, cwd: tmpDir });
+        const result = await runSensors({ all: true, cwd: tmpDir });
         const test = result.sensors.find((s: any) => s.name === 'test');
         expect(test.status).toBe('fail');
         expect(result.overall).toBe('fail');
@@ -373,11 +359,11 @@ describe('runSensors — honest floor (not_certified over real stack)', () => {
     const os = require('os');
 
     beforeEach(() => {
-        mockExecSyncFn.mockReset();
-        mockExecSyncFn.mockReturnValue('' as any);
+        mockRunCommand.mockReset();
+        mockRunCommand.mockResolvedValue(ok());
     });
 
-    it('returns not_certified (not skipped) for a generic manifest over a real stack', () => {
+    it('returns not_certified (not skipped) for a generic manifest over a real stack', async () => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-floor-'));
         fs.mkdirSync(path.join(dir, '.awm'), { recursive: true });
         fs.writeFileSync(path.join(dir, '.awm', 'sensors.json'),
@@ -389,7 +375,7 @@ describe('runSensors — honest floor (not_certified over real stack)', () => {
         try {
             jest.resetModules();
             const { runSensors } = require('../../../src/commands/sensors/run');
-            const result = runSensors({ fast: true, cwd: dir }); // --fast filters the fast:false security sensor → empty
+            const result = await runSensors({ fast: true, cwd: dir }); // --fast filters the fast:false security sensor → empty
             expect(result.overall).toBe('not_certified');
         } finally {
             process.env.AWM_HOME = prevHome;


### PR DESCRIPTION
Three compounding costs in `awm sensors run` on a growing repo, all rooted in `execSync`. They are levers A, B and C of the sensor-performance analysis; D (`--changed`) is deliberately out of scope here and tracked separately.

## 1. A timeout leaked the real work — this is the ratchet

`execSync(cmd, { timeout })` spawns `/bin/sh -c cmd` and SIGTERMs only that shell. A sensor command is almost always a wrapper (`npx tsc --noEmit`), so the tool doing the work is a grandchild: it survived, got reparented to init, and kept burning CPU.

The deterioration is cumulative: a timeout leaves a full `tsc`/`eslint` alive → the next run has less CPU → it times out too → another orphan. A repo that is fine at 200 files becomes ungateable at 2000 for reasons unrelated to its size.

`exec.ts` now spawns `detached` so the child leads its own process group, and kills the whole group with a negative-pid signal, escalating SIGTERM → SIGKILL after a grace period. It never blocks waiting for a group that will not die. Windows has no POSIX process groups, so it falls back to `taskkill /T`.

## 2. A timeout discarded everything the sensor had already produced

`execSync` cannot stream, so 60s of eslint output was thrown away and the caller had to re-run the same command by hand to learn anything — paying for the same work twice, plus a reasoning round-trip to decide what to do with a `not_certified` carrying zero findings.

Output is now collected as it arrives and survives the cut. Findings in a partial run are real findings and report as `fail`, carrying `incomplete` so the caller knows the list is not exhaustive.

The asymmetry matters and is the half that protects the gate: a **clean** partial still certifies nothing and stays `inconclusive`, because the findings could be in the part that never ran. Without that, conserving partial output would turn a timeout into a false green.

## 3. Sensors ran one after another

Wall clock was the sum of all sensors while the other cores sat idle. They now run through a bounded pool (default `min(4, cores-1)`, overridable via `AWM_SENSORS_CONCURRENCY` or a `concurrency` key in the manifest). Dispatch and reporting stay in manifest order, so output is deterministic regardless of completion order.

## Notes

`runSensors` is now async. It is reached only through the `awm sensors` commands; the package declares no library exports, so this is not a breaking change for consumers.

## Verification

Run on this branch at `f2b4777`:

- `npx tsc --noEmit` — clean.
- `npx jest --runInBand` — **138 suites, 1232 tests, 0 failures.**

One caveat worth recording for anyone re-running this: a first pass reported 3 suites / 4 tests failing, all from `tests/commands/watch/e2e-crash.test.ts`. That is an environment artifact, not a regression — the E2E suite asserts on the built CLI and the checkout had no `dist/`. The test says so itself (`dist ausente: corre 'cd cli && npm run build'`). After `npm run build` the full suite is green.

## Release impact

This PR is titled `feat(...)` on purpose. Per `CONSTITUTION.md`, a push to `main` triggers `release.yml`, which bumps by conventional commit and publishes via OIDC Trusted Publisher. Merging this cuts **v3.6.0** to npm automatically — the merge is a release, not just a merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_