### PR TITLE
feat(init)!: exit 0 when init did its job, even if the harness stays degraded

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -279,8 +279,20 @@ export async function runInit(opts: RunInitOptions = {}): Promise<number> {
         });
     }
 
-    // `result` mirrors the exit code, so a consumer can branch on one field
-    // instead of correlating stdout with $?: ok → 0, degraded → 1, failed → 2.
+    // `result` distinguishes `ok` from `degraded` in the JSON; the EXIT CODE does
+    // not, on purpose (D-008).
+    //
+    // `degraded` used to exit `1`. It does not mean init failed — it means the
+    // harness still has `pending` steps, which is the NORMAL outcome of a first run:
+    // `CONSTITUTION.md` and `AGENTS.md` are written by an agent session, not by the
+    // CLI. So a run where nothing broke reported failure, and `awm init --yes && …`
+    // died under `set -e` — in the one command whose entire job is bootstrapping a
+    // script. Three independent readers called it a bug before it was one; the docs
+    // had grown a warning box asking people to ignore the exit code.
+    //
+    // The exit code now answers "did init do its job?". "Is the harness fully
+    // healthy?" is `awm doctor`'s question, and `result` still carries it here for
+    // any consumer that wants to branch on it.
     const result = outcome.after.overall === 'healthy' ? 'ok' : 'degraded';
 
     if (opts.json) {
@@ -289,7 +301,7 @@ export async function runInit(opts: RunInitOptions = {}): Promise<number> {
         process.stdout.write(renderInitOutcome(outcome) + '\n');
     }
 
-    return result === 'ok' ? 0 : 1;
+    return 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/tests/commands/init.test.ts
+++ b/cli/tests/commands/init.test.ts
@@ -111,14 +111,17 @@ describe('runInit', () => {
         });
     });
 
-    it('returns exit 1 on a bare HOME and never prompts with --yes (cache stubbed)', async () => {
+    it('returns exit 0 on a bare HOME and never prompts with --yes (cache stubbed)', async () => {
         const { runInit } = require('../../src/commands/init');
         const code = await runInit({
             cwd: tmpHome,
             yes: true,
             actions: { syncCache: async () => {}, installHook: () => ({ status: 'installed' }) },
         });
-        expect(code).toBe(1); // cache/hook/devCore siguen ausentes (syncCache no-op) → degradado
+        // Degradado (cache/hook/devCore siguen ausentes con syncCache no-op) pero NADA
+        // fallo, y el exit code de `init` responde por init, no por la salud del
+        // harness — ver D-008. Esto salia 1 y rompia `awm init --yes && …` bajo `set -e`.
+        expect(code).toBe(0);
     });
 
     it('--json emits a parseable InitOutcome', async () => {
@@ -134,7 +137,10 @@ describe('runInit', () => {
         expect(Array.isArray(parsed.steps)).toBe(true);
         expect(parsed.after.overall).toBe('degraded');
         expect(parsed.result).toBe('degraded'); // success envelope is self-describing too
-        expect(code).toBe(1);
+        // El exit code deja de duplicar `result`: la distincion ok/degradado sigue
+        // disponible para quien la quiera, en el campo, no en `$?` (D-008).
+        expect(parsed.failed).toBe(0);
+        expect(code).toBe(0);
     });
 
     const prefsFile = () => path.join(process.env.AWM_HOME as string, 'preferences.json');
@@ -249,6 +255,44 @@ describe('runInit', () => {
         expect(code).toBeLessThanOrEqual(1);
         expect(readPreferences().enabledAgents)
             .toEqual(['claude-code', 'codex', 'opencode']);
+    });
+
+    // -----------------------------------------------------------------------
+    // D-008 — el exit code de `init` responde por init, no por la salud del harness
+    // -----------------------------------------------------------------------
+    //
+    // El contrato entero en un solo lugar, porque el sitio que lo rompia era el
+    // ausente: ningun test preguntaba "¿un script puede encadenar `awm init &&`?".
+    // Habia dos assertions de `toBe(1)`, y las dos *documentaban* el bug en vez de
+    // detenerlo. Tres lectores independientes lo reportaron como fallo antes de que
+    // lo fuera, y la doc habia crecido un recuadro pidiendo ignorar el exit code.
+
+    it('a degraded-but-successful run exits 0, so `awm init && next` survives set -e', async () => {
+        const { runInit } = require('../../src/commands/init');
+        const code = await runInit({
+            cwd: tmpHome,
+            yes: true,
+            json: true,
+            actions: { syncCache: async () => {}, installHook: () => ({ status: 'installed' }) },
+        });
+        const parsed = JSON.parse(writeSpy.mock.calls.map((c) => c[0]).join(''));
+
+        // Las tres afirmaciones juntas son el punto: degradado, sin nada fallado, exit 0.
+        // Cualquiera de las tres sola se puede satisfacer sin el fix.
+        expect(parsed.result).toBe('degraded');
+        expect(parsed.failed).toBe(0);
+        expect(code).toBe(0);
+    });
+
+    it('still refuses with exit 2 when a gate rejects — 0 does not mean "always succeed"', async () => {
+        const { runInit } = require('../../src/commands/init');
+        const code = await runInit({
+            cwd: tmpHome,
+            agent: 'codex',
+            yes: true,
+            assertProviderSupported: () => { throw new Error('requires Codex >= 0.145.0'); },
+        });
+        expect(code).toBe(2);
     });
 
     // -----------------------------------------------------------------------

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -29,13 +29,17 @@ awm init [--agent <agent>] [--machine-only] [--yes] [--json]
 | `-y, --yes` | Skip confirmation prompts (for scripts). |
 | `--json` | Emit the full `InitOutcome` as JSON instead of the rendered report — on success **and** on failure. |
 
-**Exit codes:** `0` healthy · `1` degraded (ran to completion, some checks still missing) · `2` failed (one or more steps failed; every write was rolled back).
+**Exit codes:** `0` init did its job — including a run that ends `degraded`, i.e. ran to completion with checks still pending · `2` did not complete: a gate refused, or a step failed and every write was rolled back. **`1` is not used.**
 
-**`--json` contract.** Both documents carry a `result` field mirroring the exit code, so a bootstrap script can branch on one value:
+> **Cambió en la v5.0.0.** `degraded` salía `1`, así que un run donde no fallaba nada
+> reportaba fallo y `awm init --yes && …` moría bajo `set -e`. El exit code responde por
+> init; la salud del harness la responde `awm doctor`. Ver [`decisions.md`](decisions.md) D-008.
+
+**`--json` contract.** Both documents carry a `result` field, so a script that wants the `ok` / `degraded` distinction can branch on it — the exit code no longer encodes it:
 
 | `result` | Exit | Document |
 |---|---|---|
-| `ok` / `degraded` | 0 / 1 | The `InitOutcome`: `steps`, `applied`/`pending`/`failed`, `before`, `after`, `transactionId`, `modifiedFiles`. |
+| `ok` / `degraded` | 0 | The `InitOutcome`: `steps`, `applied`/`pending`/`failed`, `before`, `after`, `transactionId`, `modifiedFiles`. |
 | `failed` | 2 | A failure envelope: `error` (names the failed steps), `steps`, `failedSteps` (the `action: "failed"` subset, each with `id` and `error`), `before`, `after`, and `transaction`. |
 
 On `result: "failed"`, `transaction` records what happened to the machine: `committed` is always `false`, `rolledBack` says whether every path in `restoredFiles` was restored to its pre-init state, and `rollbackError` appears only if the restore itself failed (recover with `awm backup restore <transactionId>`). `after` is the state observed at the end of the step pipeline — *before* the rollback ran — so it describes what the failing run produced, not what is on disk now.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -13,6 +13,7 @@ Formato: qué se decidió, por qué, qué implica. Sin historia larga — eso vi
 | [D-005](#d-005) | 2026-08-09 | El gate de release corre en las tres plataformas | Vigente |
 | [D-006](#d-006) | 2026-08-09 | `awm remove` tiene modo no interactivo, simétrico con `add` | Vigente |
 | [D-007](#d-007) | 2026-08-09 | Un artefacto usurpado se **reporta**, no se auto-repara | Vigente |
+| [D-008](#d-008) | 2026-08-09 | El exit code de `awm init` responde por init, no por la salud del harness | Vigente |
 
 ---
 
@@ -128,3 +129,48 @@ estructural escrita a mano de `SkillIntegrity` (`{ valid; repairable; dead }`). 
 subconjunto exacto, TypeScript nunca se quejó, y al crecer el tipo real esta copia quedó
 atrás en silencio. Ahora referencia el tipo. Es la misma clase que la tabla de renderers
 duplicada de D-002: **una copia de algo que el código ya define en otro lado.**
+
+---
+
+## D-008
+
+**`awm init` sale `0` cuando init hizo su trabajo, aunque el harness quede `degraded`.** (Opción 1 de las tres evaluadas.)
+
+Salía `1` cuando el `doctor` posterior reportaba `degraded` — que en un primer run es lo
+**normal**: dos pasos quedan `pending` porque `CONSTITUTION.md` y `AGENTS.md` los escribe
+una sesión de agente, no el CLI. Un run donde no fallaba nada reportaba fallo.
+
+**La evidencia de que era un bug y no una convención:**
+- `awm init --yes && <siguiente>` se cortaba bajo `set -e` — en el único comando cuyo
+  trabajo entero es arrancar un script de bootstrap.
+- `core-acceptance.md` había crecido un recuadro **⚠️ Read this before judging any exit
+  code** pidiendo ignorarlo. Cuando la doc tiene que pedir que ignores el comportamiento,
+  el comportamiento es el problema.
+- **Tres lectores independientes** lo reportaron como fallo: dos corridas del playbook
+  `agent-matrix` marcaron AG-02 y CX-01 FAIL con `failed: 0` en su propio JSON.
+
+**El contrato nuevo:**
+
+| Código | Significa |
+|---|---|
+| `0` | Init hizo su trabajo. Puede quedar `degraded`; eso sigue siendo éxito. |
+| `2` | No se completó: un gate rechazó, o un paso falló y se revirtió todo. |
+
+`1` deja de usarse. La distinción `ok`/`degraded` no se pierde: sigue en el campo `result`
+del `--json`, que es donde un consumidor que la quiera debe leerla. "¿El harness está
+sano?" es la pregunta de `awm doctor`, no de `init`.
+
+**Descartadas:**
+- *Un flag `--strict`* — mantiene compatibilidad con scripts que hoy chequean el `1`, pero
+  deja dos semánticas conviviendo y un flag más que explicar, para preservar un
+  comportamiento que nadie quería.
+- *Solo arreglar la doc* — riesgo cero, pero el próximo que escriba un script de bootstrap
+  o corra un playbook vuelve a chocar. Ya se repitió tres veces.
+
+**Costo:** es un cambio de contrato observable, así que sale como **major (v5.0.0)**. Un
+script que hoy hace `awm init || echo degradado` deja de imprimir esa rama; el reemplazo es
+leer `result` del `--json`.
+
+**Cómo se detuvo:** el sitio que faltaba era el test ausente — ningún test preguntaba si un
+script podía encadenar `awm init &&`. Había dos assertions de `toBe(1)`, y las dos
+*documentaban* el bug en vez de detenerlo.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -74,7 +74,7 @@ La parte determinística —`awm sensors run`, su código de salida y el gate de
 | Proveedor | Instalación de artefactos | Entrega de contexto | Hooks | Evidencia |
 |---|---|---|---|---|
 | **Claude Code** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Suite + E2E aislado en CI (ubuntu, windows, macos) + playbook [`agent-matrix`](testing/agent-matrix.md) corrido contra el binario real (AG-01…AG-06, CC-01, CC-02), incluido **AG-06 con control negativo**: un `HOME` sin AWM responde que no tiene ninguna skill de AWM, así que lo que la sesión nombró vino de la instalación observada y no de su ambiente. |
-| **Codex** | ✅ Verificado | ✅ Verificado | ⚠ Sin verificar | Suite + `tests/integration/codex-provider-isolated`. La **transición de confianza del hook** requiere el binario real. |
+| **Codex** | ✅ Verificado | ✅ Verificado | ⚠ Sin verificar | Suite + `tests/integration/codex-provider-isolated` + playbook [`agent-matrix`](testing/agent-matrix.md) contra `codex-cli 0.146.0` real (Ubuntu, 2026-08-09): instalación y `.toml` parseado con `tomllib`, AG-06 nombró skills instaladas. **Los hooks siguen ⚠**: `doctor` reportó `hook.trust: pending-trust` — el hook está instalado y **la transición de confianza nunca ocurrió**, así que nunca se lo observó disparar. AG-06 no lo cierra: Codex también recibe contexto por el bloque gestionado en `AGENTS.md` (`context.global: delivered`), que es otro camino. |
 | **OpenCode** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El escritor de `opencode.json` está cubierto por tests; que OpenCode *lea* ese campo no fue observado. |
 | **Cursor** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El `.mdc` se genera y se valida su forma. Que Cursor **cargue** un `.mdc` con `alwaysApply: false` no fue observado. |
 | **Copilot** | ✅ Verificado (solo proyecto) | ⚠ Sin verificar | ⛔ No tiene | El `.instructions.md` se genera. Que Copilot **honre** `applyTo: "**"` no fue observado. |
@@ -162,6 +162,7 @@ Enunciado como trabajo, no como defecto. Esto es lo que hay que construir para s
 | 3 | **Reconciliación de scope de proyecto en `awm update`** | `update` reconcilia artefactos de máquina; los de proyecto son trabajo de `awm sync`. Un proyecto sin `sync` queda desactualizado en silencio. | Elimina un paso manual |
 | 4 | **Pruebas de los packs `python` y `shell` contra proyectos reales** | Existen y están completos; nadie los corrió contra un repo Python o de shell de verdad. | Sube 2 packs a ✅ |
 | 5 | **Un séptimo proveedor** | El modelo de capacidades ya lo soporta como una edición localizada (tabla de renderers + entrada de provider). No hay ninguno pedido todavía. | Amplía la cobertura |
+| 6 | **Observar el hook de Codex disparando, con la confianza otorgada** | Es lo único que separa a Codex de ✅ en hooks. La corrida real del playbook dejó `hook.trust: pending-trust`: instalado, nunca disparado. Pide una corrida donde una persona acepte la confianza en la UI de Codex y **después** observe el re-anclaje de sesión. | Sube Codex a ✅ en hooks |
 
 ---
 

--- a/docs/testing/agent-matrix.md
+++ b/docs/testing/agent-matrix.md
@@ -58,14 +58,16 @@ awm init -a <agent> --yes --json > init-<agent>.json
 ```
 **Expect:** `failed: 0`.
 
-> **Judge `failed`, not the exit code.** `awm init` exits `1` on a run where nothing broke:
-> exit `1` means *the harness is degraded*, which normally just means two steps are `pending`
-> because they need an agent session to write `CONSTITUTION.md` and `AGENTS.md`. This is
-> spelled out in [core-acceptance](core-acceptance.md), and this playbook used to assume you
-> had read it first — **two separate runs marked AG-02 FAIL on the exit code while their own
-> JSON said `failed: 0`**, so it is repeated here.
+> **Judge `failed`, not the exit code.** A run can finish `degraded` — two steps `pending`
+> because an agent session writes `CONSTITUTION.md` and `AGENTS.md` — and that is a normal
+> first run, not a failure.
 >
 > `failed: 0` → PASS. `failed: > 0` → FAIL, and `modifiedFiles` lists what was rolled back.
+>
+> Desde la **v5.0.0** el exit code acompaña: `0` = init hizo su trabajo, `2` = no se
+> completó, y `1` no se usa. Contra una v4.x, un run sano sale `1` — **dos corridas
+> distintas marcaron AG-02 FAIL por eso**, con `failed: 0` en su propio JSON. Ver
+> [core-acceptance](core-acceptance.md) y [`decisions.md`](../decisions.md) D-008.
 
 **Legitimate exception:** exit `2` with a message that the agent's binary is missing or below its minimum version — that is a **correct refusal**, record it as PASS with a note. `codex` requires ≥ `0.145.0`.
 

--- a/docs/testing/agent-matrix.md
+++ b/docs/testing/agent-matrix.md
@@ -57,6 +57,16 @@ awm doctor --json -a <agent>
 awm init -a <agent> --yes --json > init-<agent>.json
 ```
 **Expect:** `failed: 0`.
+
+> **Judge `failed`, not the exit code.** `awm init` exits `1` on a run where nothing broke:
+> exit `1` means *the harness is degraded*, which normally just means two steps are `pending`
+> because they need an agent session to write `CONSTITUTION.md` and `AGENTS.md`. This is
+> spelled out in [core-acceptance](core-acceptance.md), and this playbook used to assume you
+> had read it first — **two separate runs marked AG-02 FAIL on the exit code while their own
+> JSON said `failed: 0`**, so it is repeated here.
+>
+> `failed: 0` → PASS. `failed: > 0` → FAIL, and `modifiedFiles` lists what was rolled back.
+
 **Legitimate exception:** exit `2` with a message that the agent's binary is missing or below its minimum version — that is a **correct refusal**, record it as PASS with a note. `codex` requires ≥ `0.145.0`.
 
 **AG-03 · Install a skill for this agent**
@@ -162,7 +172,7 @@ awm doctor --json -a antigravity
 | Agent | AG-01 | AG-02 | AG-03 | AG-04 | AG-05 | AG-06 | Extras | Notes |
 |---|---|---|---|---|---|---|---|---|
 | claude-code | PASS | PASS | PASS | PASS | PASS | PASS | CC-01 PASS · CC-02 PASS | 2026-08-09, awm 4.0.0, Linux. AG-02 exit `1` / `failed: 0`. AG-05: 31 artefactos. AG-06 con control negativo (ver abajo). **Un hallazgo de producto**, arreglado: ver "Lo que encontró la corrida". |
-| codex |  |  |  |  |  |  | CX-01 CX-02 |  |
+| codex | PASS¹ | PASS¹ | PASS | PASS | PASS | PASS | CX-01 PASS¹ · CX-02 PASS | 2026-08-09, awm 4.0.0, codex-cli 0.146.0, Node 24.19.0, Ubuntu (VPC). AG-05: 30 symlinks. **Hooks siguen ⚠**: `hook.trust: pending-trust` — ver abajo. |
 | opencode |  |  |  |  |  |  | OC-01 |  |
 | cursor |  |  |  |  |  |  | CU-01 |  |
 | copilot |  |  |  |  |  |  | CP-01 CP-02 |  |
@@ -206,3 +216,48 @@ borrar un directorio real de un tercero es destructivo — ver [`decisions.md`](
 **Si repetís la corrida, esperá esto:** después de abrir una sesión real de Claude Code
 contra el `HOME` aislado, `awm doctor` reporta `mermaid-diagrams` como reemplazado. Eso es
 el producto funcionando, no una regresión.
+
+---
+
+## Lo que encontró la corrida de `codex` (2026-08-09)
+
+Ubuntu, VPC del equipo, `codex-cli 0.146.0`, contra `awm 4.0.0` publicado. La corrida
+reportó **tres FAIL**. Ninguno era del producto — los tres los produjo este documento,
+y por eso está reescrito arriba. Se dejan acá con la observación cruda: un playbook que
+se corrige sin decir qué le pasaba se vuelve a torcer.
+
+**¹ Los tres FAIL, re-clasificados con su razón**
+
+| ID | Lo observado | Por qué no es un defecto del producto |
+|---|---|---|
+| AG-01 | `awm doctor --json -a codex` **antes de `init`** → `codex is not enabled; run awm init --agent codex`, exit `2`. | El check estaba **mal ordenado**: pedía exit `0` sobre una máquina donde el agente todavía no estaba habilitado. El mensaje nombra la causa y el comando exacto — es un rechazo correcto. Corregido: AG-01 va después de AG-02. Post-`init`, `doctor` devolvió `overall: healthy`, exit `0`. |
+| AG-02 | `failed: 0` en el JSON, pero exit `1`. | Exit `1` de `awm init` significa *degradado*, no *falló* — dos pasos quedan `pending` porque los escribe una sesión de agente. El criterio es `failed`, y el prompt de la corrida no llevaba `core-acceptance.md`, donde estaba la advertencia. Ahora está repetida en AG-02. |
+| CX-01 | Igual que AG-02. | Mismo síntoma, misma causa. |
+
+**El exit code de `awm init` es un problema aparte, y este es su tercer observador.** Que la
+documentación necesite un recuadro pidiendo *ignorá el exit code* es la señal, no la
+solución: `awm init --yes && <siguiente paso>` se corta bajo `set -e` en cualquier script de
+bootstrap, que es exactamente el uso del comando. Registrado como decisión pendiente.
+
+**Lo que la corrida SÍ cerró, y lo que no**
+
+- ✅ **Instalación y entrega de contexto en Codex, contra el binario real.** AG-03 a AG-05
+  limpios; `.codex/agents/development-process.toml` parseado con `tomllib` y la
+  `description` intacta (CX-02); AG-06 nombró skills instaladas de verdad y describió la
+  orquestación, incluido el preflight del Step 0.
+- ⚠ **Los hooks de Codex siguen sin verificar.** `awm doctor` reportó
+  `hook.trust: pending-trust`: el hook está instalado, pero **la transición de confianza
+  nunca ocurrió**, así que nunca se observó dispararse. AG-06 pasó igual — y eso no lo
+  contradice, porque Codex también recibe el contexto por `context.global: delivered` (el
+  bloque gestionado en `AGENTS.md`), que es un camino distinto del hook. Atribuir el
+  resultado de AG-06 al hook sería justo el error que la matriz de cuatro niveles existe
+  para evitar.
+
+  `pending-trust` no degrada `overall` a propósito: otorgar la confianza es una acción del
+  usuario en la UI de Codex que AWM no puede hacer por él, y marcarlo rojo dejaría a todo
+  usuario de Codex en `degraded` para siempre. Cerrar este ⚠ pide **una corrida donde
+  alguien acepte la confianza y después observe el hook disparar**.
+
+**Nota menor, sin registrar como hallazgo:** Codex reportó ver algunas skills "duplicadas en
+dos registros". `.agents/skills` lo comparten Codex y OpenCode, y una instalación global más
+una de proyecto pueden mostrar el mismo nombre dos veces. No se investigó; queda anotado.

--- a/docs/testing/core-acceptance.md
+++ b/docs/testing/core-acceptance.md
@@ -23,11 +23,22 @@ Teardown when you're done: delete `$AWM_HOME` and `$WORK`.
 
 ---
 
-## ⚠️ Read this before judging any exit code
+## Los exit codes de `awm init`
 
-**`awm init` exits `1` on a perfectly successful run.** Exit `1` means *"the harness is degraded"* — normally just "two steps need an agent to finish them" — **not** "something failed".
+| Código | Significa | Qué hacer |
+|---|---|---|
+| `0` | **Init hizo su trabajo.** Puede quedar `degraded` — normalmente dos pasos `pending` que escribe una sesión de agente (`CONSTITUTION.md`, `AGENTS.md`) — y eso sigue siendo un éxito. | Seguir. `awm init --yes && <siguiente>` es seguro. |
+| `2` | **No se completó.** O un gate rechazó (binario del agente ausente o por debajo del mínimo), o algún paso falló y el run se revirtió entero. | Leer el mensaje. Un `2` con causa clara es un rechazo *correcto*, no un bug. |
 
-The reliable signal is the JSON, not the exit code:
+`awm init` **no usa exit `1`.**
+
+> **Esto cambió en la v5.0.0.** Antes, un run donde no fallaba nada salía `1` solo porque
+> el harness quedaba `degraded` — y este documento tenía un recuadro pidiendo *ignorá el
+> exit code*. Tres lectores independientes lo reportaron como fallo antes de que lo fuera,
+> y `awm init --yes && …` moría bajo `set -e`, en el único comando cuyo trabajo entero es
+> arrancar un script. Ver [`decisions.md`](../decisions.md) D-008.
+
+La salud del harness la responde `awm doctor`, y el JSON de `init` la sigue trayendo:
 
 ```bash
 awm init --yes --json > init.json; echo "exit=$?"
@@ -37,10 +48,10 @@ awm init --yes --json > init.json; echo "exit=$?"
 { "result": "degraded", "applied": 4, "pending": 2, "failed": 0 }
 ```
 
-- `failed: 0` → **nothing broke.** `pending` counts steps that require an agent session (writing `CONSTITUTION.md`, `AGENTS.md`).
-- `failed: > 0` → a real failure. `awm init` is transactional: on failure it rolls back every file it touched, and `modifiedFiles` lists them.
+- `failed: 0` → **no se rompió nada.** `pending` cuenta pasos que necesitan una sesión de agente.
+- `failed: > 0` → falla real. `awm init` es transaccional: revierte todo lo que tocó, y `modifiedFiles` lo lista.
 
-Judge on **`failed`**, and on `result` (`ok` | `degraded` | `failed`). Exit codes: `0` = clean, `1` = degraded, `2` = a gate refused (e.g. the agent's binary isn't installed or is below its minimum version) — a `2` with a clear message is a *correct* refusal, not a bug.
+Para un script, `$?` alcanza. Para saber si además quedó algo pendiente, mirar `result`.
 
 ---
 


### PR DESCRIPTION
La corrida de [`agent-matrix`](docs/testing/agent-matrix.md) para `codex` en el VPC (`codex-cli 0.146.0`, Ubuntu, contra `awm 4.0.0`) reportó tres FAIL. Ninguno era del producto — pero uno de ellos era el **tercer observador independiente** del mismo problema real, y eso lo convirtió en uno.

> ⚠️ **Breaking change** — sale como **v5.0.0**.

## El cambio

`awm init` salía `1` cuando el `doctor` posterior reportaba `degraded`. En un primer run eso es lo **normal**: dos pasos quedan `pending` porque `CONSTITUTION.md` y `AGENTS.md` los escribe una sesión de agente, no el CLI. Un run donde no fallaba nada reportaba fallo, y `awm init --yes && <siguiente>` moría bajo `set -e` — en el único comando cuyo trabajo entero es arrancar un script de bootstrap.

| Código | Antes | Ahora |
|---|---|---|
| `0` | healthy | **init hizo su trabajo** (incluye `degraded`) |
| `1` | degraded | *no se usa* |
| `2` | falló | no se completó: gate rechazó, o un paso falló y se revirtió todo |

La distinción `ok`/`degraded` no se pierde: sigue en el campo `result` del `--json`. "¿El harness está sano?" es la pregunta de `awm doctor`, no de `init`. Detalle y alternativas descartadas en [`decisions.md`](docs/decisions.md) D-008.

**Migración:** un script que hacía `awm init || echo degradado` debe leer `result` del `--json`.

## Por qué era un bug y no una convención

- **Tres lectores independientes** lo reportaron como fallo antes de que lo fuera: dos corridas del playbook marcaron AG-02 y CX-01 FAIL, con `failed: 0` en su propio JSON.
- `core-acceptance.md` había crecido un recuadro **⚠️ Read this before judging any exit code** pidiendo ignorarlo. Cuando la doc tiene que pedir que ignores el comportamiento, el comportamiento es el problema. Ese recuadro se reemplaza por la tabla del contrato.

## El sitio que faltaba era el test ausente

Ninguno preguntaba si un script podía encadenar `awm init &&`. Había dos assertions de `toBe(1)`, y las dos **documentaban** el bug en vez de detenerlo.

El test nuevo afirma las tres cosas juntas — `result: degraded`, `failed: 0`, exit `0` — porque cualquiera de las tres sola se satisface sin el fix. Aparte cubre que el rechazo de gate sigue saliendo `2`, para que "exit 0" no se lea como "siempre éxito".

- **Revert probe:** 3 tests a rojo contra el código viejo.
- **Contra el binario construido:** la cadena encadena (`exit 0`, `result: degraded`, `failed: 0`, `pending: 2`); el rechazo de Codex sigue en `2`.
- Suite: **176 suites / 1728 tests**.

## Los otros dos FAIL de la corrida, re-clasificados

| ID | Lo observado | Diagnóstico |
|---|---|---|
| AG-01 | `doctor -a codex` **antes de `init`** → `codex is not enabled; run awm init --agent codex`, exit `2` | Check mal ordenado. El mensaje nombra la causa y el comando exacto: rechazo correcto. Ya corregido en el PR anterior; post-`init` la corrida obtuvo `overall: healthy`, exit `0`. |
| CX-01 | Igual que AG-02 | Mismo síntoma, misma causa. |

Los tres quedan escritos con su observación cruda en el playbook. Un playbook que se corrige sin decir qué le pasaba se vuelve a torcer.

## Matriz de soporte

**Codex sube a ✅ en instalación y entrega de contexto** contra el binario real.

**Los hooks NO.** `doctor` reportó `hook.trust: pending-trust`: el hook está instalado y **la transición de confianza nunca ocurrió**, así que nunca se lo observó disparar. AG-06 pasó, y eso no lo cierra — Codex también recibe el contexto por el bloque gestionado en `AGENTS.md` (`context.global: delivered`), que es otro camino, y atribuirle el resultado al hook sería justo el error que la matriz de cuatro niveles existe para evitar. Agregado como ítem 6 de "🔜 lo que falta desarrollar", con qué pide para cerrarse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc