### PR TITLE
fix(windows): harden pidExistsNative against a real CI flake found post-merge

### DIFF
--- a/cli/src/core/journal/process.ts
+++ b/cli/src/core/journal/process.ts
@@ -251,16 +251,50 @@ export function spawnStructured(argv: string[], cwd: string, nonce: string, extr
  *  rompia el invariante "JAMAS safe sin evidencia" (safeToReplace
  *  devolvia 'safe' para un proceso vivo). process.kill(pid,0) evita la
  *  capa de emulacion por completo. */
+/** Sleep sincronico REAL, multiplataforma, sin depender de un binario externo
+ *  (`sleep` no existe nativamente en win32 — ver el comentario de sleepSync
+ *  mas arriba). `Atomics.wait` sobre un buffer compartido bloquea el hilo
+ *  actual durante `ms` sin abrir ningun subproceso; funciona identico en
+ *  cualquier plataforma que soporte Node. Usado SOLO por pidExistsNative
+ *  para el reintento acotado de abajo — nunca en un hot-path de alta
+ *  frecuencia. */
+function sleepMsSync(ms: number): void {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/** Reintento acotado (R6, post-mortem de CI real): dos corridas reales de
+ *  windows-latest sobre el MISMO commit (uno vía `release.yml`, uno vía
+ *  `ci.yml`, ambos re-corriendo el suite completo desde cero) dieron
+ *  resultados DISTINTOS para el mismo test — `pidExistsNative` reportando
+ *  ESRCH para un proceso recien spawneado por el propio test, genuinamente
+ *  vivo — evidencia directa de una condicion de carrera transitoria
+ *  especifica de esta plataforma/runner, no un bug determinista (el codigo
+ *  no cambio entre ambas corridas). Un solo intento en el hot-path exacto
+ *  "acabo de spawnear esto, ¿esta vivo?" no le da tiempo al SO a que el pid
+ *  sea consultable via OpenProcess bajo carga pesada del runner. Reintentar
+ *  con una pausa breve ANTES de declarar ESRCH definitivo no debilita el
+ *  invariante "jamas muerte sin evidencia" — un proceso genuinamente muerto
+ *  sigue reportando ESRCH en el reintento; esto solo absorbe el falso
+ *  negativo transitorio. Costo maximo: ~150ms, y SOLO en la rama que ya iba
+ *  a declarar "no existe" — el camino feliz (proceso vivo, exito inmediato)
+ *  no paga nada. */
+const PID_EXISTS_RETRY_ATTEMPTS = 3;
+const PID_EXISTS_RETRY_DELAY_MS = 50;
+
 function pidExistsNative(pid: number): boolean {
-    try {
-        process.kill(pid, 0);
-        return true;
-    } catch (error) {
-        // ESRCH = el SO confirmo que el pid no existe. Cualquier otro
-        // codigo (ej. EPERM: existe pero sin permiso de senializarlo) NO
-        // es evidencia de muerte — falla a favor de "vivo" (R2.1).
-        return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+    for (let attempt = 0; attempt < PID_EXISTS_RETRY_ATTEMPTS; attempt++) {
+        try {
+            process.kill(pid, 0);
+            return true;
+        } catch (error) {
+            // ESRCH = el SO confirmo que el pid no existe. Cualquier otro
+            // codigo (ej. EPERM: existe pero sin permiso de senializarlo) NO
+            // es evidencia de muerte — falla a favor de "vivo" (R2.1).
+            if ((error as NodeJS.ErrnoException).code !== 'ESRCH') return true;
+            if (attempt < PID_EXISTS_RETRY_ATTEMPTS - 1) sleepMsSync(PID_EXISTS_RETRY_DELAY_MS);
+        }
     }
+    return false;
 }
 
 /** Vivo Y con la MISMA identidad — tupla completa, nunca PID solo (R2.1,

--- a/cli/tests/core/journal/process.test.ts
+++ b/cli/tests/core/journal/process.test.ts
@@ -242,6 +242,19 @@ describe('process identity (win32, mockeado — sin windows real disponible en e
         expect(killSpy).toHaveBeenCalledWith(999999, 0);
     });
 
+    test('pidExistsNative reintenta un ESRCH transitorio antes de declarar muerte — no confia en un unico intento (regresion: CI real windows-latest, dos corridas del mismo commit dieron resultados distintos para un proceso recien spawneado)', () => {
+        Object.defineProperty(process, 'platform', { value: 'win32' });
+        let calls = 0;
+        const killSpy = jest.spyOn(process, 'kill').mockImplementation(() => {
+            calls++;
+            if (calls < 3) { const err: any = new Error('transient'); err.code = 'ESRCH'; throw err; }
+            return true;   // el pid "aparece" recien al tercer intento — simula la carrera real observada
+        });
+        const fakeRef = { pid: 424242, startTime: 'x', spawnNonce: 'n', argvDigest: 'd', processGroup: 424242, psArgsDigest: 'x' };
+        expect(refIsAlive(fakeRef)).toBe(true);   // NUNCA declara muerte por el ESRCH transitorio de los primeros 2 intentos
+        expect(killSpy).toHaveBeenCalledTimes(3);
+    });
+
     test('refIsAlive en win32 NUNCA declara muerte por un error que no sea ESRCH (ej. EPERM: el pid existe pero sin permiso de senializarlo) (R2.1)', () => {
         Object.defineProperty(process, 'platform', { value: 'win32' });
         jest.spyOn(process, 'kill').mockImplementation(() => {


### PR DESCRIPTION
## Summary

R7's own merge commit (17ed10b) hit a CI failure on `windows-latest` that its own pre-merge PR CI run didn't show: `refIsAlive` returned `false` immediately after a fresh, genuinely-alive spawn (`tests/core/journal/process.test.ts`, both the basic `spawnStructured` test and the reduced-identity test).

Key evidence this is flakiness, not a regression:
- `cli/src/core/journal/process.ts` (where `refIsAlive`/`pidExistsNative` live) was **not touched** by either R6's harness-retro PR (#33, docs-only) or R7 (#34, didn't touch this file).
- On that exact same merge commit, `release.yml`'s own internal `jest` gate **passed**, while `ci.yml`'s separate windows-latest run **failed** on the identical tests — same code, same commit, two different real runs, two different outcomes.
- Both source PRs' own pre-merge CI (`ba72420` for #34, and #33's head before it) passed cleanly on `windows-latest`.

That pattern — unchanged code, inconsistent results across independent runs of the same commit — points at a transient OS-level race (a just-spawned pid not yet reliably queryable via `OpenProcess`/signal-0 under heavy `windows-latest` runner load), not a logic bug.

## Fix

`pidExistsNative` now retries up to 3 times (50ms apart, ~150ms worst case) before trusting an `ESRCH` result, using a true synchronous cross-platform sleep (`Atomics.wait` on a `SharedArrayBuffer` — no external `sleep` binary, which doesn't exist natively on win32 anyway per this file's own established notes). Only the "about to declare not-found" branch pays the cost; the happy path is unaffected. A genuinely dead process still reports `ESRCH` on every retry, so the file's "never declare death without evidence" invariant is unweakened — this only absorbs a transient false negative.

Added a regression test simulating the exact observed shape (`ESRCH` twice, then success) and verified via revert-and-rerun that it discriminates the fix (red without the retry, green with it).

## Test plan

- [x] `cd cli && npx tsc --noEmit && npx jest --runInBand` — clean (153/153 suites, 1479/1479 tests)
- [x] Revert-and-rerun on the new regression test confirms it actually pins the fix
- [ ] CI (`ci.yml`) green on both `ubuntu-latest` and `windows-latest` — this is the actual test of whether the fix holds against real Windows CI

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_