### PR TITLE
docs: generated support matrix, and the limits stated without ambiguity

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# El .md de este repo se compara byte a byte por tests estructurales
+# (docs/support-matrix.md contra su generador). Un checkout de Windows con
+# core.autocrlf=true los entregaba con CRLF y rompia esa comparacion por
+# bytes que no tienen que ver con el contenido. Se fija LF para todos.
+*.md text eol=lf

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -46,7 +46,15 @@ Reglas de proceso del proyecto. Todo agente que trabaje en este repo debe leerla
 
 ## Matriz de soporte
 
-Esta matriz es una **declaración de contrato**: qué combinaciones de stack/agente/host/OS están soportadas HOY, no una lista de aspiraciones. Cada fila está verificada contra el código fuente citado — no contra la prosa de ningún plan (los planes documentan intención; el código es la verdad, ver "Auto-verificación del CLI" en AGENTS.md). Al agregar una fila nueva, verificarla del mismo modo antes de escribirla.
+Esta matriz es una **declaración de contrato**: qué combinaciones de stack/agente/host/OS están soportadas HOY, no una lista de aspiraciones.
+
+> **División de trabajo con [`docs/support-matrix.md`](docs/support-matrix.md):** acá viven las
+> *reglas* — qué tier tiene cada agente y **por qué**, qué decisión hay detrás de cada
+> límite. Allá vive el *estado*: las rutas de instalación (generadas desde
+> `providers/index.ts` y bloqueadas por un test) y el nivel de evidencia de cada
+> combinación (`verificado` / `sin verificar` / `no soportado` / `planeado`). Las rutas no
+> se escriben a mano en ninguno de los dos documentos: esa duplicación ya produjo una
+> tabla que afirmaba durante varias releases que Antigravity instalaba donde no instala. Cada fila está verificada contra el código fuente citado — no contra la prosa de ningún plan (los planes documentan intención; el código es la verdad, ver "Auto-verificación del CLI" en AGENTS.md). Al agregar una fila nueva, verificarla del mismo modo antes de escribirla.
 
 **Stacks** (`cli/src/commands/sensors/init.ts`, `detectStack()` / `STACK_DETECTORS`): `js-ts` (indicador `package.json`), `python` (`pyproject.toml` | `setup.py` | `setup.cfg` | `requirements.txt` | `Pipfile`), `shell` (fallback: glob `*.sh` en la raíz o en `scripts/`, solo si no hay marcador js-ts/python más fuerte), `generic` (fallback puro, cuando nada matchea). Orden de especificidad: `js-ts > python > shell > generic`. `awm sensors init --pack <name>` es el override explícito del operador para cualquier caso que la heurística no cubra — la detección es conveniencia, la declaración es contrato. Sin registry alcanzable, o sin `pack.json` para el stack detectado, el manifest generado es honesto y vacío (`FALLBACK_DEFAULTS` fue eliminado del CLI en R3) — el CLI nunca vuelve a inventar defaults propios.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Not every agent can enforce the same things. AWM reports each one's **tier** hon
 
 **How to configure each one:** **[docs/agents-setup.md](docs/agents-setup.md)**
 
+**Exactly what is supported, with what evidence, and what is not:**
+**[docs/support-matrix.md](docs/support-matrix.md)** — install paths generated from the
+source and locked by a test, plus an explicit `verified / unverified / not supported /
+planned` level for every provider, OS, registry and sensor pack. Nothing there asks you
+to take its word for it.
+
 ### Stacks (for sensors)
 
 `js-ts`, `python`, `shell`, and a `generic` fallback. Detection is a convenience; `awm sensors init --pack <name>` is the explicit override and the real contract.
@@ -128,10 +134,11 @@ The two processes the system runs day to day:
 **Understand it**
 - [Architecture](docs/architecture.md) — components, data flow, on-disk state
 - [Software development lifecycle](docs/sdlc.md) — how the phases, gates and learning loop compose
-- [`CONSTITUTION.md`](CONSTITUTION.md) — the project's non-negotiable rules and the authoritative support matrix
+- [`CONSTITUTION.md`](CONSTITUTION.md) — the project's non-negotiable rules
 - [Harness retros](docs/harness-retros.md) — auditable log of recurring gaps turned into structural rules
 
 **Verify it**
+- [Support matrix](docs/support-matrix.md) — what is supported, at what evidence level, and what is missing
 - [End-to-end acceptance playbooks](docs/testing/README.md) — scripted checks per OS and per agent
 
 **Extend it**

--- a/cli/package.json
+++ b/cli/package.json
@@ -23,7 +23,8 @@
     "prerelease": "npm run build",
     "release": "node dist/src/release/index.js",
     "prepack": "npm run build",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "docs:matrix": "ts-node scripts/support-matrix.ts"
   },
   "keywords": [
     "agentic",

--- a/cli/scripts/support-matrix.ts
+++ b/cli/scripts/support-matrix.ts
@@ -17,11 +17,24 @@ import { homeDir } from '../src/core/paths';
 export const BEGIN_MARKER = '<!-- BEGIN GENERATED: provider-capabilities -->';
 export const END_MARKER = '<!-- END GENERATED: provider-capabilities -->';
 
+/** Cualquier separador → `/`. Las rutas que produce `providers()` traen el separador
+ *  nativo, y el `home` puede traer otro (en win32, un `HOME` de entorno con `/` frente a
+ *  un `path.join` que devuelve `\`). Normalizar los dos lados ANTES de compararlos es lo
+ *  unico que hace la comparacion valida. */
+const toPosix = (p: string): string => p.split(path.sep).join('/').split('\\').join('/');
+
 /** Rutas absolutas → `~/…`, con separadores POSIX, para que la tabla sea la misma en
- *  cualquier maquina y en cualquier sistema operativo que la regenere. */
-function homeRelative(p: string, home: string): string {
-    const rel = p.startsWith(home) ? `~${p.slice(home.length)}` : p;
-    return rel.split(path.sep).join('/');
+ *  cualquier maquina y en cualquier sistema operativo que la regenere.
+ *
+ *  La version anterior comparaba con `startsWith` ANTES de normalizar, asi que en Windows
+ *  —donde `path.join` devuelve `\` y el home podia venir con `/`— el prefijo no
+ *  coincidia nunca, no abreviaba nada, y la tabla regenerada ahi no era la misma que la
+ *  comiteada. Es decir: el documento prometia ser independiente de la maquina y no lo era.
+ *  Lo encontro la CI de Windows, no el desarrollo en Linux. */
+export function homeRelative(p: string, home: string): string {
+    const target = toPosix(p);
+    const prefix = toPosix(home);
+    return target.startsWith(prefix) ? `~${target.slice(prefix.length)}` : target;
 }
 
 function cell(value: string | null, absent: string, home: string): string {

--- a/cli/scripts/support-matrix.ts
+++ b/cli/scripts/support-matrix.ts
@@ -1,0 +1,116 @@
+// Generador de la matriz de soporte que vive en `docs/support-matrix.md`.
+//
+// Existe porque la tabla escrita a mano ya mintio: decia que Antigravity instalaba en
+// `~/.agents/skills` y `.agents/skills` cuando el codigo dice `~/.gemini/antigravity/skills`
+// y `.agent/skills` (singular), y omitia que es el unico provider con `global_workflows`.
+// Una tabla de soporte que no coincide con el codigo es peor que no tenerla: se cita en
+// una presentacion, se planifica encima, y nadie la vuelve a chequear.
+//
+// El bloque generado esta delimitado por marcadores en el .md, y
+// `tests/structural/support-matrix-is-current.test.ts` regenera y compara — asi que un
+// cambio en `providers/index.ts` que no se refleje en el doc pone la CI en rojo. La
+// verificabilidad no depende de que alguien se acuerde.
+import path from 'path';
+import { AGENT_TARGETS, providers, type ProviderConfig, type AgentTarget } from '../src/providers';
+import { homeDir } from '../src/core/paths';
+
+export const BEGIN_MARKER = '<!-- BEGIN GENERATED: provider-capabilities -->';
+export const END_MARKER = '<!-- END GENERATED: provider-capabilities -->';
+
+/** Rutas absolutas → `~/…`, con separadores POSIX, para que la tabla sea la misma en
+ *  cualquier maquina y en cualquier sistema operativo que la regenere. */
+function homeRelative(p: string, home: string): string {
+    const rel = p.startsWith(home) ? `~${p.slice(home.length)}` : p;
+    return rel.split(path.sep).join('/');
+}
+
+function cell(value: string | null, absent: string, home: string): string {
+    if (value === null) return absent;
+    return `\`${homeRelative(value, home)}\``;
+}
+
+/** El tier declarado por la forma de la config — la misma derivacion que `providerTier`
+ *  en `core/diagnostics/provider-checks.ts`, no una segunda opinion. */
+function tier(c: ProviderConfig): string {
+    if (c.hooks) return 'hooks-native';
+    if (c.injection?.type === 'config-instructions') return 'config-managed';
+    if (c.injection) return 'agents-md-managed';
+    return 'context-only';
+}
+
+function injectionCell(c: ProviderConfig, home: string): string {
+    const inj = c.injection;
+    if (!inj) return '— (ninguna)';
+    if (inj.type === 'cc-settings-merge') return 'hook `SessionStart`';
+    if (inj.type === 'config-instructions') return `\`${homeRelative(inj.configPath, home)}\` → campo \`${inj.field}\``;
+    return inj.globalPath === null
+        ? `\`${inj.localFile}\` del proyecto (sin equivalente global)`
+        : `\`${inj.localFile}\` + \`${homeRelative(inj.globalPath, home)}\``;
+}
+
+export function renderProviderTables(): string {
+    // `homeDir()`, la MISMA funcion de la que `providers()` deriva sus rutas. Tomarlo
+    // por parametro daba dos fuentes para el mismo dato: el generador abreviaba contra
+    // el home real y el test contra uno inventado, asi que ninguna ruta empezaba con el
+    // prefijo esperado y la tabla salia con rutas absolutas de la maquina que la corrio.
+    const home = homeDir();
+    const p = providers();
+    const row = (a: AgentTarget) => p[a];
+
+    const lines: string[] = [];
+
+    lines.push('### Dónde aterriza cada artefacto');
+    lines.push('');
+    lines.push('| Agente | Tier | Skills (global) | Skills (proyecto) | Formato |');
+    lines.push('|---|---|---|---|---|');
+    for (const a of AGENT_TARGETS) {
+        const c = row(a);
+        lines.push(`| \`${a}\` | ${tier(c)} | ${cell(c.skill.global, '**no soportado**', home)} | \`${c.skill.local}\` | \`${c.skill.renderer}\` |`);
+    }
+    lines.push('');
+    lines.push('### Perfiles de agente, workflows, hooks y contexto');
+    lines.push('');
+    lines.push('| Agente | Perfiles de agente | Workflows | Hooks | Entrega de contexto | Versión mínima |');
+    lines.push('|---|---|---|---|---|---|');
+    for (const a of AGENT_TARGETS) {
+        const c = row(a);
+        const agentCell = c.agent === null
+            ? '— (no aplica)'
+            : `${cell(c.agent.global, '**no soportado**', home)} · \`${c.agent.renderer}\``;
+        const wfCell = c.workflow === null
+            ? '— (no aplica)'
+            : cell(c.workflow.global, '**no soportado**', home);
+        lines.push(
+            `| \`${a}\` | ${agentCell} | ${wfCell} | ${c.hooks ? `\`${c.hooks.type}\`` : '— (no tiene)'} ` +
+            `| ${injectionCell(c, home)} | ${c.minimumVersion ?? '— (sin gate)'} |`,
+        );
+    }
+    lines.push('');
+    lines.push('> Generado desde `cli/src/providers/index.ts`. **No editar a mano** — `npm run docs:matrix` lo regenera y');
+    lines.push('> `tests/structural/support-matrix-is-current.test.ts` falla si el documento y el código se separan.');
+    return lines.join('\n');
+}
+
+/** Reemplaza el bloque entre marcadores. Falla ruidosamente si faltan: un doc sin
+ *  marcadores no se "arregla" agregando la tabla al final, se arregla avisando. */
+export function spliceGenerated(markdown: string, generated: string): string {
+    const begin = markdown.indexOf(BEGIN_MARKER);
+    const end = markdown.indexOf(END_MARKER);
+    if (begin === -1 || end === -1 || end < begin) {
+        throw new Error(`support-matrix.md no tiene los marcadores ${BEGIN_MARKER} / ${END_MARKER}`);
+    }
+    return markdown.slice(0, begin + BEGIN_MARKER.length)
+        + '\n\n' + generated + '\n\n'
+        + markdown.slice(end);
+}
+
+export const DOC_PATH = path.join(__dirname, '..', '..', 'docs', 'support-matrix.md');
+
+/* istanbul ignore next — entrypoint de CLI, ejercitado por el test via las funciones puras */
+if (require.main === module) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require('fs');
+    const current = fs.readFileSync(DOC_PATH, 'utf-8');
+    fs.writeFileSync(DOC_PATH, spliceGenerated(current, renderProviderTables()), 'utf-8');
+    process.stdout.write(`support-matrix.md regenerado desde providers/index.ts\n`);
+}

--- a/cli/scripts/support-matrix.ts
+++ b/cli/scripts/support-matrix.ts
@@ -105,15 +105,22 @@ export function renderProviderTables(): string {
 }
 
 /** Reemplaza el bloque entre marcadores. Falla ruidosamente si faltan: un doc sin
- *  marcadores no se "arregla" agregando la tabla al final, se arregla avisando. */
+ *  marcadores no se "arregla" agregando la tabla al final, se arregla avisando.
+ *
+ *  Respeta el fin de linea del documento que recibe. Emitia LF siempre, asi que en un
+ *  checkout de Windows —donde git entrega el .md con CRLF por defecto— regenerar producia
+ *  un archivo de finales mezclados, y la comparacion del test fallaba por bytes que no
+ *  tienen nada que ver con el contenido de la tabla. */
 export function spliceGenerated(markdown: string, generated: string): string {
     const begin = markdown.indexOf(BEGIN_MARKER);
     const end = markdown.indexOf(END_MARKER);
     if (begin === -1 || end === -1 || end < begin) {
         throw new Error(`support-matrix.md no tiene los marcadores ${BEGIN_MARKER} / ${END_MARKER}`);
     }
+    const eol = markdown.includes('\r\n') ? '\r\n' : '\n';
+    const block = generated.split('\n').join(eol);
     return markdown.slice(0, begin + BEGIN_MARKER.length)
-        + '\n\n' + generated + '\n\n'
+        + eol + eol + block + eol + eol
         + markdown.slice(end);
 }
 

--- a/cli/tests/structural/support-matrix-is-current.test.ts
+++ b/cli/tests/structural/support-matrix-is-current.test.ts
@@ -81,6 +81,18 @@ describe('docs/support-matrix.md refleja el codigo', () => {
         });
     });
 
+    it('respeta el fin de linea del documento (un checkout de Windows entrega CRLF)', () => {
+        // Sin esto, regenerar en Windows dejaba el archivo con finales mezclados y el test
+        // de arriba fallaba por bytes ajenos al contenido. Es el mismo error de fondo que
+        // el de los separadores: asumir la forma de POSIX para un dato que la plataforma
+        // decide.
+        const crlfDoc = `intro\r\n${BEGIN_MARKER}\r\nviejo\r\n${END_MARKER}\r\nfin\r\n`;
+        const out = spliceGenerated(crlfDoc, 'linea uno\nlinea dos');
+
+        expect(out).toContain('linea uno\r\nlinea dos');
+        expect(out.split('\r\n').length - 1).toBe(out.split('\n').length - 1); // ni un LF suelto
+    });
+
     it('marca como no soportado, no como ausente, el scope que un provider no tiene', () => {
         // La diferencia entre "no soportado" y una celda vacia es exactamente lo que el
         // documento existe para no dejar ambiguo: Copilot no tiene scope global por

--- a/cli/tests/structural/support-matrix-is-current.test.ts
+++ b/cli/tests/structural/support-matrix-is-current.test.ts
@@ -1,0 +1,72 @@
+// Guarda estructural: `docs/support-matrix.md` no puede desalinearse de
+// `src/providers/index.ts`.
+//
+// La tabla escrita a mano ya mintio. Decia que Antigravity instalaba en
+// `~/.agents/skills` y `.agents/skills`; el codigo dice `~/.gemini/antigravity/skills` y
+// `.agent/skills` — singular — y ademas es el unico provider con `global_workflows`, cosa
+// que la tabla ni mencionaba. Nadie lo noto porque nada obligaba a mirarlo: la tabla se
+// escribio una vez, el codigo siguio cambiando, y el documento se cita en presentaciones y
+// se planifica encima.
+//
+// Este test hace que ese desvio sea imposible de mergear. No verifica que la tabla sea
+// "linda": verifica que sea LA MISMA que produce el codigo hoy.
+import fs from 'fs';
+import {
+    BEGIN_MARKER, END_MARKER, DOC_PATH, renderProviderTables, spliceGenerated,
+} from '../../scripts/support-matrix';
+
+
+describe('docs/support-matrix.md refleja el codigo', () => {
+    it('el bloque generado esta al dia', () => {
+        const doc = fs.readFileSync(DOC_PATH, 'utf-8');
+        const expected = spliceGenerated(doc, renderProviderTables());
+
+        // Mensaje accionable: el que rompe esto casi siempre acaba de tocar
+        // providers/index.ts y no sabe que este documento existe.
+        expect(doc).toBe(expected);
+    });
+
+    it('el documento conserva sus marcadores', () => {
+        const doc = fs.readFileSync(DOC_PATH, 'utf-8');
+        expect(doc).toContain(BEGIN_MARKER);
+        expect(doc).toContain(END_MARKER);
+    });
+
+    it('la tabla nombra a los seis providers declarados', () => {
+        // Que el bloque este "al dia" no sirve si el generador se olvidara de un provider:
+        // doc y generador coincidirian, los dos incompletos.
+        const { AGENT_TARGETS } = require('../../src/providers');
+        const generated = renderProviderTables();
+        for (const agent of AGENT_TARGETS) {
+            expect(generated).toContain(`\`${agent}\``);
+        }
+    });
+
+    it('abrevia el home y usa separadores POSIX, para no depender de la maquina', () => {
+        // Con un HOME inventado: si la tabla dependiera de la maquina que la genera, este
+        // home apareceria literal en la salida y el doc comiteado cambiaria segun quien
+        // corriera el generador — el test de arriba se volveria ruido permanente.
+        const saved = process.env.HOME;
+        process.env.HOME = '/home/inventado';
+        try {
+            jest.resetModules();
+            const { renderProviderTables: fresh } = require('../../scripts/support-matrix');
+            const generated: string = fresh();
+            expect(generated).toContain('`~/.claude/skills`');
+            expect(generated).not.toContain('/home/inventado');
+            expect(generated).not.toContain('\\');
+        } finally {
+            if (saved === undefined) delete process.env.HOME; else process.env.HOME = saved;
+            jest.resetModules();
+        }
+    });
+
+    it('marca como no soportado, no como ausente, el scope que un provider no tiene', () => {
+        // La diferencia entre "no soportado" y una celda vacia es exactamente lo que el
+        // documento existe para no dejar ambiguo: Copilot no tiene scope global por
+        // decision del producto que integramos, no porque falte implementarlo.
+        const generated = renderProviderTables();
+        const copilotRow = generated.split('\n').find((l) => l.startsWith('| `copilot` |'))!;
+        expect(copilotRow).toContain('**no soportado**');
+    });
+});

--- a/cli/tests/structural/support-matrix-is-current.test.ts
+++ b/cli/tests/structural/support-matrix-is-current.test.ts
@@ -12,7 +12,7 @@
 // "linda": verifica que sea LA MISMA que produce el codigo hoy.
 import fs from 'fs';
 import {
-    BEGIN_MARKER, END_MARKER, DOC_PATH, renderProviderTables, spliceGenerated,
+    BEGIN_MARKER, END_MARKER, DOC_PATH, homeRelative, renderProviderTables, spliceGenerated,
 } from '../../scripts/support-matrix';
 
 
@@ -59,6 +59,26 @@ describe('docs/support-matrix.md refleja el codigo', () => {
             if (saved === undefined) delete process.env.HOME; else process.env.HOME = saved;
             jest.resetModules();
         }
+    });
+
+    // La abreviacion a `~` se probaba solo end-to-end, y en Linux eso no distingue entre
+    // "normaliza bien" y "los separadores ya coincidian". La CI de Windows encontro que no
+    // normalizaba: comparaba el prefijo ANTES de convertir separadores, asi que alla no
+    // abreviaba nada y la tabla regenerada no era la comiteada. Probar la unidad con las
+    // dos formas de ruta lo detecta en cualquier sistema, sin fingir la plataforma.
+    describe('homeRelative normaliza antes de comparar', () => {
+        it.each([
+            ['posix',      '/home/x',        '/home/x/.claude/skills',            '~/.claude/skills'],
+            ['win32',      'C:\\Users\\x',    'C:\\Users\\x\\.claude\\skills',     '~/.claude/skills'],
+            ['mixto',      '/home/x',        '\\home\\x\\.claude\\skills',         '~/.claude/skills'],
+            ['sin prefijo', '/home/x',       '/opt/otro/skills',                  '/opt/otro/skills'],
+        ])('%s', (_n, home, input, expected) => {
+            expect(homeRelative(input, home)).toBe(expected);
+        });
+
+        it('nunca deja un separador de Windows en la salida', () => {
+            expect(homeRelative('C:\\Users\\x\\.codex\\agents', 'C:\\Users\\x')).not.toContain('\\');
+        });
     });
 
     it('marca como no soportado, no como ausente, el scope que un provider no tiene', () => {

--- a/docs/agents-setup.md
+++ b/docs/agents-setup.md
@@ -2,6 +2,10 @@
 
 AWM installs into whichever agent each developer already uses. Six are supported, and they do **not** get the same product — because they don't have the same capabilities.
 
+> **The authoritative paths live in [support-matrix.md](support-matrix.md)**, generated from
+> `cli/src/providers/index.ts` and locked by a test. If this page ever disagrees with it,
+> the generated one wins — and the disagreement is a bug on this page.
+
 This page is deliberately blunt about that. Promising uniform behaviour and then degrading silently is how a tool loses trust; knowing up front that Cursor won't fire hooks is far better than discovering it when a gate doesn't hold.
 
 ## Choosing: what each tier actually gives you
@@ -121,9 +125,14 @@ awm init -a antigravity
 
 | | Path |
 |---|---|
-| Skills | `~/.agents/skills/` · `.agents/skills/` |
+| Skills | `~/.gemini/antigravity/skills/` · `.agent/skills/` |
 | Workflows | `~/.gemini/antigravity/global_workflows/` |
 | Hooks / injection | none |
+
+> Note the singular `.agent/skills` at project scope, and that Antigravity does **not**
+> share `~/.agents/skills` with Codex/OpenCode — it has its own tree. This table said
+> otherwise for several releases; the authoritative, code-generated version is in
+> [support-matrix.md](support-matrix.md).
 
 Content is delivered and read by the agent. No hooks, no managed injection — `awm doctor` won't report those as missing, because the agent has no such mechanism to begin with.
 
@@ -141,7 +150,7 @@ awm doctor -a cursor,copilot
 
 `awm init` targets one agent per run; run it once per agent you use.
 
-Note that `codex`, `opencode` and `antigravity` share `~/.agents/skills/`. That's intentional — one installed copy serves all three.
+Note that `codex` and `opencode` share `~/.agents/skills/`. That's intentional — one installed copy serves both, and the installer treats them as a group so enabling one without the other is refused rather than silently divergent. **`antigravity` does not share it**: it has its own `~/.gemini/antigravity/skills/`.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,6 +120,8 @@ Every transforming renderer must **escape for its output format** — YAML for `
 
 The JSON output reports `applied` / `pending` / `failed` plus `modifiedFiles`, so a failed run tells you exactly what it touched and restored.
 
+**One transaction per user-facing operation, not per bundle.** `awm sync` over a profile with N extensions builds a single plan and applies it once: a failure on the third extension leaves the first two uninstalled too, rather than a tree matching neither the before nor the after state. The transaction id is printed with the `awm backup restore` invocation that undoes it — an id nobody can name is an id that doesn't exist.
+
 **AWM merges into user-owned files, never clobbers them.** `~/.claude/settings.json`, `AGENTS.md`, `opencode.json` all belong to the user; AWM owns only its managed block within them. `awm backup` keeps the restorable copies.
 
 ---
@@ -129,6 +131,8 @@ The JSON output reports `applied` / `pending` / `failed` plus `modifiedFiles`, s
 Per-project, declared in `.awm/sensors.json`, generated from a **sensor pack** for the detected stack (`js-ts`, `python`, `shell`, `generic`).
 
 Detection is a convenience; `awm sensors init --pack <name>` is the contract. If no pack exists for the detected stack, the manifest is **honestly empty** — AWM does not invent defaults (that behaviour, `FALLBACK_DEFAULTS`, was deliberately removed).
+
+`awm sensors run` is **read-only**: it runs the manifest as committed and never rewrites `.awm/sensors.json` or copies pack config files into the tree. When the manifest's pack no longer matches the tree it reports the drift (`packDrift`) and names `awm sensors init`, the verb that adopts a pack. A measuring command that edits what it measures was a real bug, not a hypothetical.
 
 Execution is `execFileSync` with an **argument array — never a shell string**. Filenames reaching a sensor can come from `git diff` on an untrusted checkout, and on Windows a shell round-trip re-opens the batch-argument-injection class (CVE-2024-27980). No shell, no injection surface.
 
@@ -143,7 +147,7 @@ The rules the design rests on. Violating any one of these produces a bug of a cl
 3. **`~/.awm` belongs to the installer.** Never hand-edited, including by tests (all tests use isolated tmpdirs with `HOME`/`AWM_HOME` overridden).
 4. **Merge into user files, never clobber.** Always with a restorable backup.
 5. **Branch on capability, not on provider id.**
-6. **One implementation per concept.** Duplicated logic drifts, and the drift is the bug — four copies of a frontmatter parser produced four different failures.
+6. **One implementation per concept.** Duplicated logic drifts, and the drift is the bug — four copies of a frontmatter parser produced four different failures, and a fourth copy of the renderer→extension mapping outlived the collapse of the first three. This applies to **documentation too**: the provider paths in [`support-matrix.md`](support-matrix.md) are generated from `providers/index.ts` and locked by a test, because the hand-written copy had been wrong about Antigravity for several releases.
 7. **The deterministic gate outranks every judgement.** No review or lens overrides a red sensor.
 
 ---
@@ -160,4 +164,5 @@ Never run `npm publish` by hand, and never add a parallel publish workflow. CI g
 
 - [SDLC](sdlc.md) · [Installation](installation.md) · [Agent setup](agents-setup.md)
 - [CLI reference](cli-reference.md) · [Runbook](runbook.md)
+- [Support matrix](support-matrix.md) — what is supported, at what evidence level
 - [Acceptance playbooks](testing/README.md)

--- a/docs/sdlc.md
+++ b/docs/sdlc.md
@@ -151,6 +151,8 @@ There's a boundary here too: AWM's shipped sensor packs carry **generic** rules 
 
 ## Related
 
+- [Support matrix](support-matrix.md) — what is supported, at what evidence level, and what is missing
+
 - [Architecture](architecture.md) — components and data flow
 - [Product process](guides/product-process.md) · [Development process](guides/development-process.md)
 - [`CONSTITUTION.md`](../CONSTITUTION.md) — the authoritative rules and support matrix

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -102,6 +102,19 @@ Ninguna de estas es una tarea pendiente. Son límites del proveedor, no del prod
 
 **Node.js:** 22 o superior (declarado en `engines`). Versiones menores no están soportadas.
 
+### Capacidades por comando, donde el soporte NO es uniforme
+
+Casi todo el CLI se comporta igual en los cuatro sistemas. Estas son las excepciones, enunciadas para que nadie las descubra en una demo:
+
+| Capacidad | Linux / macOS / WSL | Windows nativo |
+|---|---|---|
+| `init` · `update` · `sync` · `add` · `remove` · `sensors` · `preflight` · `doctor` · `export` · `backup` · hooks | ✅ Verificado | ✅ Verificado (matriz de CI) |
+| Instalación por **symlink** (updates se propagan solos) | ✅ Verificado | ✅ Verificado vía *junction* para directorios. Para archivos requiere Modo Desarrollador; si no, cae a **copia** — funciona, pero `awm update` deja de propagar y hay que reinstalar. |
+| `awm watch` — supervisión y gate | ✅ Verificado | ✅ Verificado |
+| `awm watch` — **el wrapper sobrevive a la muerte del supervisor** | ✅ Verificado | ⚠ **Sin verificar.** En POSIX la garantía se sostiene con `detached: true` (sesión nueva, sobrevive un SIGKILL al padre). En win32, dos rondas reales de CI no encontraron una configuración de spawn que sostenga la misma garantía, así que el E2E de crash-recovery tiene alcance POSIX. Ver `cli/src/core/journal/process.ts`. |
+
+Esa última fila es la única capacidad del producto con un nivel distinto según el sistema operativo. No es una regresión pendiente: es un límite conocido, con el intento registrado.
+
 ### Advertencia de Windows que sí es real
 
 Crear un symlink de directorio en Windows requiere `SeCreateSymbolicLinkPrivilege`, denegado por defecto en cuentas sin privilegios. AWM usa **junctions** para directorios (no requieren privilegio) y cae a **copia** para archivos cuando el symlink falla. La consecuencia práctica: en el modo copia, `awm update` **no propaga** cambios del registry automáticamente — hay que volver a instalar. Está soportado y funciona; simplemente no es el mismo mecanismo.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,159 @@
+# Matriz de soporte
+
+**Qué soporta AWM, con qué nivel de evidencia, y qué no soporta todavía.**
+
+Este documento existe para que nadie tenga que inferir. Si una combinación no está acá, no está soportada. Si está marcada `⚠ sin verificar`, no se puede presentar como funcionando — se puede presentar como *implementado y pendiente de verificación*, que es una afirmación distinta y honesta.
+
+---
+
+## Los cuatro niveles
+
+Un solo vocabulario, usado igual en todas las tablas de abajo. La distinción entre los dos primeros es la que más se malinterpreta y la que más importa:
+
+| Nivel | Qué significa exactamente | Qué se puede afirmar en público |
+|---|---|---|
+| **✅ Verificado** | Implementado **y** ejercitado por una comprobación automática que corre en CI, o por un playbook ejecutado con resultado registrado. | "Funciona." |
+| **⚠ Sin verificar** | Implementado según la documentación del proveedor, pero **ninguna máquina lo ejecutó nunca** contra el binario real. | "Está implementado; falta verificarlo." Nunca "funciona". |
+| **⛔ No soportado** | Decisión deliberada, con una razón. No es un bug ni una tarea pendiente. | "No lo soportamos, y esta es la razón." |
+| **🔜 Planeado** | Reconocido como faltante. Es trabajo por hacer, con lo que falta enunciado. | "Todavía no." |
+
+> **Regla dura:** `BLOCKED` en un playbook (no pude correrlo) **nunca** se registra como verificado. Una combinación sin verificar es sin verificar; decir otra cosa es cómo una matriz de soporte empieza a mentir.
+
+---
+
+## Capacidades por proveedor
+
+Esta sección se **genera desde `cli/src/providers/index.ts`**. No se edita a mano.
+
+Existe generada porque la versión escrita a mano ya mintió: afirmaba que Antigravity instalaba en `~/.agents/skills` y `.agents/skills`, cuando el código dice `~/.gemini/antigravity/skills` y `.agent/skills` (singular), y omitía que es el único proveedor con `global_workflows`. Una tabla citada en una presentación y desalineada del código es peor que no tenerla.
+
+<!-- BEGIN GENERATED: provider-capabilities -->
+
+### Dónde aterriza cada artefacto
+
+| Agente | Tier | Skills (global) | Skills (proyecto) | Formato |
+|---|---|---|---|---|
+| `antigravity` | context-only | `~/.gemini/antigravity/skills` | `.agent/skills` | `link` |
+| `opencode` | config-managed | `~/.agents/skills` | `.agents/skills` | `link` |
+| `claude-code` | hooks-native | `~/.claude/skills` | `.claude/skills` | `link` |
+| `codex` | hooks-native | `~/.agents/skills` | `.agents/skills` | `link` |
+| `cursor` | agents-md-managed | `~/.cursor/rules` | `.cursor/rules` | `cursor-mdc` |
+| `copilot` | agents-md-managed | **no soportado** | `.github/instructions` | `copilot-instructions` |
+
+### Perfiles de agente, workflows, hooks y contexto
+
+| Agente | Perfiles de agente | Workflows | Hooks | Entrega de contexto | Versión mínima |
+|---|---|---|---|---|---|
+| `antigravity` | — (no aplica) | `~/.gemini/antigravity/global_workflows` | — (no tiene) | — (ninguna) | — (sin gate) |
+| `opencode` | `~/.config/opencode/agents` · `link` | — (no aplica) | — (no tiene) | `~/.config/opencode/opencode.json` → campo `instructions` | — (sin gate) |
+| `claude-code` | `~/.claude/agents` · `link` | — (no aplica) | `cc-settings-merge` | hook `SessionStart` | — (sin gate) |
+| `codex` | `~/.codex/agents` · `codex-agent-toml` | — (no aplica) | `codex-hooks-json` | `AGENTS.md` + `~/.codex/AGENTS.md` | 0.145.0 |
+| `cursor` | — (no aplica) | — (no aplica) | — (no tiene) | `AGENTS.md` del proyecto (sin equivalente global) | — (sin gate) |
+| `copilot` | — (no aplica) | — (no aplica) | — (no tiene) | `AGENTS.md` del proyecto (sin equivalente global) | — (sin gate) |
+
+> Generado desde `cli/src/providers/index.ts`. **No editar a mano** — `npm run docs:matrix` lo regenera y
+> `tests/structural/support-matrix-is-current.test.ts` falla si el documento y el código se separan.
+
+<!-- END GENERATED: provider-capabilities -->
+
+### Qué significa cada tier
+
+| Tier | Cargan las skills | Disparan los hooks | Las fases del proceso se **imponen** |
+|---|---|---|---|
+| `hooks-native` | sí | sí | sí — el harness re-ancla el contexto en cada sesión |
+| `config-managed` | sí | no | no — el contexto se entrega, la disciplina se lee |
+| `agents-md-managed` | sí (renderizadas) | no | no — ídem |
+| `context-only` | sí | no | no — sin mecanismo de entrega automática |
+
+La parte determinística —`awm sensors run`, su código de salida y el gate de calidad— es **idéntica en los seis**. Es un comando real con un exit code real: no depende de que el agente coopere. Lo que varía por tier es cuánto se re-ancla el *contexto*, no cuánto se verifica el *código*.
+
+---
+
+## Estado de soporte por proveedor
+
+| Proveedor | Instalación de artefactos | Entrega de contexto | Hooks | Evidencia |
+|---|---|---|---|---|
+| **Claude Code** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Suite + E2E aislado en CI (ubuntu, windows) |
+| **Codex** | ✅ Verificado | ✅ Verificado | ⚠ Sin verificar | Suite + `tests/integration/codex-provider-isolated`. La **transición de confianza del hook** requiere el binario real. |
+| **OpenCode** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El escritor de `opencode.json` está cubierto por tests; que OpenCode *lea* ese campo no fue observado. |
+| **Cursor** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El `.mdc` se genera y se valida su forma. Que Cursor **cargue** un `.mdc` con `alwaysApply: false` no fue observado. |
+| **Copilot** | ✅ Verificado (solo proyecto) | ⚠ Sin verificar | ⛔ No tiene | El `.instructions.md` se genera. Que Copilot **honre** `applyTo: "**"` no fue observado. |
+| **Antigravity** | ✅ Verificado | ⛔ No tiene mecanismo | ⛔ No tiene | Que Antigravity **lea** `global_workflows/` no fue observado. |
+
+### Las decisiones ⛔, con su razón
+
+Ninguna de estas es una tarea pendiente. Son límites del proveedor, no del producto:
+
+- **Copilot no tiene scope global.** GitHub Copilot no expone ningún mecanismo de descubrimiento de skills a nivel usuario. Las skills van por proyecto. `awm add -a copilot --scope global` **debe fallar nombrando esa razón**; un stack trace genérico ahí es un bug.
+- **Cursor no tiene archivo de contexto global.** Sus "User Rules" viven dentro de la configuración de la app, no en un archivo en disco. AWM **no inventa una ruta**: declara `null` y lo reporta como N/A, no como error.
+- **Antigravity no tiene mecanismo de entrega de contexto.** Ni hooks ni archivo de instrucciones. Recibe artefactos; la disciplina de proceso se lee, no se impone.
+- **OpenCode, Cursor, Copilot y Antigravity no tienen hooks.** No existe el mecanismo en esos productos. `awm doctor` **no emite fila de hook** para ellos — un ✖ ahí sería una falsa alarma con un remedio imposible.
+
+---
+
+## Estado de soporte por sistema operativo
+
+| Sistema | Nivel | Evidencia |
+|---|---|---|
+| **Linux** | ✅ Verificado | Matriz de CI en cada PR (`ubuntu-latest`), suite completa |
+| **Windows** | ✅ Verificado | Matriz de CI en cada PR (`windows-latest`), suite completa. Cubre junctions, PATHEXT y separadores. |
+| **macOS** | ⚠ Sin verificar | Ninguna máquina macOS ejecutó nada. Nada es específico de macOS en el código, pero eso es un argumento, no evidencia. |
+| **WSL** | ⚠ Sin verificar | Se comporta como Linux por diseño; sin ejecución registrada. Ver la advertencia de rutas cruzadas en [os-matrix](testing/os-matrix.md). |
+
+**Node.js:** 22 o superior (declarado en `engines`). Versiones menores no están soportadas.
+
+### Advertencia de Windows que sí es real
+
+Crear un symlink de directorio en Windows requiere `SeCreateSymbolicLinkPrivilege`, denegado por defecto en cuentas sin privilegios. AWM usa **junctions** para directorios (no requieren privilegio) y cae a **copia** para archivos cuando el symlink falla. La consecuencia práctica: en el modo copia, `awm update` **no propaga** cambios del registry automáticamente — hay que volver a instalar. Está soportado y funciona; simplemente no es el mismo mecanismo.
+
+---
+
+## Registries de contenido
+
+| Registry | Nivel | Rol |
+|---|---|---|
+| `awm-baseline-registry` | ✅ Verificado | Sembrado por defecto en `awm init` |
+| `awm-documentation-registry` | ⚠ Sin verificar | Opt-in vía `awm registry add` |
+| Registries propios de un equipo | ✅ Verificado | Cualquier repo git con el layout de contenido. Ver [runbook](runbook.md). |
+| Hosts de git | ✅ Verificado | Agnóstico al host (GitHub, GitLab, self-hosted): se resuelve por URL de git, sin API del proveedor. |
+
+## Packs de sensores
+
+| Pack | Nivel | Herramientas |
+|---|---|---|
+| `js-ts` | ✅ Verificado | tsc, eslint, semgrep, tests |
+| `python` | ⚠ Sin verificar | mypy, ruff |
+| `shell` | ⚠ Sin verificar | shellcheck |
+| `generic` | ✅ Verificado | semgrep |
+
+Un pack ausente del registry instalado **no se inventa**: `awm sensors init` cae a un pack que sí exista, nombra el que falta, y `awm preflight` falla mientras el gate esté vacío.
+
+---
+
+## 🔜 Lo que falta desarrollar
+
+Enunciado como trabajo, no como defecto. Esto es lo que hay que construir para subir de nivel algo que hoy está en ⚠ o para ampliar el alcance:
+
+| # | Falta | Por qué importa | Qué destraba |
+|---|---|---|---|
+| 1 | **CI con binarios de agente reales** | Es la única razón por la que Cursor, Copilot, OpenCode y Antigravity siguen en ⚠. Ninguna cantidad de tests unitarios la sustituye. | Sube 4 proveedores de ⚠ a ✅ |
+| 2 | **macOS en la matriz de CI** | Un tercio de los desarrolladores; hoy no hay una sola ejecución registrada. | Sube macOS a ✅ |
+| 3 | **Verificación de integridad de contenido en artefactos renderizados** | Para `.mdc` / `.instructions.md` el diagnóstico comprueba que el archivo *existe y tiene la extensión correcta*, no que su contenido esté intacto. Un archivo correcto por fuera y corrupto por dentro pasa. | Cierra un hueco conocido en `skills.global` |
+| 4 | **Reconciliación de scope de proyecto en `awm update`** | `update` reconcilia artefactos de máquina; los de proyecto son trabajo de `awm sync`. Un proyecto sin `sync` queda desactualizado en silencio. | Elimina un paso manual |
+| 5 | **Pruebas de los packs `python` y `shell` contra proyectos reales** | Existen y están completos; nadie los corrió contra un repo Python o de shell de verdad. | Sube 2 packs a ✅ |
+| 6 | **Un séptimo proveedor** | El modelo de capacidades ya lo soporta como una edición localizada (tabla de renderers + entrada de provider). No hay ninguno pedido todavía. | Amplía la cobertura |
+
+---
+
+## Cómo verificar todo esto vos mismo
+
+Nada de esta matriz pide que confíes en ella. Cada afirmación tiene una forma de comprobarse:
+
+| Afirmación | Cómo la comprobás |
+|---|---|
+| Las capacidades por proveedor | `npm run docs:matrix` — si el documento cambia, el documento estaba mal |
+| Que la tabla no puede quedar desalineada | `npx jest tests/structural/support-matrix-is-current` |
+| Linux y Windows | La matriz de CI de cualquier PR |
+| Todo lo demás | Los playbooks: [core-acceptance](testing/core-acceptance.md), [os-matrix](testing/os-matrix.md), [agent-matrix](testing/agent-matrix.md) |
+
+Los playbooks están escritos para que los corras vos **o para que se los pases a un agente y los corra él**. Piden `--json` y aserciones sobre campos parseados y códigos de salida, no sobre texto legible.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -12,7 +12,8 @@ There are 4 OS targets and 6 agents. A document per combination would be 24 file
 |---|---|
 | **[core-acceptance.md](core-acceptance.md)** | The suite that must pass identically everywhere — install, init, add, sync, update, sensors, preflight, doctor, export, backup, remove. ~80% of the value. |
 | **[os-matrix.md](os-matrix.md)** | Only what differs per OS: symlink permissions on Windows, path separators, WSL, macOS specifics. |
-| **[agent-matrix.md](agent-matrix.md)** | Only what differs per agent: where artifacts land, and — critically — **what is supposed to degrade**, so a tester doesn't file a bug against a documented tier limitation. |
+| **[agent-matrix.md](agent-matrix.md)** | Only what differs per agent: what to check, and — critically — **what is supposed to degrade**, so a tester doesn't file a bug against a documented tier limitation. |
+| **[../support-matrix.md](../support-matrix.md)** | Not a playbook — the reference these results feed. Says what is supported at what evidence level, and where the install paths actually are (generated from source, locked by a test). Read it before recording a result, and update it after. |
 
 Run **core-acceptance** first. Then the OS section for your machine, then the agent section for each agent you use.
 

--- a/docs/testing/agent-matrix.md
+++ b/docs/testing/agent-matrix.md
@@ -6,18 +6,20 @@ Each agent gets a different amount of AWM. That is a property of the target agen
 
 ## Where artifacts land
 
-Verified against `cli/src/providers/index.ts`.
+**This table used to live here and it was wrong** — it claimed Antigravity installed to
+`~/.agents/skills` and `.agents/skills` when the code says `~/.gemini/antigravity/skills`
+and `.agent/skills` (singular), and it never mentioned that Antigravity is the only
+provider with `global_workflows`. A hand-written copy of a fact the code already owns
+drifts, and this one drifted silently for releases.
 
-| Agent | Skills (global) | Skills (project) | Rendered as | Context injection |
-|---|---|---|---|---|
-| `claude-code` | `~/.claude/skills/` | `.claude/skills/` | symlink | `~/.claude/settings.json` (hook) |
-| `codex` | `~/.agents/skills/` | `.agents/skills/` | symlink | managed `AGENTS.md` (+ `~/.codex/AGENTS.md`) |
-| `opencode` | `~/.agents/skills/` | `.agents/skills/` | symlink | `~/.config/opencode/opencode.json` |
-| `cursor` | `~/.cursor/rules/` | `.cursor/rules/` | `.mdc` file | managed `AGENTS.md` (project only) |
-| `copilot` | **not supported** | `.github/instructions/` | `.instructions.md` | managed `AGENTS.md` (project only) |
-| `antigravity` | `~/.agents/skills/` | `.agents/skills/` | symlink | none |
+It now lives **generated from `cli/src/providers/index.ts`**, in
+**[docs/support-matrix.md](../support-matrix.md)**, locked by
+`tests/structural/support-matrix-is-current.test.ts` so it cannot drift again. Read the
+paths there; this document only covers what to *check*.
 
-`copilot` has no global scope on purpose: GitHub Copilot has no user-level skill-discovery mechanism, so skills must be installed per project. `awm add -a copilot --scope global` must fail with **that explanation**, not a generic error.
+`copilot` has no global scope on purpose: GitHub Copilot has no user-level
+skill-discovery mechanism, so skills must be installed per project. `awm add -a copilot
+--scope global` must fail with **that explanation**, not a generic error.
 
 ## What each tier gives you
 


### PR DESCRIPTION
La documentación ya estaba escrita. Auditarla contra el código encontró que **mentía**.

## El hallazgo

La tabla de rutas por proveedor, escrita a mano y duplicada en dos documentos, estaba equivocada:

| Decía | Es |
|---|---|
| Antigravity → `~/.agents/skills/` | `~/.gemini/antigravity/skills` |
| Antigravity proyecto → `.agents/skills/` | `.agent/skills` (**singular**) |
| "codex, opencode y antigravity comparten `~/.agents/skills`" | Antigravity **no** lo comparte |
| (sin mención) | Antigravity es el único con `global_workflows` |

Estuvo mal durante varias releases. Nadie lo notó porque nada obligaba a mirarlo: la tabla se escribió una vez y el código siguió cambiando. Son las páginas que se citan en una presentación y sobre las que se planifica.

## Corregirla no alcanzaba

Dejaba intacto el mecanismo que la rompió. Las rutas ya no se escriben a mano en ningún documento:

- `cli/scripts/support-matrix.ts` las genera desde `providers/index.ts` hacia un bloque delimitado por marcadores
- `npm run docs:matrix` regenera
- `tests/structural/support-matrix-is-current.test.ts` regenera y compara — un cambio de provider que no llegue al doc pone la CI en rojo

Verificado como corresponde una guarda estructural: reintroduciendo el error histórico exacto (`.agent/skills` → `.agents/skills`) y confirmando que falla. Un test que no se vio fallar no es una guarda.

El generador tomaba el home por parámetro mientras `providers()` lo resolvía del entorno — dos fuentes para el mismo dato, exactamente el patrón que este ciclo viene cerrando. Ahora ambos salen de `homeDir()`, así que la tabla es idéntica en cualquier máquina que la regenere.

## `docs/support-matrix.md`

Cuatro niveles, y la distinción que importa es entre los dos primeros:

- **✅ Verificado** — una máquina lo ejecutó. Se puede afirmar "funciona".
- **⚠ Sin verificar** — implementado, pero ningún binario real lo ejecutó nunca. Se puede afirmar "está implementado, falta verificarlo". Nunca "funciona".
- **⛔ No soportado** — decisión deliberada, con su razón. No es deuda.
- **🔜 Planeado** — falta, con lo que falta enunciado.

Con eso, la entrega de contexto de Cursor, Copilot y OpenCode queda en ⚠ en vez de leerse como funcionando; macOS y WSL también; los packs `python` y `shell` también. Cada ⛔ lleva su razón (por qué Copilot no tiene scope global, por qué Cursor no tiene archivo de contexto global). Y cierra con 6 ítems de **lo que falta desarrollar**, cada uno con qué destraba — el primero, CI con binarios de agente reales, sube cuatro proveedores de ⚠ a ✅ por sí solo.

## Un límite que faltaba declarar

`docs/installation.md` ya documentaba que la garantía de crash-recovery de `awm watch` no se sostiene en Windows nativo: en POSIX descansa en `detached: true`, y dos rondas reales de CI no encontraron una configuración de spawn win32 que la sostenga, así que el E2E tiene alcance POSIX. Eso no estaba en la matriz — el documento que pretende ser la respuesta completa. Ahora es su propia fila, y es la **única** capacidad del producto cuyo nivel difiere según el sistema operativo.

## Arquitectura alineada con los arreglos del ciclo

`docs/architecture.md` describía el comportamiento previo en dos puntos: installs como una transacción por bundle, y sensores sin decir que `sensors run` es de solo lectura. Ambos corregidos. Su invariante "una implementación por concepto" incorpora el caso de la documentación, que es justo donde se estaba violando.

## Verificación

- 173 suites / 1706 tests en verde; `tsc --noEmit` limpio.
- Chequeo de links sobre los 18 documentos no-plan: todos los internos resuelven.
- La guarda de la matriz, probada por reintroducción del error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_