### PR TITLE
fix(doctor): stop writing, and document the JSON shape it actually emits

### DIFF
--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -5,7 +5,9 @@ import { gatherContext } from '../core/diagnostics/context';
 import { computeProviderOverall } from '../core/diagnostics/checks';
 import { CheckReport, CheckResult, ProviderCheck, ProviderCheckState, ProviderDiagnosticReport } from '../core/diagnostics/types';
 import { platformLabel, isWindowsNative, WINDOWS_KNOWN_GAP } from '../core/paths';
-import { getPreferences } from '../utils/config';
+// `readPreferences`, no `getPreferences`: este comando esta documentado como
+// read-only y el segundo auto-vivifica el archivo. Ver la nota en config.ts.
+import { readPreferences } from '../utils/config';
 import { resolveAgentTargets } from '../core/agent-targets';
 
 function glyph(status: CheckResult['status']): string {
@@ -132,7 +134,7 @@ export function runDoctor(opts: RunDoctorOptions = {}): number {
     // internal-error catch further down.
     let targets: ReturnType<typeof resolveAgentTargets>;
     try {
-        const prefs = getPreferences();
+        const prefs = readPreferences();
         targets = resolveTargets({ prefs, explicit: opts.agent });
     } catch (err) {
         process.stderr.write(`awm doctor: ${(err as Error).message}\n`);

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -104,6 +104,29 @@ function normalizePreferences(
     };
 }
 
+/**
+ * Las preferencias TAL COMO ESTAN, sin escribir nada. Devuelve los defaults en memoria
+ * cuando el archivo no existe todavia.
+ *
+ * `getPreferences` auto-vivifica: si no hay archivo, lo crea con los defaults. Eso esta
+ * bien para un comando que va a configurar la maquina, y esta mal para uno que solo
+ * mira. `awm doctor` —documentado como «Read-only dashboard. Changes nothing.»— lo
+ * llamaba, asi que en una maquina limpia el comando de inspeccion dejaba un
+ * `preferences.json` con `claude-code` como agente por defecto, que despues se lee como
+ * «el usuario configuro esto» cuando no lo hizo. Lo encontro el playbook de aceptacion,
+ * no la suite: ningun test preguntaba si un comando de lectura escribia.
+ *
+ * Se midieron los otros siete comandos de inspeccion (`list`, `preflight`, `sensors
+ * status`, `context-budget`, `backup list`, `ledger list`, `registry status`): todos
+ * limpios. `doctor` era el unico.
+ */
+export function readPreferences(): AwmPreferences {
+    const loaded = loadPreferences();
+    return loaded.exists
+        ? loaded.prefs
+        : { ...DEFAULT_PREFS, enabledAgents: [...DEFAULT_PREFS.enabledAgents] };
+}
+
 export function getPreferences(): AwmPreferences {
     const loaded = loadPreferences();
     if (!loaded.exists) {

--- a/cli/tests/commands/doctor-is-read-only.test.ts
+++ b/cli/tests/commands/doctor-is-read-only.test.ts
@@ -1,0 +1,98 @@
+// `awm doctor` está documentado como «Read-only dashboard of machine + project harness
+// state. **Changes nothing.**» — y escribía.
+//
+// `getPreferences()` auto-vivifica `preferences.json` con los defaults cuando el archivo
+// no existe (`config.ts`: `if (!loaded.exists) savePreferences(DEFAULT_PREFS)`). Un
+// getter con efecto de escritura escondido adentro. `doctor` lo llamaba para resolver a
+// qué agentes mirar, así que en una máquina limpia el comando de inspección dejaba un
+// `preferences.json` con `claude-code` como agente por defecto — que después se lee como
+// «el usuario configuró esto» cuando no lo hizo.
+//
+// Lo encontró el playbook de aceptación en su segundo check, no la suite: ningún test
+// preguntaba si un comando de lectura escribía. Se midieron los otros siete comandos de
+// inspección (`list`, `preflight`, `sensors status`, `context-budget`, `backup list`,
+// `ledger list`, `registry status`) y todos estaban limpios — así que acá el sitio ES la
+// clase, con medición en vez de suposición.
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+describe('awm doctor no escribe nada', () => {
+    let home: string;
+    let projectRoot: string;
+    let saved: { HOME?: string; AWM_HOME?: string };
+    let writeSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'awm-doctor-ro-')));
+        saved = { HOME: process.env.HOME, AWM_HOME: process.env.AWM_HOME };
+        process.env.HOME = home;
+        process.env.AWM_HOME = path.join(home, '.awm');
+        projectRoot = path.join(home, 'proj');
+        fs.mkdirSync(path.join(projectRoot, '.git'), { recursive: true });
+        jest.resetModules();
+        writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+        writeSpy.mockRestore();
+        if (saved.HOME === undefined) delete process.env.HOME; else process.env.HOME = saved.HOME;
+        if (saved.AWM_HOME === undefined) delete process.env.AWM_HOME; else process.env.AWM_HOME = saved.AWM_HOME;
+        fs.rmSync(home, { recursive: true, force: true });
+    });
+
+    /** Todo lo que exista bajo `home`, para comparar el antes y el después. */
+    const treeOf = (dir: string): string[] => {
+        const out: string[] = [];
+        const walk = (sub: string) => {
+            for (const e of fs.readdirSync(path.join(dir, sub), { withFileTypes: true })) {
+                const rel = path.join(sub, e.name);
+                out.push(rel);
+                if (e.isDirectory()) walk(rel);
+            }
+        };
+        walk('.');
+        return out.sort();
+    };
+
+    it('no crea AWM_HOME ni preferences.json en una máquina limpia', () => {
+        const { runDoctor } = require('../../src/commands/doctor');
+        const before = treeOf(home);
+
+        runDoctor({ cwd: projectRoot, json: true });
+
+        expect(fs.existsSync(path.join(home, '.awm', 'preferences.json'))).toBe(false);
+        expect(treeOf(home)).toEqual(before);
+    });
+
+    it('tampoco escribe cuando ya hay preferencias', () => {
+        // El otro camino de `getPreferences`: el archivo existe. `migrationRequired`
+        // podía reescribirlo — sigue siendo una escritura desde un comando de lectura.
+        fs.mkdirSync(path.join(home, '.awm'), { recursive: true });
+        const prefsPath = path.join(home, '.awm', 'preferences.json');
+        fs.writeFileSync(prefsPath, JSON.stringify({
+            enabledAgents: ['claude-code'], defaultAgent: 'claude-code',
+            installMethod: 'symlink', defaultScope: 'global',
+        }));
+        const before = fs.readFileSync(prefsPath, 'utf-8');
+        const beforeTree = treeOf(home);
+
+        const { runDoctor } = require('../../src/commands/doctor');
+        runDoctor({ cwd: projectRoot, json: true });
+
+        expect(fs.readFileSync(prefsPath, 'utf-8')).toBe(before);
+        expect(treeOf(home)).toEqual(beforeTree);
+    });
+
+    it('sigue reportando sobre el agente por defecto sin archivo de preferencias', () => {
+        // No alcanza con no escribir: tiene que seguir funcionando. Sin preferencias,
+        // los defaults en memoria son la respuesta correcta.
+        const { runDoctor } = require('../../src/commands/doctor');
+
+        const code = runDoctor({ cwd: projectRoot, json: true });
+
+        expect([0, 1]).toContain(code);   // 0 sano / 1 degradado, nunca 2 (error)
+        const emitted = writeSpy.mock.calls.map((c) => String(c[0])).join('');
+        expect(JSON.parse(emitted).providers.map((p: { id: string }) => p.id)).toEqual(['claude-code']);
+    });
+});

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -54,7 +54,9 @@ Read-only dashboard of machine + project harness state. Changes nothing.
 awm doctor [--json]
 ```
 
-Glyphs: `✔` healthy · `⚠` advisory (does not degrade) · `✖` missing (degrades state). Each non-healthy row carries a remedy — a command (`→ awm …`) or a skill to ask the agent to run (`→ skill: …`). `--json` emits the structured `CheckReport`.
+Glyphs: `✔` healthy · `⚠` advisory (does not degrade) · `✖` missing (degrades state). Each non-healthy row carries a remedy — a command (`→ awm …`) or a skill to ask the agent to run (`→ skill: …`). `--json` emits a `ProviderDiagnosticReport`: `{ providers: [...], overall }`, one entry
+per resolved agent with its `tier` and `checks`. If you are asserting on parsed fields,
+that is the shape — there is no top-level `results` array.
 
 A row that is **absent** means "nothing to verify", not "verified fine": a provider with no
 native-agent directory, or a registry that ships no `agents/`, emits no row rather than a


### PR DESCRIPTION
Los dos hallazgos del playbook de aceptación, encontrados en su **segundo check**. Ninguno lo tenía la suite: ningún test preguntaba si un comando de lectura escribe, y ninguno verificaba el tipo JSON documentado.

## 1 · `awm doctor` escribía

Documentado como *"Read-only dashboard. **Changes nothing.**"*, y creaba `$AWM_HOME/preferences.json` en una máquina limpia.

`getPreferences()` auto-viviifica el archivo con los defaults cuando no existe — **una escritura escondida dentro de un getter** — y `doctor` lo llamaba para resolver qué agentes inspeccionar.

No es cosmético: un comando de inspección dejaba un `preferences.json` diciendo que `claude-code` es el agente por defecto, que después se lee como *"el usuario configuró esto"* cuando no lo hizo.

`readPreferences()` devuelve lo que hay en disco, o los defaults en memoria, y nunca escribe.

**Los otros siete comandos de inspección se midieron, no se supusieron** — `list`, `preflight`, `sensors status`, `context-budget`, `backup list`, `ledger list`, `registry status`: todos ya estaban limpios. Acá el sitio sí es la clase, con evidencia.

## 2 · El tipo del `--json`

La referencia decía `CheckReport`. Emite `ProviderDiagnosticReport` (`{providers, overall}`). Importa justo para el público del playbook: un agente que asserta sobre `results` no encuentra nada.

## Verificación

Test nuevo con tres casos: no crea nada en una máquina limpia, no reescribe cuando ya hay preferencias, y **sigue funcionando** sin archivo (no alcanza con no escribir). Verificado en rojo contra el código viejo. Suite 175/1719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_