### PR TITLE
feat(context-budget): make the budget check a command so it can run where a human is

### DIFF
--- a/cli/src/commands/context-budget/budget.ts
+++ b/cli/src/commands/context-budget/budget.ts
@@ -1,0 +1,116 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * The feedforward context budget.
+ *
+ * `AGENTS.md`, `CONSTITUTION.md` and `CLAUDE.md` are injected into EVERY agent session
+ * before a single line of code is read, so their size is a per-session tax paid
+ * forever. They grow because curing a lesson is an append and pruning one is a
+ * judgement call nobody is forced to make.
+ *
+ * Prose does not hold this line. Measured on a real repo, `AGENTS.md` went 73KB → 141KB
+ * across 45 revisions and never shrank once, while `harness-retro` already carried an
+ * explicit "merge and prune, never append raw" rule. Adding a second copy of an ignored
+ * rule has no expected effect, so this measures instead.
+ *
+ * It does NOT forbid growth — it makes growth deliberate. First check pins the current
+ * total; later checks report when the files have grown past it. The ways out are pruning
+ * back under, or raising `maxBytes` in a committed diff a human reviews.
+ *
+ * **Where this runs matters as much as what it measures.** It belongs at the last moment
+ * a human is guaranteed to be present — the pre-handoff gate at the end of
+ * `writing-plans`, before execution is handed to subagents. Wired into `awm sensors run`
+ * instead, it would fire during unattended overnight runs and strand the very PR the
+ * user came back expecting. Hence a command, not a sensor.
+ */
+
+/** Injected into every session by the AWM session hook / context contract. */
+export const DEFAULT_FILES = ['AGENTS.md', 'CONSTITUTION.md', 'CLAUDE.md'];
+
+export const CONFIG_FILE = path.join('.awm', 'context-budget.json');
+
+export type BudgetConfig = { files: string[]; maxBytes: number };
+
+export type BudgetReport = {
+    /** 'pinned' on the first check; 'within' under budget; 'over' past it. */
+    status: 'pinned' | 'within' | 'over';
+    totalBytes: number;
+    maxBytes: number;
+    /** Per-file sizes, in the order declared. Absent files are omitted. */
+    breakdown: { file: string; bytes: number }[];
+};
+
+/** Rough but stable: ~4 bytes per token for prose. Reporting only — never a gate input. */
+export function estimateTokens(bytes: number): number {
+    return Math.round(bytes / 4 / 1000);
+}
+
+export function measure(cwd: string, files: string[]): { total: number; breakdown: { file: string; bytes: number }[] } {
+    const breakdown: { file: string; bytes: number }[] = [];
+    let total = 0;
+    for (const f of files) {
+        let s: fs.Stats;
+        try {
+            s = fs.statSync(path.join(cwd, f));
+        } catch {
+            continue;   // a repo need not have all three
+        }
+        if (!s.isFile()) continue;
+        total += s.size;
+        breakdown.push({ file: f, bytes: s.size });
+    }
+    return { total, breakdown };
+}
+
+/**
+ * Read the pinned budget. A malformed or partial config returns null so the caller
+ * re-pins rather than treating an unreadable budget as an absent limit — the quiet
+ * direction of wrong, where the check silently stops checking.
+ */
+export function readConfig(cwd: string): BudgetConfig | null {
+    try {
+        const raw = JSON.parse(fs.readFileSync(path.join(cwd, CONFIG_FILE), 'utf-8'));
+        if (typeof raw.maxBytes !== 'number' || !Number.isFinite(raw.maxBytes)) return null;
+        return {
+            files: Array.isArray(raw.files) && raw.files.length ? raw.files : DEFAULT_FILES,
+            maxBytes: raw.maxBytes,
+        };
+    } catch {
+        return null;
+    }
+}
+
+export function writeConfig(cwd: string, config: BudgetConfig): void {
+    fs.mkdirSync(path.join(cwd, '.awm'), { recursive: true });
+    const body = {
+        _comment: 'Context budget for files injected into every agent session. Raising maxBytes '
+            + 'is allowed but must be a deliberate, reviewed change — see writing-plans, '
+            + 'Context Budget Gate.',
+        ...config,
+    };
+    fs.writeFileSync(path.join(cwd, CONFIG_FILE), JSON.stringify(body, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Measure the injected context against the pinned budget.
+ *
+ * On the first check there is nothing to compare against, so the current total is
+ * pinned and the result is `pinned`. Pinning rather than failing means adopting this
+ * never blocks a repo that is already large — it only stops it getting larger.
+ */
+export function checkBudget(cwd: string): BudgetReport {
+    const config = readConfig(cwd);
+    if (!config) {
+        const { total, breakdown } = measure(cwd, DEFAULT_FILES);
+        writeConfig(cwd, { files: DEFAULT_FILES, maxBytes: total });
+        return { status: 'pinned', totalBytes: total, maxBytes: total, breakdown };
+    }
+    const { total, breakdown } = measure(cwd, config.files);
+    return {
+        status: total > config.maxBytes ? 'over' : 'within',
+        totalBytes: total,
+        maxBytes: config.maxBytes,
+        breakdown,
+    };
+}

--- a/cli/src/commands/context-budget/index.ts
+++ b/cli/src/commands/context-budget/index.ts
@@ -1,0 +1,55 @@
+import { Command } from 'commander';
+import pc from 'picocolors';
+import { checkBudget, estimateTokens, CONFIG_FILE, BudgetReport } from './budget';
+
+const KB = (bytes: number) => `${(bytes / 1024).toFixed(0)}KB`;
+
+/**
+ * Exit code. `over` exits 1 so a caller that wants a hard gate can have one — but the
+ * skill that invokes this (writing-plans, Context Budget Gate) deliberately does not
+ * treat it as one. It runs at the last attended moment and presents a choice; blocking
+ * would strand the unattended runs this whole design exists to protect.
+ */
+export function exitCodeFor(report: BudgetReport): number {
+    return report.status === 'over' ? 1 : 0;
+}
+
+export function formatReport(report: BudgetReport): string {
+    const tokens = `~${estimateTokens(report.totalBytes)}k tokens`;
+    const breakdown = report.breakdown.map(b => `${b.file} ${KB(b.bytes)}`).join(', ');
+
+    if (report.status === 'pinned') {
+        return `${pc.green('✔')}  Context budget pinned at ${KB(report.totalBytes)} (${tokens} per session).\n`
+            + `   ${breakdown}\n`
+            + `   Saved to ${CONFIG_FILE} — commit it. Growth past this point will report here.\n`;
+    }
+    if (report.status === 'within') {
+        return `${pc.green('✔')}  Context budget OK: ${KB(report.totalBytes)} of ${KB(report.maxBytes)} (${tokens} per session).\n`
+            + `   ${breakdown}\n`;
+    }
+    const over = report.totalBytes - report.maxBytes;
+    return `${pc.yellow('⚠')}  Context budget exceeded: ${KB(report.totalBytes)} vs ${KB(report.maxBytes)} `
+        + `(over by ${KB(over)}).\n`
+        + `   ${breakdown}\n`
+        + `   These files are injected into EVERY session — ${tokens} spent before any code is read.\n\n`
+        + `   Decide now, while you are here:\n`
+        + `     1. Prune  — cheapest moment: that context is already loaded and you are\n`
+        + `                 choosing what matters for the work about to start.\n`
+        + `     2. Raise  — edit "maxBytes" in ${CONFIG_FILE}; a reviewed decision to keep\n`
+        + `                 paying for this in every future session.\n`
+        + `     3. Accept — proceed and note it in the plan.\n`;
+}
+
+export function registerContextBudgetCommand(program: Command): void {
+    program
+        .command('context-budget')
+        .description('check the size of the files injected into every agent session')
+        .option('--json', 'emit the report as JSON')
+        .option('--cwd <path>', 'directory to measure (default: current)')
+        .action((opts) => {
+            const report = checkBudget(opts.cwd ?? process.cwd());
+            process.stdout.write(opts.json ? JSON.stringify(report, null, 2) + '\n' : formatReport(report));
+            const code = exitCodeFor(report);
+            if (code !== 0) process.exit(code);
+        });
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -31,6 +31,7 @@ import { syncToMiro } from './core/miro';
 import { registerHooksCommand } from './commands/hooks';
 import { registerSensorsCommand } from './commands/sensors';
 import { registerLedgerCommand } from './commands/ledger';
+import { registerContextBudgetCommand } from './commands/context-budget';
 import { registerDoctorCommand } from './commands/doctor';
 import { registerBackupCommand } from './commands/backup';
 import { registerInitCommand } from './commands/init';
@@ -681,6 +682,7 @@ miroCmd.command('sync <storyMapPath>')
 registerHooksCommand(program);
 registerSensorsCommand(program);
 registerLedgerCommand(program);
+registerContextBudgetCommand(program);
 registerDoctorCommand(program);
 registerBackupCommand(program);
 registerInitCommand(program);

--- a/cli/tests/commands/context-budget/budget.test.ts
+++ b/cli/tests/commands/context-budget/budget.test.ts
@@ -1,0 +1,120 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { checkBudget, readConfig, CONFIG_FILE } from '../../../src/commands/context-budget/budget';
+import { exitCodeFor, formatReport } from '../../../src/commands/context-budget';
+
+function project(files: Record<string, number>): string {
+    // CLAUDE.md: no test may reach the real ~/.awm. Everything here is a tmpdir.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-budget-'));
+    for (const [name, bytes] of Object.entries(files)) {
+        fs.writeFileSync(path.join(dir, name), 'a'.repeat(bytes));
+    }
+    return dir;
+}
+
+describe('checkBudget', () => {
+    const dirs: string[] = [];
+    const make = (f: Record<string, number>) => { const d = project(f); dirs.push(d); return d; };
+    afterAll(() => dirs.forEach(d => fs.rmSync(d, { recursive: true, force: true })));
+
+    it('pins the current total on the first check instead of failing', () => {
+        // Adopting this must never block a repo that is already large — it only stops
+        // it getting larger. A first-run failure would make it unadoptable exactly
+        // where it is most needed.
+        const dir = make({ 'AGENTS.md': 5000, 'CONSTITUTION.md': 3000 });
+
+        const report = checkBudget(dir);
+
+        expect(report.status).toBe('pinned');
+        expect(report.totalBytes).toBe(8000);
+        expect(readConfig(dir)!.maxBytes).toBe(8000);
+    });
+
+    it('reports over once the files grow past the pin', () => {
+        const dir = make({ 'AGENTS.md': 5000 });
+        checkBudget(dir);                                        // pin at 5000
+        fs.appendFileSync(path.join(dir, 'AGENTS.md'), 'b'.repeat(2000));
+
+        const report = checkBudget(dir);
+
+        expect(report.status).toBe('over');
+        expect(report.totalBytes).toBe(7000);
+        expect(report.maxBytes).toBe(5000);
+    });
+
+    it('goes quiet again once pruned back under budget', () => {
+        const dir = make({ 'AGENTS.md': 5000 });
+        checkBudget(dir);
+        fs.writeFileSync(path.join(dir, 'AGENTS.md'), 'a'.repeat(4000));
+
+        expect(checkBudget(dir).status).toBe('within');
+    });
+
+    it('does not re-pin on later checks, so the budget is a real ratchet', () => {
+        // If a later check re-pinned, growth would always look like the new normal and
+        // the budget would never mean anything.
+        const dir = make({ 'AGENTS.md': 5000 });
+        checkBudget(dir);
+        fs.appendFileSync(path.join(dir, 'AGENTS.md'), 'b'.repeat(9000));
+        checkBudget(dir);
+
+        expect(readConfig(dir)!.maxBytes).toBe(5000);
+    });
+
+    it('counts only the files that exist', () => {
+        const dir = make({ 'AGENTS.md': 1000 });   // no CONSTITUTION.md, no CLAUDE.md
+
+        const report = checkBudget(dir);
+
+        expect(report.totalBytes).toBe(1000);
+        expect(report.breakdown.map(b => b.file)).toEqual(['AGENTS.md']);
+    });
+
+    it('re-pins when the config is unreadable rather than treating it as no limit', () => {
+        // An unparseable budget must not silently disable the check — that is the quiet
+        // direction of wrong, where it stops checking and still reports success.
+        const dir = make({ 'AGENTS.md': 2000 });
+        fs.mkdirSync(path.join(dir, '.awm'), { recursive: true });
+        fs.writeFileSync(path.join(dir, CONFIG_FILE), '{ not json');
+
+        const report = checkBudget(dir);
+
+        expect(report.status).toBe('pinned');
+        expect(readConfig(dir)!.maxBytes).toBe(2000);
+    });
+
+    it('honours a custom file list from the config', () => {
+        const dir = make({ 'AGENTS.md': 1000, 'OTHER.md': 500 });
+        fs.mkdirSync(path.join(dir, '.awm'), { recursive: true });
+        fs.writeFileSync(path.join(dir, CONFIG_FILE), JSON.stringify({ files: ['OTHER.md'], maxBytes: 100 }));
+
+        const report = checkBudget(dir);
+
+        expect(report.totalBytes).toBe(500);
+        expect(report.status).toBe('over');
+    });
+});
+
+describe('reporting', () => {
+    it('exits non-zero only when over budget', () => {
+        expect(exitCodeFor({ status: 'over', totalBytes: 2, maxBytes: 1, breakdown: [] })).toBe(1);
+        expect(exitCodeFor({ status: 'within', totalBytes: 1, maxBytes: 2, breakdown: [] })).toBe(0);
+        expect(exitCodeFor({ status: 'pinned', totalBytes: 1, maxBytes: 1, breakdown: [] })).toBe(0);
+    });
+
+    it('offers the three choices when over, since this runs while a human is present', () => {
+        const out = formatReport({
+            status: 'over',
+            totalBytes: 227_000,
+            maxBytes: 224_000,
+            breakdown: [{ file: 'AGENTS.md', bytes: 145_000 }],
+        });
+
+        expect(out).toContain('Prune');
+        expect(out).toContain('Raise');
+        expect(out).toContain('Accept');
+        expect(out).toMatch(/~5[0-9]k tokens/);
+    });
+});


### PR DESCRIPTION
Follow-up to #19 (registry), which shipped the context budget check as a sensor. That placement was wrong twice over.

## Wrong phase

As a `fast` sensor it ran on **every** `awm sensors run` — including the QA gate of an unattended overnight run.

A check whose entire purpose is to make a human decide (prune, raise, accept) cannot fire at 3 AM. It stalls the run one step from done and the user wakes up to no PR, which is strictly worse than not checking at all.

`development-process` already pins where it belongs: the execution mode lives in the plan, so *phases before the plan exists are always interactive*. That makes the end of `writing-plans` the last moment a human is guaranteed present — **by contract, not by luck**. That is a phase gate, not a sensor.

## Wrong delivery

`initSensors` copies files only from the **detected** pack's directory. A script sitting in `sensor-packs/generic/` therefore never reached a `js-ts` project — which is every JS/TS repo. The feature was inert exactly where it was needed.

Duplicating the script into each pack would fix delivery and start drifting immediately.

## Both dissolve at the same point

This is a CLI capability, like `awm ledger` — not project config. No copying, no per-pack duplication, no forcing a phase check into a model built for always-on gates.

```
awm context-budget [--json] [--cwd <path>]
```

Measures the files injected into every session (`AGENTS.md`, `CONSTITUTION.md`, `CLAUDE.md`) against the budget pinned in `.awm/context-budget.json`.

| Check | Behaviour |
|---|---|
| First | Pins the current total, passes. Adopting it never blocks a repo that is already large — it only stops it getting larger |
| Within budget | Quiet, exit 0 |
| Over budget | Reports, names the three ways out, exit 1 |

Exit 1 so a caller that *wants* a hard gate can have one — but the skill that invokes it deliberately does not treat it as one.

## Two failure modes handled toward the loud side

- **Unreadable config re-pins** rather than being read as "no limit". A budget that silently stops checking while still reporting success is the quiet direction of wrong.
- **Later checks never re-pin**, or growth would always look like the new normal and the budget would stop meaning anything.

## Verification

- `npx tsc --noEmit` — clean.
- `npx jest --runInBand` — **141 suites, 1262 tests, 0 failures** (9 new).

Exercised against `notion-tracker`'s real files:

```
$ awm context-budget
✔  Context budget pinned at 219KB (~56k tokens per session).
   AGENTS.md 138KB, CONSTITUTION.md 81KB

# simulate an unattended harness-retro appending a 3KB lesson
$ awm context-budget
⚠  Context budget exceeded: 222KB vs 219KB (over by 3KB).
   These files are injected into EVERY session — ~57k tokens spent before any code is read.
   1. Prune   2. Raise   3. Accept
exit=1
```

## Companion change

`awm-baseline-registry` moves the check into `writing-plans`' pre-handoff gate, turns `harness-retro` from gating to reporting, and documents the attended/unattended boundary as a design rule in `development-process`. It also deletes the `.cjs` this command replaces. **Merge this one first** — the skill calls `awm context-budget`.

## Release impact

Titled `feat(...)`: merging cuts **v3.8.0** to npm automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_