### PR TITLE
fix(doctor): detect an AWM skill link replaced by third-party content

### DIFF
--- a/cli/src/core/diagnostics/context.ts
+++ b/cli/src/core/diagnostics/context.ts
@@ -11,7 +11,8 @@ import { InjectionState } from '../context/types';
 import { computeHookStatus } from '../../commands/hooks/status';
 import { findProjectRoot, readProfile } from '../profile';
 import { discoverAllBundles, resolveBundleSkills, resolveBundleAgents, BundleDefinition } from '../bundles';
-import { classifySkillLinks } from '../skill-integrity';
+import { classifySkillLinks, managedLinkTargets } from '../skill-integrity';
+import { ManagedArtifactRecord, readArtifactState } from '../artifact-state';
 import { awmHome } from '../paths';
 import { gatherProviderChecks, ScanSkills } from './provider-checks';
 
@@ -236,9 +237,16 @@ function gatherMachine(bundles: BundleDefinition[], agent: AgentTarget = 'claude
         ambient: { wanted, installed },
         contextInjection: gatherContextInjection(),
         globalSkills: skillsDir !== null
-            ? classifySkillLinks(skillsDir, contentRoots())
-            : { valid: [], repairable: [], dead: [] },
+            ? classifySkillLinks(skillsDir, contentRoots(), managedLinkTargets(safeReadArtifactState()))
+            : { valid: [], repairable: [], dead: [], usurped: [] },
     };
+}
+
+/** `readArtifactState` tira si el JSON esta roto — correcto para un comando que va a
+ *  ESCRIBIR sobre ese estado, inaceptable para uno que solo diagnostica. Aca degrada a
+ *  "sin ledger": se pierde la deteccion de usurpaciones, no el resto del reporte. */
+function safeReadArtifactState(): ManagedArtifactRecord[] {
+    try { return readArtifactState(); } catch { return []; }
 }
 
 function gatherProject(root: string, bundles: BundleDefinition[], agent: AgentTarget = 'claude-code'): ProjectFacts {
@@ -294,7 +302,12 @@ export function gatherContext(opts: GatherOptions = {}): HarnessContext {
     const agent = opts.agent ?? 'claude-code';
     const root = findProjectRoot(cwd);
     const agents = opts.agents ?? [agent];
-    const scanSkills = opts.scanSkills ?? ((dir: string) => classifySkillLinks(dir, contentRoots()));
+    // El ledger se lee UNA vez por corrida y se comparte con todos los dirs escaneados:
+    // es lo unico que distingue "el usuario puso este directorio" de "algo reemplazo
+    // nuestro symlink". Best-effort — un ledger ausente o corrupto degrada a "no puedo
+    // detectar usurpaciones", nunca revienta un comando de diagnostico.
+    const managed = managedLinkTargets(safeReadArtifactState());
+    const scanSkills = opts.scanSkills ?? ((dir: string) => classifySkillLinks(dir, contentRoots(), managed));
     return {
         machine: gatherMachine(bundles, agent, root ?? undefined),
         project: root ? gatherProject(root, bundles, agent) : null,

--- a/cli/src/core/diagnostics/provider-checks.ts
+++ b/cli/src/core/diagnostics/provider-checks.ts
@@ -106,13 +106,20 @@ function skillsGlobalCheck(
     }
     const shared = owners.length > 1;
     const broken = integrity.repairable.length + integrity.dead.length;
+    // Usurpado ≠ roto: el link no cuelga, DESAPARECIO — otro instalador dejo un
+    // directorio real con el mismo nombre encima. El agente carga esa skill, no la
+    // nuestra, y hasta que esto se reporto el scan solo miraba symlinks, asi que el
+    // caso era literalmente invisible y `overall` decia `healthy`. No se auto-repara:
+    // borrar un directorio real con contenido de un tercero es destructivo y necesita
+    // que lo pida una persona.
+    const usurped = integrity.usurped.length;
     // Broken links are checked BEFORE shared: 'shared' is a non-degrading/OK state
     // (see checks.ts's DEGRADING_PROVIDER_STATES), so if it were set unconditionally
     // for a shared dir it would silently mask real broken/dead symlinks — a green
     // checkmark next to "N broken links → repair-global-skills" would contradict its
     // own trailing text, and `overall` would never degrade despite real breakage.
     let state: ProviderCheckState;
-    if (broken > 0) {
+    if (broken > 0 || usurped > 0) {
         state = 'broken';
     } else if (shared) {
         state = 'shared';
@@ -126,8 +133,18 @@ function skillsGlobalCheck(
         state,
         target: dir,
         owners: shared ? owners : undefined,
-        detail: broken > 0 ? `${broken} broken links` : undefined,
-        remediationCode: broken > 0 ? 'repair-global-skills' : undefined,
+        detail: [
+            broken > 0 ? `${broken} broken links` : null,
+            usurped > 0
+                ? `${usurped} replaced by non-AWM content (${integrity.usurped.join(', ')})`
+                : null,
+        ].filter(Boolean).join('; ') || undefined,
+        // Una usurpacion NO la arregla `repair-global-skills` (solo toca symlinks
+        // colgantes), asi que ofrecer ese remedio seria mandar al usuario a un comando
+        // que no cambia nada. Reinstalar el bundle es lo que la resuelve.
+        remediationCode: usurped > 0
+            ? 'reinstall-usurped-skills'
+            : broken > 0 ? 'repair-global-skills' : undefined,
     };
 }
 
@@ -331,7 +348,8 @@ export function gatherProviderChecks(agents: AgentTarget[], scanSkills: ScanSkil
         const provider = providerFor(agent);
         const dir = provider.skill.global;
         const owners = (dir !== null ? ownersByDir.get(dir) : undefined) ?? [agent];
-        const integrity = (dir !== null ? scansByDir.get(dir) : undefined) ?? { valid: [], repairable: [], dead: [] };
+        const integrity = (dir !== null ? scansByDir.get(dir) : undefined)
+            ?? { valid: [], repairable: [], dead: [], usurped: [] };
 
         const checks: ProviderCheck[] = [
             binaryVersionCheck(agent),

--- a/cli/src/core/diagnostics/types.ts
+++ b/cli/src/core/diagnostics/types.ts
@@ -1,6 +1,7 @@
 // src/core/diagnostics/types.ts
 import { AgentTarget } from '../../providers';
 import { InjectionState } from '../context/types';
+import { SkillIntegrity } from '../skill-integrity';
 
 export type CheckLevel = 'machine' | 'project';
 export type CheckStatus = 'ok' | 'warn' | 'missing'; // ✔ / ⚠ / ✖
@@ -34,7 +35,13 @@ export interface MachineFacts {
     devCore: { present: boolean; brokenLinks: string[] };
     ambient: { wanted: string[]; installed: string[] };
     contextInjection: { agent: AgentTarget; state: InjectionState }[];
-    globalSkills: { valid: string[]; repairable: string[]; dead: string[] };
+    /** `SkillIntegrity` por referencia, no una copia estructural. Estaba escrito a mano
+     *  aca — `{ valid; repairable; dead }` — y como era un subconjunto exacto TypeScript
+     *  no se quejaba nunca, asi que al agregarle `usurped` al tipo real este campo quedo
+     *  atras en silencio y los llamadores no podian ni pasar el valor completo. Misma
+     *  clase de bug que la tabla de renderers duplicada: una copia de algo que el codigo
+     *  ya define en otro lado. */
+    globalSkills: SkillIntegrity;
 }
 
 export interface ProjectFacts {

--- a/cli/src/core/skill-integrity.ts
+++ b/cli/src/core/skill-integrity.ts
@@ -1,12 +1,17 @@
 import fs from 'fs';
 import path from 'path';
 import { AGENT_TARGETS, AgentTarget, providerFor } from '../providers';
+import { ManagedArtifactRecord } from './artifact-state';
 import { isWindowsNative } from './paths';
 
 export type SkillIntegrity = {
     valid: string[];
     repairable: string[];
     dead: string[];
+    /** Entradas que NO son symlinks pero que el ledger de artefactos declara como
+     *  targets gestionados por AWM: un tercero (otro instalador, el propio agente)
+     *  reemplazo nuestro link por contenido real suyo. Ver `managedLinkTargets`. */
+    usurped: string[];
 };
 
 export type RepairResult = {
@@ -23,12 +28,42 @@ function findRegistrySkillPath(registryContentDirs: string[], name: string): str
     return null;
 }
 
+/** Normaliza una ruta para comparar contra el ledger: absoluta siempre, y en
+ *  Windows tambien case-insensitive, porque NTFS lo es y el ledger guarda la
+ *  ruta con el casing que tuvo al instalarse, no el que tiene al leerse. */
+function pathKey(p: string): string {
+    const resolved = path.resolve(p);
+    return isWindowsNative() ? resolved.toLowerCase() : resolved;
+}
+
+/** Targets que el ledger de artefactos declara instalados con el renderer `link`,
+ *  normalizados con `pathKey` para comparar contra rutas del filesystem.
+ *
+ *  Solo `link`: para un renderer que produce archivos reales (`cursor-mdc`,
+ *  `copilot-instructions`) "no es un symlink" es lo esperado, no una usurpacion. */
+export function managedLinkTargets(records: ManagedArtifactRecord[]): Set<string> {
+    return new Set(
+        records.filter((r) => r.renderer === 'link').map((r) => pathKey(r.targetPath)),
+    );
+}
+
 /** Clasifica cada entrada de `skillsDir` (read-only, no muta nada).
  *  Agnostico al alcance: `skillsDir` es global (`provider.skill.global`) o de
  *  proyecto (`<projectRoot>/<provider.skill.local>`) — el nombre decia "Global" y
- *  eso basto para que nadie lo apuntara nunca a un dir de proyecto. */
-export function classifySkillLinks(skillsDir: string, registryContentDirs: string[]): SkillIntegrity {
-    const out: SkillIntegrity = { valid: [], repairable: [], dead: [] };
+ *  eso basto para que nadie lo apuntara nunca a un dir de proyecto.
+ *
+ *  `managedTargets` (opcional, ver `managedLinkTargets`) es lo que distingue
+ *  "un directorio que el usuario puso ahi" de "un directorio que reemplazo un
+ *  link nuestro". Sin el, el scan solo mira symlinks y una usurpacion es
+ *  literalmente invisible: `awm doctor` reporta `healthy` mientras el agente
+ *  carga la skill de otro. Por defecto vacio, para que los llamadores que no
+ *  tienen ledger a mano conserven el comportamiento anterior. */
+export function classifySkillLinks(
+    skillsDir: string,
+    registryContentDirs: string[],
+    managedTargets: ReadonlySet<string> = new Set(),
+): SkillIntegrity {
+    const out: SkillIntegrity = { valid: [], repairable: [], dead: [], usurped: [] };
     let entries: string[];
     try { entries = fs.readdirSync(skillsDir); }
     catch { return out; } // dir ausente → nada que clasificar
@@ -37,7 +72,12 @@ export function classifySkillLinks(skillsDir: string, registryContentDirs: strin
         const p = path.join(skillsDir, name);
         let lst: fs.Stats;
         try { lst = fs.lstatSync(p); } catch { continue; }
-        if (!lst.isSymbolicLink()) continue; // dirs/archivos reales no son nuestro problema
+        if (!lst.isSymbolicLink()) {
+            // Un dir/archivo real que puso el usuario no es nuestro problema. Uno
+            // que el ledger declara nuestro SI lo es — ahi hubo un reemplazo.
+            if (managedTargets.has(pathKey(p))) out.usurped.push(name);
+            continue;
+        }
         if (fs.existsSync(p)) { out.valid.push(name); continue; } // target vivo
         // symlink colgante → ¿reparable o muerto?
         if (findRegistrySkillPath(registryContentDirs, name)) out.repairable.push(name);

--- a/cli/tests/core/diagnostics/checks.test.ts
+++ b/cli/tests/core/diagnostics/checks.test.ts
@@ -2,6 +2,7 @@ import { runChecks, computeProviderOverall } from '../../../src/core/diagnostics
 import { HarnessContext, ProjectFacts, ProviderFacts } from '../../../src/core/diagnostics/types';
 import { AgentTarget } from '../../../src/providers';
 import { InjectionState } from '../../../src/core/context/types';
+import { SkillIntegrity } from '../../../src/core/skill-integrity';
 
 function healthyMachine(): HarnessContext['machine'] {
     return {
@@ -10,7 +11,7 @@ function healthyMachine(): HarnessContext['machine'] {
         devCore: { present: true, brokenLinks: [] },
         ambient: { wanted: [], installed: [] },
         contextInjection: [],
-        globalSkills: { valid: [], repairable: [], dead: [] },
+        globalSkills: { valid: [], repairable: [], dead: [], usurped: [] },
     };
 }
 
@@ -173,7 +174,7 @@ describe('runChecks — project', () => {
 });
 
 describe('machineChecks — global skill integrity', () => {
-    function machineCtx(globalSkills: { valid: string[]; repairable: string[]; dead: string[] }): HarnessContext {
+    function machineCtx(globalSkills: SkillIntegrity): HarnessContext {
         return {
             machine: {
                 registryCache: { present: true, gitState: 'clean' },
@@ -188,13 +189,13 @@ describe('machineChecks — global skill integrity', () => {
     }
 
     it('ok when no broken global skill links', () => {
-        const report = runChecks(machineCtx({ valid: ['a'], repairable: [], dead: [] }));
+        const report = runChecks(machineCtx({ valid: ['a'], repairable: [], dead: [], usurped: [] }));
         const row = report.results.find((r) => r.id === 'machine.globalSkills');
         expect(row?.status).toBe('ok');
     });
 
     it('warns with awm init remedy when there are broken links', () => {
-        const report = runChecks(machineCtx({ valid: ['a'], repairable: ['b'], dead: ['c'] }));
+        const report = runChecks(machineCtx({ valid: ['a'], repairable: ['b'], dead: ['c'], usurped: [] }));
         const row = report.results.find((r) => r.id === 'machine.globalSkills');
         expect(row?.status).toBe('warn');
         expect(row?.detail).toContain('2'); // 1 repairable + 1 dead

--- a/cli/tests/core/diagnostics/context.test.ts
+++ b/cli/tests/core/diagnostics/context.test.ts
@@ -250,7 +250,7 @@ describe('gatherContext — providers matrix (Task 9)', () => {
     });
 
     function healthySharedSkills() {
-        return { valid: ['development-process'], repairable: [], dead: [] };
+        return { valid: ['development-process'], repairable: [], dead: [], usurped: [] };
     }
 
     it('reports shared skills for both owners without scanning twice', () => {
@@ -265,7 +265,7 @@ describe('gatherContext — providers matrix (Task 9)', () => {
     });
 
     it('marks skills.global healthy (not shared) for a single unshared provider', () => {
-        const scan = jest.fn(() => ({ valid: [], repairable: [], dead: [] }));
+        const scan = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
         const { gatherContext } = require('../../../src/core/diagnostics/context');
         const report = gatherContext({ cwd: tmpHome, bundles: [], agents: ['claude-code'], scanSkills: scan });
         expect(scan).toHaveBeenCalledTimes(1);

--- a/cli/tests/core/diagnostics/provider-checks.test.ts
+++ b/cli/tests/core/diagnostics/provider-checks.test.ts
@@ -193,7 +193,7 @@ describe('gatherProviderChecks — shared skills.global does not mask broken lin
 
         // OpenCode and Codex share ~/.agents/skills (providers/index.ts). Stub the
         // scan to report 2 broken/dead links on that shared directory.
-        const scanSkills = jest.fn(() => ({ valid: ['ok-skill'], repairable: ['stale-skill'], dead: ['ghost-skill'] }));
+        const scanSkills = jest.fn(() => ({ valid: ['ok-skill'], repairable: ['stale-skill'], dead: ['ghost-skill'], usurped: [] }));
         const ctx = gatherContext({ cwd: tmpHome, bundles: [], agents: ['opencode', 'codex'], scanSkills });
 
         expect(scanSkills).toHaveBeenCalledTimes(1);
@@ -211,7 +211,7 @@ describe('gatherProviderChecks — shared skills.global does not mask broken lin
         const { gatherContext } = require('../../../src/core/diagnostics/context');
         const { computeProviderOverall } = require('../../../src/core/diagnostics/checks');
 
-        const scanSkills = jest.fn(() => ({ valid: ['ok-skill'], repairable: [], dead: [] }));
+        const scanSkills = jest.fn(() => ({ valid: ['ok-skill'], repairable: [], dead: [], usurped: [] }));
         const ctx = gatherContext({ cwd: tmpHome, bundles: [], agents: ['opencode', 'codex'], scanSkills });
 
         for (const provider of ctx.providers) {
@@ -260,7 +260,7 @@ describe('gatherProviderChecks — agents.native reports broken on a malformed C
         );
 
         const { gatherContext } = require('../../../src/core/diagnostics/context');
-        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [] }));
+        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
         const ctx = gatherContext({ cwd: tmpHome, bundles: [], agents: ['codex'], scanSkills });
 
         const codex = ctx.providers.find((p: { id: string }) => p.id === 'codex');

--- a/cli/tests/core/diagnostics/provider-tier.test.ts
+++ b/cli/tests/core/diagnostics/provider-tier.test.ts
@@ -55,7 +55,7 @@ describe('contextGlobalCheck — scope-aware (Task 4.4 / deferred Task 4.2 findi
     }
 
     function scanSkillsStub() {
-        return jest.fn(() => ({ valid: [], repairable: [], dead: [] }));
+        return jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
     }
 
     beforeEach(() => {
@@ -188,7 +188,7 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
         // classifySkillLinks only ever sees symlinks (`if (!lst.isSymbolicLink()) continue;`)
         // — a real scan over rulesDir would find nothing here either. Stubbed explicitly so the
         // test proves the FIX (renderer-gating), not an accident of what classifySkillLinks does.
-        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [] }));
+        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
         const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');
         const facts = gatherProviderChecks(['cursor'], scanSkills);
         const skillsCheck = facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');
@@ -236,7 +236,7 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
         const rulesDir = path.join(tmpHome, '.cursor/rules');
         expect(fs.existsSync(path.join(rulesDir, 'using-awm.mdc'))).toBe(true);
 
-        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [] }));
+        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
         const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');
         const facts = gatherProviderChecks(['cursor'], scanSkills);
         const skillsCheck = facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');
@@ -248,7 +248,7 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
     });
 
     it('non-link renderer with an empty/missing dir reports absent, not a false healthy', () => {
-        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [] }));
+        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
         const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');
         const facts = gatherProviderChecks(['cursor'], scanSkills);
         const skillsCheck = facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');
@@ -260,7 +260,7 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
         const skillsDir = path.join(tmpHome, '.claude/skills');
         fs.mkdirSync(skillsDir, { recursive: true });
 
-        const scanSkills = jest.fn(() => ({ valid: ['using-awm'], repairable: [], dead: [] }));
+        const scanSkills = jest.fn(() => ({ valid: ['using-awm'], repairable: [], dead: [], usurped: [] }));
         const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');
         const facts = gatherProviderChecks(['claude-code'], scanSkills);
         const skillsCheck = facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');
@@ -273,7 +273,7 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
         const skillsDir = path.join(tmpHome, '.claude/skills');
         fs.mkdirSync(skillsDir, { recursive: true });
 
-        const scanSkills = jest.fn(() => ({ valid: [], repairable: ['stale-skill'], dead: [] }));
+        const scanSkills = jest.fn(() => ({ valid: [], repairable: ['stale-skill'], dead: [], usurped: [] }));
         const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');
         const facts = gatherProviderChecks(['claude-code'], scanSkills);
         const skillsCheck = facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');
@@ -295,7 +295,7 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
             fs.writeFileSync(path.join(rulesDir, 'notes.txt'), 'my own notes, not an AWM rule');
             fs.mkdirSync(path.join(rulesDir, 'some-user-dir'));
 
-            const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [] }));
+            const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
             const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');
             const facts = gatherProviderChecks(['cursor'], scanSkills);
             const skillsCheck = facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');
@@ -312,7 +312,7 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
                 '---\ndescription: foo\nglobs:\nalwaysApply: false\n---\n\nBody.',
             );
 
-            const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [] }));
+            const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
             const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');
             const facts = gatherProviderChecks(['cursor'], scanSkills);
             const skillsCheck = facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');

--- a/cli/tests/core/init/steps-registry-sync.test.ts
+++ b/cli/tests/core/init/steps-registry-sync.test.ts
@@ -62,7 +62,7 @@ describe('stepCache — registry sync error results', () => {
                 devCore: { present: true, brokenLinks: [] },
                 ambient: { wanted: [], installed: [] },
                 contextInjection: [],
-                globalSkills: { valid: [], repairable: [], dead: [] },
+                globalSkills: { valid: [], repairable: [], dead: [], usurped: [] },
             },
             project: null,
         };

--- a/cli/tests/core/init/steps.test.ts
+++ b/cli/tests/core/init/steps.test.ts
@@ -27,7 +27,7 @@ function machine(): HarnessContext['machine'] {
         devCore: { present: true, brokenLinks: [] },
         ambient: { wanted: [], installed: [] },
         contextInjection: [],
-        globalSkills: { valid: [], repairable: [], dead: [] },
+        globalSkills: { valid: [], repairable: [], dead: [], usurped: [] },
     };
 }
 
@@ -435,7 +435,7 @@ describe('stepGlobalSkillsRepair', () => {
         const a = spies();
         (a as any).repairGlobalSkills = jest.fn(() => ({ relinked: ['b'], pruned: ['c'], failed: [] }));
         const m = machine();
-        m.globalSkills = { valid: ['a'], repairable: ['b'], dead: ['c'] };
+        m.globalSkills = { valid: ['a'], repairable: ['b'], dead: ['c'], usurped: [] };
         const r = stepGlobalSkillsRepair(deps({ machine: m, project: null }, a));
         expect(r.action).toBe('applied');
         expect(a.repairGlobalSkills).toHaveBeenCalledTimes(1);
@@ -447,7 +447,7 @@ describe('stepGlobalSkillsRepair', () => {
         const a = spies();
         (a as any).repairGlobalSkills = jest.fn(() => ({ relinked: ['b'], pruned: [], failed: [] }));
         const m = machine();
-        m.globalSkills = { valid: [], repairable: ['b'], dead: [] };
+        m.globalSkills = { valid: [], repairable: ['b'], dead: [], usurped: [] };
         const r = stepGlobalSkillsRepair(deps({ machine: m, project: null }, a, { agent: 'opencode' }));
         expect(r.action).toBe('applied');
         expect(a.repairGlobalSkills).toHaveBeenCalledWith(providerFor('opencode').skill.global, expect.any(Array));
@@ -459,7 +459,7 @@ describe('stepGlobalSkillsRepair', () => {
         const m = machine();
         // Broken-count is nonzero, so the ONLY thing that can make this skip is the
         // null-global-dir guard itself, not the "nothing broken" early return above.
-        m.globalSkills = { valid: [], repairable: ['b'], dead: ['c'] };
+        m.globalSkills = { valid: [], repairable: ['b'], dead: ['c'], usurped: [] };
         const r = stepGlobalSkillsRepair(deps({ machine: m, project: null }, a, { agent: 'copilot' }));
         expect(r.action).toBe('skipped');
         expect(a.repairGlobalSkills).not.toHaveBeenCalled();

--- a/cli/tests/core/skill-integrity.test.ts
+++ b/cli/tests/core/skill-integrity.test.ts
@@ -83,7 +83,7 @@ describe('classifySkillLinks', () => {
 
     it('returns empty arrays when the skills dir does not exist', () => {
         const result = classifySkillLinks('/nonexistent/dir', ['/also/nonexistent']);
-        expect(result).toEqual({ valid: [], repairable: [], dead: [] });
+        expect(result).toEqual({ valid: [], repairable: [], dead: [], usurped: [] });
     });
 });
 

--- a/cli/tests/core/usurped-skill-links.test.ts
+++ b/cli/tests/core/usurped-skill-links.test.ts
@@ -1,0 +1,138 @@
+// Un symlink gestionado por AWM que otro instalador reemplaza por un directorio real
+// era INVISIBLE para todo el sistema de diagnostico.
+//
+// Encontrado corriendo el playbook `agent-matrix` para `claude-code` contra el binario
+// publicado: `awm init` dejo `~/.claude/skills/mermaid-diagrams` como symlink al registry
+// baseline y lo anoto en `state/artifacts.json`; la primera sesion real de Claude Code
+// materializo su propia skill `mermaid-diagrams` (bundled, mismo nombre) encima, pisando
+// el symlink con un directorio real distinto — otra `description`, sin `version`, con un
+// README.md que la nuestra no tiene.
+//
+// Despues de eso:
+//   - `awm doctor -a claude-code` reportaba `skills.global: healthy`, `overall: healthy`,
+//     exit 0;
+//   - `awm sync` no lo tocaba;
+//   - el agente cargaba la skill del tercero, no la instalada.
+//
+// La causa es una sola linea de `classifySkillLinks`: `if (!lst.isSymbolicLink()) continue`.
+// Correcta para una skill que el usuario puso a mano — AWM no debe tocarla — y equivocada
+// cuando el ledger de artefactos dice que esa ruta exacta es nuestra. El clasificador nunca
+// consultaba el ledger, asi que no podia distinguir los dos casos.
+import fs from 'fs';
+import path from 'path';
+import { classifySkillLinks, managedLinkTargets } from '../../src/core/skill-integrity';
+import { ManagedArtifactRecord } from '../../src/core/artifact-state';
+import { mkCanonicalTmpDir } from '../support/tmp';
+
+describe('a managed skill link replaced by third-party content is detected', () => {
+    let registry: string;
+    let skillsDir: string;
+    const made: string[] = [];
+
+    const record = (targetPath: string, renderer: ManagedArtifactRecord['renderer'] = 'link'): ManagedArtifactRecord => ({
+        name: path.basename(targetPath),
+        type: 'skill',
+        scope: 'global',
+        targetPath,
+        sourcePath: path.join(registry, 'skills', path.basename(targetPath)),
+        renderer,
+        owners: ['claude-code'],
+    });
+
+    beforeEach(() => {
+        registry = mkCanonicalTmpDir('awm-usurp-reg-');
+        skillsDir = mkCanonicalTmpDir('awm-usurp-skills-');
+        made.push(registry, skillsDir);
+        fs.mkdirSync(path.join(registry, 'skills', 'mermaid-diagrams'), { recursive: true });
+        fs.writeFileSync(path.join(registry, 'skills', 'mermaid-diagrams', 'SKILL.md'), '# awm\n');
+    });
+
+    afterAll(() => { for (const d of made) fs.rmSync(d, { recursive: true, force: true }); });
+
+    /** Lo que hace el tercero: borra nuestro symlink y deja su propio directorio. */
+    function usurp(name: string): string {
+        const p = path.join(skillsDir, name);
+        fs.rmSync(p, { recursive: true, force: true });
+        fs.mkdirSync(p, { recursive: true });
+        fs.writeFileSync(path.join(p, 'SKILL.md'), '# someone else\n');
+        return p;
+    }
+
+    it('reports the replaced entry as usurped, not as healthy', () => {
+        const target = path.join(skillsDir, 'mermaid-diagrams');
+        fs.symlinkSync(path.join(registry, 'skills', 'mermaid-diagrams'), target);
+
+        // Antes de la usurpacion: un link vivo y nada mas.
+        const managed = managedLinkTargets([record(target)]);
+        const before = classifySkillLinks(skillsDir, [registry], managed);
+        expect(before.valid).toEqual(['mermaid-diagrams']);
+        expect(before.usurped).toEqual([]);
+
+        usurp('mermaid-diagrams');
+
+        const after = classifySkillLinks(skillsDir, [registry], managed);
+        expect(after.usurped).toEqual(['mermaid-diagrams']);
+        // Y no se cuela por ninguna de las categorias existentes: `valid` es lo que hace
+        // que `doctor` diga `healthy`, y `repairable`/`dead` mandarian a un remedio
+        // (`repair-global-skills`) que solo toca symlinks y aca no cambiaria nada.
+        expect(after.valid).toEqual([]);
+        expect(after.repairable).toEqual([]);
+        expect(after.dead).toEqual([]);
+    });
+
+    it('leaves a directory the user created alone — it is not in the ledger', () => {
+        usurp('my-own-skill');
+        const scan = classifySkillLinks(skillsDir, [registry], managedLinkTargets([]));
+        expect(scan.usurped).toEqual([]);
+        expect(scan.valid).toEqual([]);
+    });
+
+    it('does not flag a rendered artifact: a real file is what `cursor-mdc` produces', () => {
+        // El ledger tambien anota artefactos renderizados (`.mdc`, `.instructions.md`).
+        // Para esos, "no es un symlink" es el estado correcto — contarlos como usurpados
+        // pintaria de rojo cada instalacion sana de Cursor y Copilot.
+        const target = path.join(skillsDir, 'rendered.mdc');
+        fs.writeFileSync(target, '---\ndescription: x\n---\n');
+        const managed = managedLinkTargets([record(target, 'cursor-mdc')]);
+        expect(managed.size).toBe(0);
+        expect(classifySkillLinks(skillsDir, [registry], managed).usurped).toEqual([]);
+    });
+
+    it('defaults to no detection when no ledger is passed (callers without one are unchanged)', () => {
+        usurp('mermaid-diagrams');
+        expect(classifySkillLinks(skillsDir, [registry]).usurped).toEqual([]);
+    });
+});
+
+// El hallazgo del playbook no fue "el clasificador no ve X" — fue "doctor dice healthy".
+// Detectarlo en `classifySkillLinks` no sirve de nada si el check que lo consume lo
+// descarta, asi que la superficie que reporto el bug se asserta por separado.
+describe('awm doctor degrades on a usurped global skill', () => {
+    const { gatherProviderChecks } = require('../../src/core/diagnostics/provider-checks');
+
+    function checkFor(usurped: string[], repairable: string[] = []) {
+        const scan = jest.fn(() => ({ valid: [], repairable, dead: [], usurped }));
+        const facts = gatherProviderChecks(['claude-code'], scan);
+        return facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');
+    }
+
+    it('is broken, names what was replaced, and does not offer a remedy that cannot fix it', () => {
+        const check = checkFor(['mermaid-diagrams']);
+        expect(check.state).toBe('broken');
+        expect(check.detail).toContain('mermaid-diagrams');
+        // `repair-global-skills` solo re-linkea symlinks colgantes: mandaria al usuario a
+        // un comando que corre limpio y no cambia nada.
+        expect(check.remediationCode).toBe('reinstall-usurped-skills');
+    });
+
+    it('still reports plain broken links the old way when nothing was usurped', () => {
+        const check = checkFor([], ['gone']);
+        expect(check.state).toBe('broken');
+        expect(check.detail).toBe('1 broken links');
+        expect(check.remediationCode).toBe('repair-global-skills');
+    });
+
+    it('is healthy when neither happened', () => {
+        expect(checkFor([]).state).not.toBe('broken');
+    });
+});

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -12,6 +12,7 @@ Formato: qué se decidió, por qué, qué implica. Sin historia larga — eso vi
 | [D-004](#d-004) | 2026-08-09 | macOS entra a la matriz de CI | Vigente |
 | [D-005](#d-005) | 2026-08-09 | El gate de release corre en las tres plataformas | Vigente |
 | [D-006](#d-006) | 2026-08-09 | `awm remove` tiene modo no interactivo, simétrico con `add` | Vigente |
+| [D-007](#d-007) | 2026-08-09 | Un artefacto usurpado se **reporta**, no se auto-repara | Vigente |
 
 ---
 
@@ -91,3 +92,39 @@ Era interactivo puro. Una limpieza automatizada quedaba bloqueada, y el playbook
 - **`--yes` implica cero prompts.** La primera versión seguía abriendo el multiselect de agentes sin `--agent`, así que el flag prometía no-interactivo y colgaba cualquier script. Sin `--agent`, el default son los agentes habilitados — igual que `add`, `sync`, `update` y `doctor`.
 
 El nombre es de **bundle**, por D-001. Remover lo que no está instalado no es error: reporta que nada coincidió y sale `0`, así que un script de limpieza es seguro de re-correr.
+
+---
+
+## D-007
+
+**Cuando un tercero reemplaza un artefacto que AWM instaló, `doctor` lo reporta. No lo arregla solo.**
+
+El caso apareció corriendo el playbook `agent-matrix` contra el binario real: Claude Code
+trae su propia skill `mermaid-diagrams` y la materializó encima del symlink que `awm init`
+había puesto en `~/.claude/skills/`. El agente cargaba la del tercero. `awm doctor` decía
+`healthy`, `overall: healthy`, exit `0`; `awm sync` no lo tocaba.
+
+**Por qué era invisible:** `classifySkillLinks` empieza con `if (!lst.isSymbolicLink()) continue`.
+Eso es correcto para una skill que puso el usuario a mano — AWM no debe tocarla — y falso
+cuando `state/artifacts.json` dice que esa ruta exacta es nuestra. El clasificador nunca
+leía el ledger, así que no tenía cómo distinguir los dos casos. **El ledger de propiedad
+existía desde siempre; ningún diagnóstico lo consultaba.**
+
+**Implica:**
+- `SkillIntegrity` gana una cuarta categoría, `usurped`, separada de `valid`/`repairable`/`dead`.
+- `skills.global` pasa a `broken`, nombra qué fue reemplazado, y `overall` degrada.
+- El remedio es `reinstall-usurped-skills`, **no** `repair-global-skills`: ese último solo
+  re-linkea symlinks colgantes, así que correría limpio sin cambiar nada — mandar ahí al
+  usuario sería peor que no ofrecer remedio.
+- Solo aplica al renderer `link`. Para `cursor-mdc` / `copilot-instructions`, "no es un
+  symlink" es el estado sano; contarlo pintaría de rojo toda instalación correcta.
+
+**Por qué no se auto-repara:** restaurar el symlink exige borrar un directorio real con
+contenido de un tercero. Eso es destructivo y no es reversible desde el backup de AWM, que
+solo conoce lo que AWM escribió. Se reporta con nombre y remedio; la orden la da una persona.
+
+**Efecto lateral, del mismo tipo de bug:** `MachineFacts.globalSkills` era una copia
+estructural escrita a mano de `SkillIntegrity` (`{ valid; repairable; dead }`). Como era un
+subconjunto exacto, TypeScript nunca se quejó, y al crecer el tipo real esta copia quedó
+atrás en silencio. Ahora referencia el tipo. Es la misma clase que la tabla de renderers
+duplicada de D-002: **una copia de algo que el código ya define en otro lado.**

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -73,7 +73,7 @@ La parte determinística —`awm sensors run`, su código de salida y el gate de
 
 | Proveedor | Instalación de artefactos | Entrega de contexto | Hooks | Evidencia |
 |---|---|---|---|---|
-| **Claude Code** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Suite + E2E aislado en CI (ubuntu, windows) |
+| **Claude Code** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Suite + E2E aislado en CI (ubuntu, windows, macos) + playbook [`agent-matrix`](testing/agent-matrix.md) corrido contra el binario real (AG-01…AG-06, CC-01, CC-02), incluido **AG-06 con control negativo**: un `HOME` sin AWM responde que no tiene ninguna skill de AWM, así que lo que la sesión nombró vino de la instalación observada y no de su ambiente. |
 | **Codex** | ✅ Verificado | ✅ Verificado | ⚠ Sin verificar | Suite + `tests/integration/codex-provider-isolated`. La **transición de confianza del hook** requiere el binario real. |
 | **OpenCode** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El escritor de `opencode.json` está cubierto por tests; que OpenCode *lea* ese campo no fue observado. |
 | **Cursor** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El `.mdc` se genera y se valida su forma. Que Cursor **cargue** un `.mdc` con `alwaysApply: false` no fue observado. |

--- a/docs/testing/agent-matrix.md
+++ b/docs/testing/agent-matrix.md
@@ -40,11 +40,17 @@ Substitute `<agent>` and run in a scratch project (setup as in core-acceptance).
 
 ### Common to every agent
 
-**AG-01 · The agent is recognised**
+**AG-01 · The agent is recognised** *(run this AFTER AG-02)*
 ```bash
 awm doctor --json -a <agent>
 ```
 **Expect:** exit `0`; a `providers` entry for `<agent>` with the `tier` from the table above.
+
+> **Order matters, and this check used to have it wrong.** It sat first and asked for exit
+> `0` on a scratch project where nothing had been installed yet — which `awm doctor`
+> cannot give you: with no hook and no skills it reports `degraded` and exits `1`, exactly
+> as documented. Bootstrap first (AG-02), then ask whether the agent is healthy. A `1`
+> *before* AG-02 is the correct answer, not a finding.
 
 **AG-02 · Bootstrap for this agent**
 ```bash
@@ -155,7 +161,7 @@ awm doctor --json -a antigravity
 
 | Agent | AG-01 | AG-02 | AG-03 | AG-04 | AG-05 | AG-06 | Extras | Notes |
 |---|---|---|---|---|---|---|---|---|
-| claude-code |  |  |  |  |  |  | CC-01 CC-02 |  |
+| claude-code | PASS | PASS | PASS | PASS | PASS | PASS | CC-01 PASS · CC-02 PASS | 2026-08-09, awm 4.0.0, Linux. AG-02 exit `1` / `failed: 0`. AG-05: 31 artefactos. AG-06 con control negativo (ver abajo). **Un hallazgo de producto**, arreglado: ver "Lo que encontró la corrida". |
 | codex |  |  |  |  |  |  | CX-01 CX-02 |  |
 | opencode |  |  |  |  |  |  | OC-01 |  |
 | cursor |  |  |  |  |  |  | CU-01 |  |
@@ -163,3 +169,40 @@ awm doctor --json -a antigravity
 | antigravity |  |  |  |  |  |  | AN-01 |  |
 
 Record **BLOCKED** for any agent whose binary you don't have. Do not infer a result from another agent's outcome — the bugs this suite exists to catch are precisely the ones that only appear on one provider's path.
+
+---
+
+## Lo que encontró la corrida de `claude-code` (2026-08-09)
+
+Vale escribirlo porque es el argumento entero a favor de correr esto contra un binario
+real: **1726 tests unitarios en verde no lo habían visto**, y la corrida lo encontró en
+menos de veinte minutos.
+
+**AG-06 se corrió con un control negativo.** Un `claude -p` anidado podría estar leyendo el
+ambiente del proceso padre en lugar del `HOME` aislado, y entonces "nombró las skills" no
+probaría nada. El control: la misma pregunta con un `HOME` limpio sin AWM. Respondió que no
+tiene ninguna skill de AWM. Recién con eso la respuesta afirmativa vale como evidencia.
+
+**El hallazgo:** al terminar AG-06, `~/.claude/skills/mermaid-diagrams` había dejado de ser
+el symlink que `awm init` instaló. Claude Code trae su propia skill `mermaid-diagrams` y la
+materializó encima — un directorio real, otra `description`, sin `version`, con un
+`README.md` que la nuestra no tiene. El agente cargaba esa, no la instalada.
+
+Lo grave no fue la colisión de nombres: fue que **nada lo reportaba**.
+
+```
+skills.global: healthy   ·   overall: healthy   ·   exit 0
+```
+
+`awm sync` tampoco lo tocaba. La causa es una línea de `classifySkillLinks`:
+`if (!lst.isSymbolicLink()) continue`. Correcta para una skill que puso el usuario a mano
+— AWM no debe tocarla — y equivocada cuando el ledger de artefactos dice que esa ruta
+exacta es nuestra. El clasificador nunca consultaba el ledger, así que no podía distinguir
+los dos casos, y la usurpación era literalmente invisible.
+
+Hoy `doctor` reporta `broken`, nombra qué fue reemplazado y sale `1`. No se auto-repara:
+borrar un directorio real de un tercero es destructivo — ver [`decisions.md`](../decisions.md) D-007.
+
+**Si repetís la corrida, esperá esto:** después de abrir una sesión real de Claude Code
+contra el `HOME` aislado, `awm doctor` reporta `mermaid-diagrams` como reemplazado. Eso es
+el producto funcionando, no una regresión.


### PR DESCRIPTION
Hallazgo del playbook [`agent-matrix`](docs/testing/agent-matrix.md) corrido para `claude-code` contra el binario publicado. **1726 tests unitarios en verde no lo habían visto**; la corrida lo encontró en menos de veinte minutos.

## Qué pasó

Al terminar AG-06, `~/.claude/skills/mermaid-diagrams` había dejado de ser el symlink que `awm init` instaló. Claude Code trae su propia skill con ese nombre y la materializó encima — directorio real, otra `description`, sin `version`, con un `README.md` que la nuestra no tiene. El agente cargaba esa.

Lo grave no fue la colisión de nombres. Fue que nada lo reportaba:

```
skills.global: healthy   ·   overall: healthy   ·   exit 0
```

`awm sync` tampoco lo tocaba.

## Causa

Una línea de `classifySkillLinks`:

```ts
if (!lst.isSymbolicLink()) continue;
```

Correcta para una skill que puso el usuario a mano — AWM no debe tocarla — y falsa cuando `state/artifacts.json` dice que esa ruta exacta es nuestra. **El ledger de propiedad existía desde siempre; ningún diagnóstico lo consultaba**, así que el clasificador no tenía cómo distinguir los dos casos.

## Qué cambia

- `SkillIntegrity` gana `usurped`, separado de `valid`/`repairable`/`dead`.
- `skills.global` pasa a `broken`, nombra qué fue reemplazado, `overall` degrada.
- Remedio `reinstall-usurped-skills`, **no** `repair-global-skills` — ese solo re-linkea symlinks colgantes, así que correría limpio sin cambiar nada; mandar ahí al usuario es peor que no ofrecer remedio.
- Solo para el renderer `link`. En `cursor-mdc` / `copilot-instructions` un archivo real es el estado sano; contarlo pintaría de rojo toda instalación correcta de Cursor y Copilot.
- **No se auto-repara** ([D-007](docs/decisions.md#d-007)): restaurar el link exige borrar un directorio de un tercero. Es destructivo y el backup de AWM no lo cubre — solo conoce lo que AWM escribió.

## El bug hermano que salió con él

`MachineFacts.globalSkills` era una copia estructural escrita a mano de `SkillIntegrity` (`{ valid; repairable; dead }`). Como era un subconjunto exacto, TypeScript nunca se quejó, y al crecer el tipo real esta copia quedó atrás en silencio. Ahora referencia el tipo. Misma clase que la tabla de renderers duplicada de D-002: una copia de algo que el código ya define en otro lado.

## Verificación

- **Revert probe:** los dos tests que cubren el hallazgo pasan a rojo contra el código viejo, el resto queda verde.
- **Reproducción real** re-corrida contra el binario construido: `broken` · `1 replaced by non-AWM content (mermaid-diagrams)` · `overall: degraded` · exit `1`.
- Suite completa: **176 suites / 1726 tests**.
- Cuatro casos negativos en el test nuevo: un directorio del usuario no se marca, un `.mdc` renderizado no se marca, y sin ledger el comportamiento es el anterior.

## Documentación

- `agent-matrix.md`: hoja de resultados de `claude-code` completa, con **AG-06 corrido con control negativo** (un `HOME` sin AWM responde que no tiene ninguna skill de AWM — recién con eso la respuesta afirmativa vale como evidencia), y la corrección de **AG-01**, que pedía exit `0` antes de AG-02 sobre un proyecto donde nada estaba instalado todavía: imposible por diseño. Cuarto playbook escrito contra la doc y no contra el comportamiento.
- `support-matrix.md`: la evidencia de Claude Code deja de ser solo "suite + E2E en CI".
- `decisions.md`: D-007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_