### PR TITLE
feat(remove): non-interactive mode, symmetric with add (D-006)

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -529,19 +529,44 @@ program.command('list [package]')
       outro(`Run ${pc.green('awm add')} to install artifacts.`);
   });
 
-program.command('remove')
-  .description('Remove an installed skill or workflow')
+// Simetrico con `add`: si se puede instalar scripteado, se tiene que poder desinstalar
+// scripteado. `remove` era interactivo puro — sin nombre posicional, sin `--scope`, sin
+// `--yes` — asi que cualquier limpieza automatizada quedaba bloqueada, y el playbook de
+// aceptacion (CORE-17) scripteaba `awm remove dev --yes`, una invocacion que nunca
+// existio. Tercera vez en esta sesion que un playbook se escribio contra lo que la doc
+// prometia y no contra el comportamiento. Ver docs/decisions.md, D-006.
+//
+// El nombre es de BUNDLE, igual que en `add` (D-001).
+program.command('remove [name]')
+  .description('Remove an installed bundle interactively, or non-interactively with flags')
   .option('-a, --agent <agent>', `Target agent(s), comma-separated: ${AGENT_TARGETS.join(', ')} (defaults to every enabled agent)`)
-  .action(async (options: { agent?: string }) => {
+  .option('-s, --scope <scope>', 'Scope: local or global (skips the prompt)')
+  .option('-y, --yes', 'Skip the confirmation prompt (requires a name)')
+  .action(async (name: string | undefined, options: { agent?: string; scope?: string; yes?: boolean }) => {
       intro(pc.bgCyan(pc.black(' AWM - Remove Artifact ')));
 
       const prefs = getPreferences();
+
+      // `--yes` sin nombre borraria lo que el usuario nunca eligio: un `rm -rf` silencioso
+      // sobre todo lo instalado. Se rechaza antes de tocar nada.
+      if (options.yes && !name) {
+          console.error(pc.red('--yes requires a bundle name: `awm remove <bundle> --yes`.'));
+          console.error(pc.dim('Without a name, removal stays interactive so you see what you are deleting.'));
+          process.exit(1);
+      }
 
       // Multi-agent selection (matching the add command flow). --agent skips
       // the interactive prompt and resolves the same way as add/sync/update/doctor (R12/R13).
       let targetAgents: AgentTarget[];
       if (options.agent) {
           targetAgents = resolveTargetsOrExit(prefs, options.agent);
+      } else if (options.yes) {
+          // `--yes` significa CERO prompts, no "cero confirmaciones". Sin esto, un
+          // `awm remove dev --yes` sin `--agent` seguia abriendo el multiselect de
+          // agentes y colgaba cualquier script — el flag prometia no-interactivo y no lo
+          // era. Sin `--agent`, el default son los agentes habilitados, igual que en
+          // `add`, `sync`, `update` y `doctor`.
+          targetAgents = [...prefs.enabledAgents];
       } else {
           const agentChoice = await multiselect({
               message: 'From which agent(s)?',
@@ -556,16 +581,25 @@ program.command('remove')
           targetAgents = agentChoice as AgentTarget[];
       }
 
-      const scopeChoice = await select({
-          message: 'Scope?',
-          options: [
-              { value: 'local', label: 'Project (Local)' },
-              { value: 'global', label: 'Global' }
-          ],
-          initialValue: prefs.defaultScope
-      });
-      handleCancel(scopeChoice);
-      const scopeVal = scopeChoice as Scope;
+      let scopeVal: Scope;
+      if (options.scope) {
+          if (options.scope !== 'local' && options.scope !== 'global') {
+              console.error(pc.red(`Invalid scope "${options.scope}". Use: local or global.`));
+              process.exit(1);
+          }
+          scopeVal = options.scope;
+      } else {
+          const scopeChoice = await select({
+              message: 'Scope?',
+              options: [
+                  { value: 'local', label: 'Project (Local)' },
+                  { value: 'global', label: 'Global' }
+              ],
+              initialValue: prefs.defaultScope
+          });
+          handleCancel(scopeChoice);
+          scopeVal = scopeChoice as Scope;
+      }
 
       // projectRoot explicito: `config.local` es relativo, y resolverlo contra
       // `process.cwd()` hacia que `awm remove` no encontrara nada desde un
@@ -591,18 +625,42 @@ program.command('remove')
           }
       );
 
-      const toRemove = await multiselect({
-          message: 'Select artifact(s) to remove',
-          options: groupedOpts,
-          required: true
-      });
-      handleCancel(toRemove);
-
-      const resolved = resolveSelectedArtifacts(toRemove as any[]) as typeof installed;
+      let resolved: typeof installed;
+      if (name) {
+          // Los artefactos del bundle pedido que estan REALMENTE instalados en este
+          // scope. Se cruza contra `installed`: lo que no esta instalado no se puede
+          // remover, y decirlo es mejor que borrar un subconjunto en silencio.
+          const bundle = discoverAllBundles().find((b) => b.name === name);
+          if (!bundle) {
+              console.error(pc.red(`Bundle "${name}" not found in registry.`));
+              console.error(pc.dim('Run `awm list` to see available packages.'));
+              process.exit(1);
+          }
+          const owned = new Set<string>([
+              ...bundle.skills.map((sk) => sk.name),
+              ...bundle.workflows,
+              ...bundle.agents,
+          ]);
+          resolved = installed.filter((a) => owned.has(a.name));
+          if (resolved.length === 0) {
+              outro(pc.yellow(`Nothing from "${name}" is installed at ${scopeVal} scope for the selected agent(s).`));
+              process.exit(0);
+          }
+      } else {
+          const toRemove = await multiselect({
+              message: 'Select artifact(s) to remove',
+              options: groupedOpts,
+              required: true
+          });
+          handleCancel(toRemove);
+          resolved = resolveSelectedArtifacts(toRemove as any[]) as typeof installed;
+      }
       const names = resolved.map(a => pc.red(a.name)).join(', ');
 
-      const confirmRemove = await confirm({ message: `Remove ${names}?` });
-      handleCancel(confirmRemove);
+      // `--yes` salta la confirmacion, nunca la seleccion: lo que se borra siempre sale
+      // de un nombre que el usuario escribio.
+      const confirmRemove = options.yes ? true : await confirm({ message: `Remove ${names}?` });
+      if (!options.yes) handleCancel(confirmRemove);
 
       if (confirmRemove) {
           try {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -104,7 +104,23 @@ awm list [package] [-a, --all]
 
 ### `awm remove`
 
-Interactively uninstall a skill or workflow — prompts for agent, scope, then removes the symlink/folder. (No non-interactive flags.)
+Remove an installed **bundle**. Interactive by default; the flags below make it scriptable.
+
+```
+awm remove [name] [-a <agent>] [-s <scope>] [-y]
+```
+
+| Flag | Description |
+|---|---|
+| `-a, --agent <agent>` | Target agent(s), comma-separated. Defaults to every enabled agent. |
+| `-s, --scope <scope>` | `local` or `global`. Skips the scope prompt. |
+| `-y, --yes` | Skip the confirmation. **Requires a name** — and implies fully non-interactive: no agent or scope prompt either. |
+
+`--yes` without a name is refused. Removal without a name stays interactive so you see
+what you are deleting; `--yes` skips the *confirmation*, never the *selection*.
+
+Removing what is not installed is not an error — it reports that nothing matched and
+exits `0`, so a cleanup script is safe to re-run.
 
 ### `awm sync`
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -11,6 +11,7 @@ Formato: qué se decidió, por qué, qué implica. Sin historia larga — eso vi
 | [D-003](#d-003) | 2026-08-09 | Cuatro niveles de evidencia, y `BLOCKED` nunca es `PASS` | Vigente |
 | [D-004](#d-004) | 2026-08-09 | macOS entra a la matriz de CI | Vigente |
 | [D-005](#d-005) | 2026-08-09 | El gate de release corre en las tres plataformas | Vigente |
+| [D-006](#d-006) | 2026-08-09 | `awm remove` tiene modo no interactivo, simétrico con `add` | Vigente |
 
 ---
 
@@ -76,3 +77,17 @@ El repo es público: los runners no cuestan minutos.
 - *`workflow_run`* — más limpio conceptualmente, pero es el que más riesgo tiene de dejar de publicar en silencio si queda mal configurado. La duplicación de la matriz entre `ci.yml` y `release.yml` es el precio, y es visible.
 
 **Costo:** el release espera a las tres plataformas (~5 min, lo que tarda Windows) en vez de ~2. Se paga una vez por merge a `main`.
+
+---
+
+## D-006
+
+**`awm remove` acepta `[name]`, `--scope` y `--yes`.** Simétrico con `add`: si se puede instalar scripteado, se tiene que poder desinstalar scripteado.
+
+Era interactivo puro. Una limpieza automatizada quedaba bloqueada, y el playbook (`CORE-17`) scripteaba `awm remove dev --yes` — una invocación que nunca existió. **Tercera vez en esta sesión** que un playbook se escribió contra lo que la doc prometía y no contra el comportamiento (las otras dos: `--type` en `add`, y `AG-03`).
+
+**Dos límites deliberados:**
+- **`--yes` sin nombre se rechaza.** Borraría lo que el usuario nunca eligió — un `rm -rf` silencioso sobre todo lo instalado. Sin nombre, la remoción sigue siendo interactiva: `--yes` salta la *confirmación*, nunca la *selección*.
+- **`--yes` implica cero prompts.** La primera versión seguía abriendo el multiselect de agentes sin `--agent`, así que el flag prometía no-interactivo y colgaba cualquier script. Sin `--agent`, el default son los agentes habilitados — igual que `add`, `sync`, `update` y `doctor`.
+
+El nombre es de **bundle**, por D-001. Remover lo que no está instalado no es error: reporta que nada coincidió y sale `0`, así que un script de limpieza es seguro de re-correr.


### PR DESCRIPTION
`CORE-17` del playbook scriptea `awm remove dev --yes`. Esa invocación **nunca existió**: `remove` no aceptaba nombre posicional, ni `--scope`, ni `--yes` — era interactivo puro.

**Tercera vez en esta sesión** que un playbook se escribió contra lo que la doc prometía y no contra el comportamiento (las otras: `--type` en `add`, y `AG-03`).

Se arregla haciendo que el comportamiento coincida, no el playbook: si un bundle se puede instalar scripteado, se tiene que poder desinstalar scripteado, o cualquier limpieza automatizada queda bloqueada. El nombre es de **bundle**, por D-001.

## Dos límites deliberados

**`--yes` sin nombre se rechaza.** Borraría lo que el usuario nunca eligió — un `rm -rf` silencioso sobre todo lo instalado. Sin nombre la remoción sigue interactiva: `--yes` salta la *confirmación*, nunca la *selección*.

**`--yes` implica cero prompts.** Mi primera versión seguía abriendo el multiselect de agentes cuando faltaba `--agent`, así que el flag prometía no-interactivo y colgaba cualquier script. Sin `--agent`, el default son los agentes habilitados — igual que `add`, `sync`, `update` y `doctor`.

## Verificación contra el binario compilado

| Caso | Resultado |
|---|---|
| `--yes` sin nombre | rechazado con explicación |
| bundle inexistente | `Bundle "x" not found in registry` |
| scope inválido | `Invalid scope "raro". Use: local or global.` |
| **CORE-17 real** | 23 skills → 0, exit 0 |
| re-correr sin nada instalado | lo reporta, exit 0 — seguro de repetir |

Suite 174/1716. `docs/decisions.md` D-006, `cli-reference` y `CORE-17` actualizados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_