### PR TITLE
test: one suite-wide timeout instead of twenty-four per-file ones

### DIFF
--- a/cli/jest.config.js
+++ b/cli/jest.config.js
@@ -2,5 +2,19 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.ts'],
-  setupFiles: ['<rootDir>/jest.setup.js']
+  setupFiles: ['<rootDir>/jest.setup.js'],
+  // El default de jest son 5s, pensado para tests puros. Esta suite no lo es: 24
+  // archivos clonan repos git de verdad, spawnean procesos y consultan si un pid sigue
+  // vivo — y en Windows cada una de esas consultas spawnea `tasklist`, cientos de ms
+  // bajo carga. Con 5s quedaban justo en el borde: verde varias corridas y timeout la
+  // siguiente, sin que cambiara una linea. Paso dos veces en un mismo dia, en
+  // `watch/runner` y en `core/profile-pins`, y la segunda publico a npm con la matriz
+  // en rojo.
+  //
+  // Un presupuesto por archivo hubiera sido arreglar 24 sitios y dejar la clase abierta
+  // para el proximo test que haga I/O real. Esto la cierra de una vez, incluidos los
+  // que todavia no existen. No afloja nada: un test colgado sigue fallando, solo que
+  // a los 30s en vez de a los 5. Los archivos que ya declaran su propio presupuesto
+  // (60s, 180s) lo conservan — el override por archivo gana.
+  testTimeout: 30000,
 };

--- a/cli/tests/commands/watch/runner.test.ts
+++ b/cli/tests/commands/watch/runner.test.ts
@@ -8,7 +8,8 @@ import { logsDir } from '../../../src/core/journal/paths';
 import { Job } from '../../../src/core/journal/types';
 import { argvDigest } from '../../../src/core/journal/process';
 
-// Presupuesto explicito, como sus tres hermanos de `tests/commands/watch/`
+// Presupuesto explicito POR ENCIMA del global (30s en jest.config.js), como sus tres
+// hermanos de `tests/commands/watch/`
 // (integration 30s, supervisor-loop 60s, e2e-crash 180s). Este archivo era el unico de
 // la familia sin uno, y hace el mismo trabajo que ellos: cada `collectAndReconcile`
 // consulta si el proceso sigue vivo, y en Windows eso spawnea `tasklist` — cientos de ms


### PR DESCRIPTION
**`main` quedó en rojo** después del merge de #41: Windows falló en `core/profile-pins.test.ts`, que clona repos git de verdad. Misma forma que `watch/runner.test.ts` dos commits antes — que arreglé **solo dentro de su familia** y no barrí para el resto. Arreglar sitios y dejar la clase abierta es el error que esta sesión viene nombrando.

## La clase

24 archivos de test clonan repositorios, spawnean procesos o preguntan si un pid sigue vivo. En Windows cada consulta de vida spawnea `tasklist` — cientos de ms bajo carga. Contra el default de 5s de jest quedaban justo en el borde: verde varias corridas y timeout la siguiente, sin que cambiara una línea de código.

`testTimeout: 30000` en `jest.config.js` la cierra en un solo lugar, **incluidos los tests que todavía no existen**. No afloja nada: un test colgado sigue fallando, solo que a los 30s en vez de a los 5. Los archivos que ya declaran un presupuesto mayor (60s, 180s) lo conservan.

Veinticuatro `jest.setTimeout` habrían sido veinticuatro sitios y la clase seguiría abierta para el próximo test que haga I/O real.

## Un hallazgo que no arreglo acá, porque es tuyo decidirlo

**Este fallo publicó a npm.** `release.yml` corre sus propios tests en `ubuntu-latest` y **no depende de la matriz `ci`**, así que un fallo exclusivo de Windows o macOS igual llega a npm. La v3.13.7 salió con la matriz en rojo.

El artefacto publicado está bien — el fallo era un timeout de test, no un defecto de producto. Pero el gate no hace lo que `CLAUDE.md` afirma que hace ("CI gates the release on the tests passing"): lo hace **para una plataforma**.

Opciones, de menor a mayor cambio:

1. **Dejarlo como está** y corregir la afirmación en `CLAUDE.md` para que diga "sobre Linux". Honesto, cero riesgo, pero acepta que un bug solo-Windows pueda publicarse.
2. **Meter la matriz dentro de `release.yml`** — el release espera a los tres sistemas. Es el gate que la doc ya promete.
3. **`workflow_run`**: que release se dispare al completar `ci` con éxito. Más limpio conceptualmente, pero es el que más riesgo tiene de dejar de publicar si queda mal configurado.

Mi recomendación es la **2**: es lo que la documentación ya dice, y el costo es tiempo de CI, no complejidad. No la implementé porque tocar el pipeline de release mal configurado puede dejar de publicar, y eso amerita tu decisión explícita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_