### PR TITLE
feat(sensors): add --changed to scope opted-in sensors to the diff

### DIFF
--- a/cli/src/commands/sensors/changed.ts
+++ b/cli/src/commands/sensors/changed.ts
@@ -1,0 +1,114 @@
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+/**
+ * Resolving "what changed" for `awm sensors run --changed`.
+ *
+ * The sensors measure the whole repo on every run, so their cost scales with the
+ * size of the repo rather than with the size of the change. A feature touching six
+ * files pays for two thousand. Raising the timeout buys a quarter; scoping the work
+ * to the diff is what actually changes the exponent.
+ *
+ * Scoping is NOT applied to every sensor — see `SensorConfig.changedCmd`. It is
+ * sound only where a finding is a property of the file it lives in (eslint,
+ * semgrep). A whole-program checker like `tsc` cannot be handed a subset without
+ * changing what it means: types cross files, so a scoped `tsc` would report clean
+ * while the change broke a caller it was never shown. That is a false green, which
+ * is the exact failure this module must not manufacture.
+ */
+
+/** Union of committed diff vs `base`, staged, unstaged and untracked files. */
+export type ChangedFiles = {
+    files: string[];
+    /** Set when the scope could not be resolved (not a repo, git absent, bad ref). */
+    error?: string;
+};
+
+function git(args: string[], cwd: string): string {
+    return execFileSync('git', args, {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}
+
+/**
+ * The default comparison point. `merge-base HEAD <base>` — not `base` directly —
+ * so a branch that is merely *behind* its base does not report every file the base
+ * moved on as "changed" by this branch.
+ */
+function mergeBase(base: string, cwd: string): string {
+    return git(['merge-base', 'HEAD', base], cwd).trim();
+}
+
+/**
+ * Files this working tree changed relative to `base`.
+ *
+ * Deliberately a union of four sources: the committed diff since the merge base,
+ * plus staged, unstaged and untracked files. A sensor gate runs mid-work, where the
+ * interesting edits are usually not committed yet — a committed-only diff would scope
+ * the run to a stale set and certify files nobody is editing.
+ *
+ * Untracked files are included but ignored files are not (`--exclude-standard`), so
+ * `node_modules` and build output never enter the scope.
+ *
+ * Never throws: a failure to resolve the scope returns `error`, and the caller
+ * degrades to the unscoped command rather than guessing at a narrower one.
+ */
+export function changedFiles(cwd: string, base = 'HEAD'): ChangedFiles {
+    let out: string[] = [];
+    try {
+        // `HEAD` means "everything not yet committed" — no merge-base needed, and it
+        // is the right default for a gate that runs before the work is committed.
+        if (base !== 'HEAD') {
+            const from = mergeBase(base, cwd);
+            out = out.concat(git(['diff', '--name-only', '--diff-filter=d', from, 'HEAD'], cwd).split('\n'));
+        }
+        out = out.concat(git(['diff', '--name-only', '--diff-filter=d', 'HEAD'], cwd).split('\n'));
+        out = out.concat(git(['diff', '--name-only', '--diff-filter=d', '--cached'], cwd).split('\n'));
+        out = out.concat(git(['ls-files', '--others', '--exclude-standard'], cwd).split('\n'));
+    } catch (e) {
+        return { files: [], error: (e as Error).message.split('\n')[0] };
+    }
+    const files = Array.from(new Set(out.map(s => s.trim()).filter(Boolean))).sort();
+    return { files };
+}
+
+/**
+ * Quote a path for a shell command line. Sensor commands are strings run through a
+ * shell, so a path with a space or a quote in it would otherwise split into two
+ * arguments — or, worse, end the quoting and let the rest of the name be read as
+ * shell syntax. Single quotes with the `'\''` escape are the only form POSIX shells
+ * treat as fully literal.
+ */
+function shellQuote(file: string): string {
+    return `'${file.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Substitute the file list into a `changedCmd` template.
+ *
+ * The template must contain `{files}`. A template without it would silently run over
+ * the whole repo while the output claimed the run was scoped, so that case is
+ * rejected by the caller rather than papered over here.
+ */
+export function applyChangedCmd(template: string, files: string[]): string {
+    return template.replace('{files}', files.map(shellQuote).join(' '));
+}
+
+/**
+ * Narrow the changed set to what a given sensor can be handed.
+ *
+ * The changed set is everything the tree touched — a README, a lockfile, a PNG. The
+ * tools do not shrug those off: eslint given a `.md` fails rather than skipping it,
+ * so an unfiltered scoped run would turn "you edited the docs" into a red gate.
+ *
+ * Case-insensitive because Windows and macOS checkouts routinely carry `.TS`/`.Ts`,
+ * and a case-sensitive match would silently drop those files from the scope — the
+ * quiet direction of wrong, where the sensor reports clean over files it never saw.
+ */
+export function filterByExtension(files: string[], extensions?: string[]): string[] {
+    if (!extensions || extensions.length === 0) return files;
+    const allowed = new Set(extensions.map(e => e.toLowerCase()));
+    return files.filter(f => allowed.has(path.extname(f).toLowerCase()));
+}

--- a/cli/src/commands/sensors/index.ts
+++ b/cli/src/commands/sensors/index.ts
@@ -26,8 +26,13 @@ export function registerSensorsCommand(program: Command): void {
         .option('--fast', 'run fast sensors only (tsc, lint)')
         .option('--slow', 'run slow sensors only (semgrep, mutation)')
         .option('--all', 'run all sensors regardless of speed')
+        .option('--changed', 'scope sensors that support it to the files changed vs --base')
+        .option('--base <ref>', 'comparison point for --changed (default: HEAD, i.e. uncommitted work)')
         .action(async (opts) => {
-            const output = await runSensors({ fast: opts.fast, slow: opts.slow, all: opts.all });
+            const output = await runSensors({
+                fast: opts.fast, slow: opts.slow, all: opts.all,
+                changed: opts.changed, base: opts.base,
+            });
             // Emit the verdict ALWAYS — an empty `sensors` with overall:'not_certified'
             // must be visible, never a silent exit-0 that reads as "clean".
             process.stdout.write(JSON.stringify(output, null, 2) + '\n');

--- a/cli/src/commands/sensors/init.ts
+++ b/cli/src/commands/sensors/init.ts
@@ -51,7 +51,13 @@ const FALLBACK_DEFAULTS: Record<string, SensorManifest['sensors']> = {
 };
 
 type PackJson = {
-    sensors?: Record<string, { defaultCmd?: string; fast?: boolean; enabled?: boolean }>;
+    sensors?: Record<string, {
+        defaultCmd?: string;
+        fast?: boolean;
+        enabled?: boolean;
+        changedCmd?: string;
+        changedExtensions?: string[];
+    }>;
 };
 
 /**
@@ -72,6 +78,12 @@ function readPackDefaults(pack: string, registryRoot: string, cwd: string): Sens
         if (def.defaultCmd) entry.cmd = def.defaultCmd.replace('{{SOURCE_DIRS}}', sourceDirs);
         if (def.fast !== undefined) entry.fast = def.fast;
         if (def.enabled !== undefined) entry.enabled = def.enabled;
+        // Carried through verbatim: without these in the written manifest, a pack can
+        // declare a sensor scopable and `--changed` would silently run it in full —
+        // the flag would look supported and do nothing. `{{SOURCE_DIRS}}` is not
+        // substituted here on purpose: a scoped command takes an explicit file list.
+        if (def.changedCmd) entry.changedCmd = def.changedCmd;
+        if (def.changedExtensions) entry.changedExtensions = def.changedExtensions;
         sensors[name] = entry;
     }
     return sensors;

--- a/cli/src/commands/sensors/run.ts
+++ b/cli/src/commands/sensors/run.ts
@@ -9,6 +9,7 @@ import { parseSemgrepOutput } from './formatters/semgrep';
 import { parseGenericOutput } from './formatters/generic';
 import { parseTestOutput } from './formatters/test';
 import { readBaseline, partition } from './baseline';
+import { changedFiles, applyChangedCmd, filterByExtension } from './changed';
 import { detectStack, initSensors } from './init';
 import { capabilityRoot } from '../../core/registries';
 
@@ -29,6 +30,13 @@ export type RunOptions = {
     cwd?: string;
     /** Skip baseline suppression (used by `awm sensors baseline` to capture all findings). */
     ignoreBaseline?: boolean;
+    /**
+     * Scope sensors that opt in (via `changedCmd`) to the files this tree changed.
+     * Sensors that do not opt in still run in full — see `SensorConfig.changedCmd`.
+     */
+    changed?: boolean;
+    /** Comparison point for `changed`. Defaults to `HEAD` (uncommitted work only). */
+    base?: string;
 };
 
 /**
@@ -252,6 +260,23 @@ export async function runSensors(opts: RunOptions = {}): Promise<RunOutput> {
     // --ignore-baseline → every finding counts (backward-compatible).
     const baseline = opts.ignoreBaseline ? null : readBaseline(cwd);
 
+    // A scoped run must never define the accepted set. `buildBaseline` snapshots the
+    // findings of the run it is given, so baselining a `--changed` run would write a
+    // baseline covering only the touched files and silently drop every accepted
+    // finding elsewhere in the repo — which then reports as NEW on the next full run.
+    // The two flags only ever meet by mistake, so refuse rather than pick a meaning.
+    if (opts.changed && opts.ignoreBaseline) {
+        throw new Error(
+            'refusing to combine --changed with a baseline capture: a partial run cannot define '
+            + 'the accepted set (it would drop every accepted finding outside the diff). '
+            + 'Run `awm sensors baseline` without --changed.',
+        );
+    }
+
+    // Resolved once for the whole run, not per sensor: `git` is cheap but the answer
+    // must be identical across sensors, or two of them scope to different file sets.
+    const changed = opts.changed ? changedFiles(cwd, opts.base ?? 'HEAD') : null;
+
     // Sensors are independent processes over the same tree, so they run
     // concurrently rather than one-after-another: wall clock becomes the slowest
     // sensor instead of the sum of all of them. Tasks are built — and dispatched —
@@ -274,11 +299,42 @@ export async function runSensors(opts: RunOptions = {}): Promise<RunOutput> {
             continue;
         }
 
-        const cmd = config.cmd;
+        // Scoping applies only where the pack opted in AND the scope resolved. Any
+        // other combination falls back to the full command: slower, never wrong.
+        let cmd = config.cmd;
+        let scope: 'changed' | undefined;
+        if (changed && !changed.error && config.changedCmd) {
+            if (!config.changedCmd.includes('{files}')) {
+                // Running the template as-is would cover the whole repo while the
+                // result claimed to be scoped — a mislabel, not a slow path.
+                tasks.push(settled({
+                    name,
+                    status: 'inconclusive',
+                    errors: [],
+                    skipReason: 'changedCmd has no {files} placeholder',
+                }));
+                continue;
+            }
+            const inScope = filterByExtension(changed.files, config.changedExtensions);
+            if (inScope.length === 0) {
+                tasks.push(settled({
+                    name,
+                    status: 'skipped',
+                    errors: [],
+                    skipReason: 'no changed files in scope',
+                    scope: 'changed',
+                }));
+                continue;
+            }
+            cmd = applyChangedCmd(config.changedCmd, inScope);
+            scope = 'changed';
+        }
+
         const timeout = config.timeout ?? (isFast ? DEFAULT_FAST_TIMEOUT : DEFAULT_SLOW_TIMEOUT);
         tasks.push(async () => {
             const result = await runSensor(name, cmd, timeout, cwd);
-            return baseline ? applyBaseline(result, baseline[name]) : result;
+            const scoped = scope ? { ...result, scope } : result;
+            return baseline ? applyBaseline(scoped, baseline[name]) : scoped;
         });
     }
 
@@ -302,5 +358,10 @@ export async function runSensors(opts: RunOptions = {}): Promise<RunOutput> {
         sensors: results,
         overall,
         ...(reconciled.upgradedFrom ? { packUpgraded: `${reconciled.upgradedFrom}→${activeManifest.pack}` } : {}),
+        // Always emitted on a --changed run, including when the scope failed to
+        // resolve: a green that came back from an unscoped fallback and a green from a
+        // genuinely scoped run are different claims, and the caller cannot tell them
+        // apart from the sensor list alone.
+        ...(changed ? { changedScope: { files: changed.files.length, ...(changed.error ? { error: changed.error } : {}) } } : {}),
     };
 }

--- a/cli/src/commands/sensors/types.ts
+++ b/cli/src/commands/sensors/types.ts
@@ -3,6 +3,26 @@ export type SensorConfig = {
     fast?: boolean;
     enabled?: boolean;
     timeout?: number;
+    /**
+     * Opt-in scoped variant used by `awm sensors run --changed`, with `{files}`
+     * standing in for the changed file list (e.g. `eslint --format json {files}`).
+     *
+     * Opt-in, never inferred. Scoping is sound only where a finding is a property of
+     * the file it lives in — eslint, semgrep. A whole-program checker (`tsc`) handed a
+     * subset reports clean while the change breaks a caller it was never shown, which
+     * is a false green. A sensor that omits this key keeps running its full `cmd`
+     * under `--changed`: slower, but never wrong.
+     */
+    changedCmd?: string;
+    /**
+     * Extensions this sensor can actually be handed, e.g. `[".ts", ".tsx"]`. The
+     * changed set is every file the tree touched — a README, a lockfile, a PNG — and
+     * eslint given a `.md` does not skip it, it fails. Filtering is per sensor because
+     * the same diff means different things to eslint and to semgrep. When the filter
+     * empties the list, the sensor is skipped rather than run over the whole repo.
+     * Absent → the sensor accepts whatever changed.
+     */
+    changedExtensions?: string[];
 };
 
 export type SensorManifest = {
@@ -51,6 +71,13 @@ export type SensorResult = {
      * caller can tell "clean" from "clean as far as we got".
      */
     incomplete?: string;
+    /**
+     * Set to 'changed' when this sensor ran against the diff rather than the whole
+     * tree. Makes a scoped result self-describing: a `pass` here means "clean over
+     * the changed files", which is a weaker claim than an unscoped `pass`, and the
+     * reader must be able to tell them apart without knowing which flags were used.
+     */
+    scope?: 'changed';
     /** New findings (not in baseline). Present only when a baseline is applied. */
     newCount?: number;
     /** Findings suppressed by the baseline. Present only when a baseline is applied. */
@@ -63,6 +90,13 @@ export type RunOutput = {
     /** Set when reconcilePack upgraded the manifest off the `generic` fallback
      *  (e.g. "generic→js-ts"). Absent on no-op runs. */
     packUpgraded?: string;
+    /**
+     * Present only on a `--changed` run. `files` is how many changed files were in
+     * scope; `error` explains why the scope could not be resolved, in which case every
+     * sensor fell back to its full command. Emitted so a scoped run is never read as a
+     * full one just because it happened to come back green.
+     */
+    changedScope?: { files: number; error?: string };
 };
 
 export type SensorCheck = {

--- a/cli/tests/commands/sensors/changed.test.ts
+++ b/cli/tests/commands/sensors/changed.test.ts
@@ -1,0 +1,129 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { changedFiles, applyChangedCmd, filterByExtension } from '../../../src/commands/sensors/changed';
+
+/** A throwaway repo. Real git, not a mock: the whole value of this module is that its
+ *  understanding of "changed" matches git's, which a mock would define into existence. */
+function repo(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-changed-'));
+    const run = (args: string[]) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+    run(['init', '-q']);
+    run(['config', 'user.email', 'test@example.com']);
+    run(['config', 'user.name', 'test']);
+    fs.writeFileSync(path.join(dir, 'base.ts'), 'export const a = 1;\n');
+    run(['add', 'base.ts']);
+    run(['commit', '-qm', 'base']);
+    return dir;
+}
+
+describe('changedFiles', () => {
+    const dirs: string[] = [];
+    const make = () => { const d = repo(); dirs.push(d); return d; };
+    afterAll(() => dirs.forEach(d => fs.rmSync(d, { recursive: true, force: true })));
+
+    it('sees unstaged, staged and untracked files, not just committed ones', () => {
+        // The gate runs mid-work, before anything is committed. A committed-only diff
+        // would scope the run to a stale set and certify files nobody is editing —
+        // exactly the files least likely to be broken right now.
+        const dir = make();
+        fs.appendFileSync(path.join(dir, 'base.ts'), 'export const b = 2;\n');   // unstaged
+        fs.writeFileSync(path.join(dir, 'staged.ts'), 'export const c = 3;\n');
+        execFileSync('git', ['add', 'staged.ts'], { cwd: dir, stdio: 'ignore' }); // staged
+        fs.writeFileSync(path.join(dir, 'untracked.ts'), 'export const d = 4;\n'); // untracked
+
+        expect(changedFiles(dir).files).toEqual(['base.ts', 'staged.ts', 'untracked.ts']);
+    });
+
+    it('excludes gitignored files so build output never enters the scope', () => {
+        const dir = make();
+        fs.writeFileSync(path.join(dir, '.gitignore'), 'dist/\n');
+        fs.mkdirSync(path.join(dir, 'dist'));
+        fs.writeFileSync(path.join(dir, 'dist', 'bundle.js'), 'noise');
+
+        expect(changedFiles(dir).files).not.toContain('dist/bundle.js');
+    });
+
+    it('omits deleted files — a sensor cannot read a path that is gone', () => {
+        const dir = make();
+        fs.rmSync(path.join(dir, 'base.ts'));
+
+        expect(changedFiles(dir).files).not.toContain('base.ts');
+    });
+
+    it('compares against the merge base, not the branch tip', () => {
+        // Guards the case where the branch is merely BEHIND its base. Diffing against
+        // the tip would report every file the base moved on as "changed by this
+        // branch", scoping the run to files this branch never touched.
+        const dir = make();
+        const run = (args: string[]) => execFileSync('git', args, { cwd: dir, stdio: 'ignore' });
+        run(['checkout', '-qb', 'feature']);
+        fs.writeFileSync(path.join(dir, 'mine.ts'), 'export const mine = 1;\n');
+        run(['add', 'mine.ts']);
+        run(['commit', '-qm', 'mine']);
+
+        // main moves on independently, so `feature` is behind it.
+        run(['checkout', '-q', 'master']);
+        fs.writeFileSync(path.join(dir, 'theirs.ts'), 'export const theirs = 1;\n');
+        run(['add', 'theirs.ts']);
+        run(['commit', '-qm', 'theirs']);
+        run(['checkout', '-q', 'feature']);
+
+        const files = changedFiles(dir, 'master').files;
+        expect(files).toContain('mine.ts');
+        expect(files).not.toContain('theirs.ts');
+    });
+
+    it('reports an error instead of an empty scope when git cannot answer', () => {
+        // An empty file list and a failed lookup are the same value structurally but
+        // opposite in meaning: one says "nothing to check", the other "I do not know".
+        // Collapsing them would silently scope a run to zero files and report clean.
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-nogit-'));
+        dirs.push(dir);
+
+        const res = changedFiles(dir);
+        expect(res.error).toBeDefined();
+        expect(res.files).toEqual([]);
+    });
+});
+
+describe('applyChangedCmd', () => {
+    it('substitutes the file list into the template', () => {
+        expect(applyChangedCmd('eslint --format json {files}', ['a.ts', 'b.ts']))
+            .toBe(`eslint --format json 'a.ts' 'b.ts'`);
+    });
+
+    it('quotes paths so a space cannot split one argument into two', () => {
+        expect(applyChangedCmd('eslint {files}', ['my dir/a.ts']))
+            .toBe(`eslint 'my dir/a.ts'`);
+    });
+
+    it("escapes a single quote in a path instead of ending the quoting", () => {
+        // Without the '\'' form the rest of the filename would be read as shell syntax.
+        expect(applyChangedCmd('eslint {files}', ["it's.ts"]))
+            .toBe(`eslint 'it'\\''s.ts'`);
+    });
+});
+
+describe('filterByExtension', () => {
+    it('drops files the sensor cannot be handed', () => {
+        // Editing a README must not turn the lint gate red: eslint given a .md fails
+        // rather than skipping it.
+        expect(filterByExtension(['src/a.ts', 'README.md', 'logo.png'], ['.ts']))
+            .toEqual(['src/a.ts']);
+    });
+
+    it('matches extensions case-insensitively', () => {
+        // Windows and macOS checkouts carry .TS. A case-sensitive match would drop them
+        // from the scope silently — the sensor would report clean over files it never saw.
+        expect(filterByExtension(['src/A.TS'], ['.ts'])).toEqual(['src/A.TS']);
+    });
+
+    it('passes everything through when the sensor declares no filter', () => {
+        const files = ['a.ts', 'b.md'];
+        expect(filterByExtension(files, undefined)).toEqual(files);
+        expect(filterByExtension(files, [])).toEqual(files);
+    });
+});

--- a/cli/tests/commands/sensors/run-changed.test.ts
+++ b/cli/tests/commands/sensors/run-changed.test.ts
@@ -1,0 +1,168 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const mockRunCommand = jest.fn();
+jest.mock('../../../src/commands/sensors/exec', () => ({
+    runCommand: (...args: any[]) => mockRunCommand(...args),
+}));
+
+const mockChangedFiles = jest.fn();
+jest.mock('../../../src/commands/sensors/changed', () => {
+    const actual = jest.requireActual('../../../src/commands/sensors/changed');
+    return { ...actual, changedFiles: (...args: any[]) => mockChangedFiles(...args) };
+});
+
+const { ok } = require('./exec-fixtures');
+
+function project(sensors: Record<string, unknown>): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-changed-run-'));
+    fs.mkdirSync(path.join(dir, '.awm'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.awm', 'sensors.json'), JSON.stringify({ pack: 'js-ts', sensors }));
+    return dir;
+}
+
+/** The two sensors that matter: one that opted into scoping, one that cannot. */
+const LINT = { fast: true, cmd: 'eslint --format json .', changedCmd: 'eslint --format json {files}' };
+const TYPECHECK = { fast: true, cmd: 'tsc --noEmit' };
+
+describe('runSensors --changed', () => {
+    let dir: string;
+    let prevAwmHome: string | undefined;
+    let fakeAwmHome: string;
+
+    beforeEach(() => {
+        jest.resetModules();
+        mockRunCommand.mockReset();
+        mockChangedFiles.mockReset();
+        mockRunCommand.mockResolvedValue(ok(''));
+        // CLAUDE.md: no test may reach the real ~/.awm.
+        fakeAwmHome = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-home-'));
+        prevAwmHome = process.env.AWM_HOME;
+        process.env.AWM_HOME = fakeAwmHome;
+    });
+
+    afterEach(() => {
+        process.env.AWM_HOME = prevAwmHome;
+        if (dir) fs.rmSync(dir, { recursive: true, force: true });
+        fs.rmSync(fakeAwmHome, { recursive: true, force: true });
+    });
+
+    const load = () => require('../../../src/commands/sensors/run');
+    const cmds = () => mockRunCommand.mock.calls.map(c => c[0]);
+
+    it('scopes a sensor that opted in and leaves one that did not at full scope', async () => {
+        // The core contract. tsc is whole-program: handed a subset it reports clean
+        // while the change breaks a caller it was never shown. Scoping is opt-in
+        // precisely so that sensor keeps measuring everything.
+        dir = project({ lint: LINT, typecheck: TYPECHECK });
+        mockChangedFiles.mockReturnValue({ files: ['src/a.ts'] });
+
+        await load().runSensors({ cwd: dir, changed: true });
+
+        expect(cmds()).toContain(`eslint --format json 'src/a.ts'`);
+        expect(cmds()).toContain('tsc --noEmit');
+    });
+
+    it('marks the scoped result so a scoped pass is not read as a full one', async () => {
+        dir = project({ lint: LINT, typecheck: TYPECHECK });
+        mockChangedFiles.mockReturnValue({ files: ['src/a.ts'] });
+
+        const out = await load().runSensors({ cwd: dir, changed: true });
+
+        expect(out.sensors.find((s: any) => s.name === 'lint').scope).toBe('changed');
+        expect(out.sensors.find((s: any) => s.name === 'typecheck').scope).toBeUndefined();
+        expect(out.changedScope).toEqual({ files: 1 });
+    });
+
+    it('falls back to the full command when the scope cannot be resolved', async () => {
+        // Not a git repo, git absent, bad ref. Running everything is slow; guessing at
+        // a narrower set would certify files nobody proved were the only ones touched.
+        dir = project({ lint: LINT });
+        mockChangedFiles.mockReturnValue({ files: [], error: 'not a git repository' });
+
+        const out = await load().runSensors({ cwd: dir, changed: true });
+
+        expect(cmds()).toContain('eslint --format json .');
+        expect(out.sensors[0].scope).toBeUndefined();
+        expect(out.changedScope).toEqual({ files: 0, error: 'not a git repository' });
+    });
+
+    it('skips an opted-in sensor when nothing changed, without touching the others', async () => {
+        dir = project({ lint: LINT, typecheck: TYPECHECK });
+        mockChangedFiles.mockReturnValue({ files: [] });
+
+        const out = await load().runSensors({ cwd: dir, changed: true });
+
+        const lint = out.sensors.find((s: any) => s.name === 'lint');
+        expect(lint.status).toBe('skipped');
+        expect(lint.skipReason).toBe('no changed files in scope');
+        expect(cmds()).toEqual(['tsc --noEmit']);
+    });
+
+    it('hands the sensor only the extensions it declared it can take', async () => {
+        // Without this, editing a README turns the lint gate red: eslint given a .md
+        // fails rather than skipping it.
+        dir = project({ lint: { ...LINT, changedExtensions: ['.ts', '.tsx'] } });
+        mockChangedFiles.mockReturnValue({ files: ['README.md', 'logo.png', 'src/a.ts'] });
+
+        await load().runSensors({ cwd: dir, changed: true });
+
+        expect(cmds()).toEqual([`eslint --format json 'src/a.ts'`]);
+    });
+
+    it('skips the sensor when the filter empties the scope, rather than running repo-wide', async () => {
+        // A docs-only commit means the lint sensor has nothing to say. Falling back to
+        // the full command here would reintroduce exactly the cost --changed removes.
+        dir = project({ lint: { ...LINT, changedExtensions: ['.ts'] }, typecheck: TYPECHECK });
+        mockChangedFiles.mockReturnValue({ files: ['README.md'] });
+
+        const out = await load().runSensors({ cwd: dir, changed: true });
+
+        expect(out.sensors.find((s: any) => s.name === 'lint').status).toBe('skipped');
+        expect(cmds()).toEqual(['tsc --noEmit']);
+    });
+
+    it('refuses a changedCmd without a {files} placeholder instead of running it repo-wide', async () => {
+        // Running the template as-is would cover the whole repo while the result
+        // claimed to be scoped. That is a mislabelled verdict, not a slow path.
+        dir = project({ lint: { ...LINT, changedCmd: 'eslint --format json .' } });
+        mockChangedFiles.mockReturnValue({ files: ['src/a.ts'] });
+
+        const out = await load().runSensors({ cwd: dir, changed: true });
+
+        expect(out.sensors[0].status).toBe('inconclusive');
+        expect(out.overall).toBe('not_certified');
+        expect(mockRunCommand).not.toHaveBeenCalled();
+    });
+
+    it('refuses to combine --changed with a baseline capture', async () => {
+        // buildBaseline snapshots the run it is given, so baselining a scoped run
+        // would write a baseline covering only the diff and silently drop every
+        // accepted finding elsewhere — which then reports as NEW on the next full run.
+        dir = project({ lint: LINT });
+        mockChangedFiles.mockReturnValue({ files: ['src/a.ts'] });
+
+        await expect(load().runSensors({ cwd: dir, changed: true, ignoreBaseline: true }))
+            .rejects.toThrow(/cannot define the accepted set/);
+    });
+
+    it('runs everything at full scope when --changed is absent', async () => {
+        dir = project({ lint: LINT, typecheck: TYPECHECK });
+
+        const out = await load().runSensors({ cwd: dir });
+
+        expect(cmds()).toEqual(['eslint --format json .', 'tsc --noEmit']);
+        expect(mockChangedFiles).not.toHaveBeenCalled();
+        expect(out.changedScope).toBeUndefined();
+    });
+
+    it('passes the requested base through to the scope resolver', async () => {
+        dir = project({ lint: LINT });
+        mockChangedFiles.mockReturnValue({ files: ['src/a.ts'] });
+
+        await load().runSensors({ cwd: dir, changed: true, base: 'main' });
+
+        expect(mockChangedFiles).toHaveBeenCalledWith(dir, 'main');
+    });
+});


### PR DESCRIPTION
Lever D of the sensor-performance analysis, and the last one. A, B and C shipped in #23 (v3.6.0).

## The problem

Sensor cost scaled with the size of the **repo**, not the size of the **change**: a feature touching six files paid for two thousand. Raising the timeout — `notion-tracker` had already gone from 10s/120s to 30s/60s — buys a quarter and postpones the problem. This changes the exponent instead.

`awm sensors run --changed [--base <ref>]` hands the changed file list to sensors that can take one.

## Scoping is opt-in, and that is the design

A sensor opts in with a `changedCmd` template containing `{files}`. Nothing is inferred.

Scoping is sound only where a finding is a **property of the file it lives in** — eslint, semgrep. A whole-program checker handed a subset reports clean while the change breaks a caller it was never shown. That is a false green, which is the exact failure the `inconclusive` doctrine in this module exists to prevent. So `typecheck`, `depcheck` and `test` declare no `changedCmd` and keep running in full under `--changed`: slower, never wrong.

## Every fallback goes to the safe side

| Situation | Behaviour |
|---|---|
| Scope unresolvable (not a repo, git absent, bad ref) | every sensor runs its **full** command; `changedScope.error` says why |
| `changedCmd` without a `{files}` placeholder | `inconclusive` — not a repo-wide run mislabelled as scoped |
| `--changed` + a baseline capture | **refused outright** |
| Filter empties the file list | sensor `skipped` — not silently run repo-wide |

That third row is the trap worth naming. `buildBaseline` snapshots the run it is given, so baselining a scoped run would write a baseline covering only the diff and **silently drop every accepted finding elsewhere in the repo** — which then reports as NEW on the next full run. The two flags only ever meet by mistake, so the code refuses rather than picking a meaning.

## What counts as "changed"

Union of the committed diff since the merge base, plus staged, unstaged and untracked files. Committed-only would scope a mid-work gate to a stale set and certify files nobody is editing — the files least likely to be broken right now.

`merge-base HEAD <base>` rather than `<base>` directly, so a branch merely *behind* its base does not claim every file the base moved on. Ignored files are excluded, so build output never enters the scope; deleted files are excluded, since a sensor cannot read a path that is gone.

## `changedExtensions`

The changed set is everything the tree touched — a README, a lockfile, a PNG — and eslint given a `.md` **fails** rather than skipping it. Without a per-sensor filter, an unrelated docs edit would turn the lint gate red. Filtering is per sensor because the same diff means different things to eslint and to semgrep.

Matching is case-insensitive: Windows and macOS checkouts carry `.TS`, and a case-sensitive match would drop those from the scope *silently* — the quiet direction of wrong, where the sensor reports clean over files it never saw.

## One gap this closes on the way

`readPackDefaults` did not carry `changedCmd`/`changedExtensions` from `pack.json` into the written manifest. Without that a pack could declare a sensor scopable and `--changed` would run it in full — the flag would look supported and do nothing.

## Self-describing output

A scoped sensor carries `scope: "changed"`, and the run carries `changedScope`. A scoped `pass` is a weaker claim than an unscoped one, and the reader must be able to tell them apart without knowing which flags were used.

## Verification

- `npx tsc --noEmit` — clean.
- `npx jest --runInBand` — **140 suites, 1253 tests, 0 failures** (16 new).

Unit tests use a mocked runner, so it was also exercised end to end against the **built** CLI on a real git repo:

```
--changed  → opted-in sensor ran `SCOPED: src/nuevo.ts`   (README.md filtered out)
             marked  "scope": "changed",  "changedScope": {"files": 4}
             sensor without changedCmd ran in full
no flag    → both ran in full, no changedScope emitted
```

## Companion change

The packs must declare which sensors are scopable — that is a separate PR on `awm-baseline-registry` (`lint` and `security` opt in; `typecheck`, `depcheck`, `test`, `mutation` deliberately do not). It is backward-safe in either merge order: an older CLI ignores unknown `pack.json` keys.

## Release impact

Titled `feat(...)`: merging cuts **v3.7.0** to npm automatically via `release.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_