### PR TITLE
fix(release,doctor): serialize releases, and give the sibling checks the ledger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,18 @@ permissions:
   contents: write
   id-token: write   # OIDC para npm Trusted Publisher
 
+# Los releases se SERIALIZAN. Dos corridas concurrentes ya rompieron una vez:
+# mergear un PR mientras el release del anterior estaba en vuelo dejo a la segunda
+# corrida adelantando `main`, y la primera murio en `git push` con non-fast-forward
+# DESPUES de haber publicado a npm. Resultado: la 4.0.1 existe en npm y no existe en
+# git — sin tag y sin entrada de CHANGELOG. Ver docs/decisions.md D-009.
+#
+# `cancel-in-progress: false` es lo importante: cancelar un release a mitad de camino
+# es justo el modo de falla que se quiere evitar. La segunda corrida ESPERA.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # El gate del release, en las TRES plataformas.
   #

--- a/cli/src/core/diagnostics/checks.ts
+++ b/cli/src/core/diagnostics/checks.ts
@@ -120,6 +120,15 @@ function projectChecks(p: ProjectFacts): CheckResult[] {
             remedy: cmd('awm sync') });
     }
 
+    // Fila aparte de `project.orphans`, y con OTRO remedio: `awm sync` solo toca
+    // symlinks, asi que sobre un directorio real que piso nuestro link corre limpio sin
+    // cambiar nada. Mandar ahi al usuario seria peor que no ofrecer remedio (D-007).
+    if (p.orphanLinks.usurped.length > 0) {
+        out.push({ id: 'project.usurped', level: 'project', label: 'skill links replaced by non-AWM content',
+            status: 'warn', detail: p.orphanLinks.usurped.join(', '),
+            remedy: cmd(`awm remove <bundle> --yes && awm add <bundle> --yes`) });
+    }
+
     // project.sensors
     out.push(p.sensors.present
         ? { id: 'project.sensors', level: 'project', label: 'sensors', status: 'ok', remedy: none }

--- a/cli/src/core/diagnostics/context.ts
+++ b/cli/src/core/diagnostics/context.ts
@@ -263,10 +263,15 @@ function gatherProject(root: string, bundles: BundleDefinition[], agent: AgentTa
     // Huerfanos: symlinks colgantes que el profile ya no reclama. Se clasifican sobre
     // el dir REAL, no sobre la lista esperada — que es justamente lo que `linked`/
     // `broken` de arriba no pueden ver. `awm sync` los cura o los poda.
-    const orphanScan = classifySkillLinks(localSkillsDir, contentRoots());
+    const orphanScan = classifySkillLinks(localSkillsDir, contentRoots(), managedLinkTargets(safeReadArtifactState()));
     const orphanLinks = {
         repairable: orphanScan.repairable.filter((n) => !expected.includes(n)),
         dead: orphanScan.dead.filter((n) => !expected.includes(n)),
+        // Usurpados NO se filtran contra `expected`: lo huerfano es lo que sobra, y esto
+        // es lo contrario — una skill que el profile SI reclama, cuyo link reemplazo un
+        // tercero por contenido suyo. Se reporta aparte porque el remedio difiere: `awm
+        // sync` cura symlinks colgantes y sobre un directorio real no hace nada.
+        usurped: orphanScan.usurped,
     };
 
     let context: ProjectFacts['context'] = { present: false };

--- a/cli/src/core/diagnostics/provider-checks.ts
+++ b/cli/src/core/diagnostics/provider-checks.ts
@@ -11,7 +11,8 @@ import fs from 'fs';
 import path from 'path';
 import { AgentTarget, ProviderConfig, RendererId, Scope, providerFor } from '../../providers';
 import { ProviderCheck, ProviderCheckState, ProviderFacts, ProviderTier } from './types';
-import { SkillIntegrity, classifySkillLinks } from '../skill-integrity';
+import { SkillIntegrity, classifySkillLinks, managedLinkTargets } from '../skill-integrity';
+import { ManagedArtifactRecord, readArtifactState } from '../artifact-state';
 import { assertProviderSupported } from '../provider-version';
 import { computeHookStatus } from '../../commands/hooks/status';
 import { InjectionOrchestrator } from '../context/orchestrator';
@@ -203,14 +204,24 @@ function workflowsGlobalCheck(agent: AgentTarget): ProviderCheck | null {
     // Los workflows se instalan con el renderer `link`, asi que un symlink colgante es
     // exactamente la misma clase de rotura que en skills — y se clasifica con la misma
     // funcion, no con una copia local que pueda divergir.
-    const integrity = classifySkillLinks(dir, contentRoots());
+    //
+    // El ledger va SIEMPRE que se escanee un dir gestionado. Cuando se agrego la
+    // deteccion de usurpaciones (D-007) se cableo en el seam `scanSkills`, que alimenta
+    // `skills.global` — y este sitio, que llama al clasificador directo, quedo afuera:
+    // detectaba links colgantes y no un workflow reemplazado por contenido ajeno. Es el
+    // mismo hermano-sin-tratar que ya aparecio varias veces en este archivo.
+    const integrity = classifySkillLinks(dir, contentRoots(), managedLinkTargets(safeArtifactState()));
     const broken = integrity.repairable.length + integrity.dead.length;
+    const usurped = integrity.usurped.length;
     return {
         id: 'workflows.global',
-        state: broken > 0 ? 'broken' : 'healthy',
+        state: broken > 0 || usurped > 0 ? 'broken' : 'healthy',
         target: dir,
-        detail: broken > 0 ? `${broken} broken link(s)` : undefined,
-        remediationCode: broken > 0 ? 'awm-init' : undefined,
+        detail: [
+            broken > 0 ? `${broken} broken link(s)` : null,
+            usurped > 0 ? `${usurped} replaced by non-AWM content (${integrity.usurped.join(', ')})` : null,
+        ].filter(Boolean).join('; ') || undefined,
+        remediationCode: usurped > 0 ? 'reinstall-usurped-skills' : broken > 0 ? 'awm-init' : undefined,
     };
 }
 
@@ -248,7 +259,31 @@ function agentsNativeCheck(agent: AgentTarget): ProviderCheck | null {
             remediationCode: broken > 0 ? 'reinstall-native-agents' : undefined,
         };
     }
-    return { id: 'agents.native', state: 'healthy', target: dir };
+    // Renderer `link` (claude-code, `~/.claude/agents`): esto devolvia `healthy` fijo
+    // con solo mirar que el dir no estuviera vacio. Un symlink colgante ahi adentro
+    // pasaba, y un artefacto reemplazado por contenido de un tercero tambien — el
+    // agente cargaba el ajeno mientras doctor daba verde. El dir es gestionado igual
+    // que el de skills, asi que se verifica igual.
+    const integrity = classifySkillLinks(dir, contentRoots(), managedLinkTargets(safeArtifactState()));
+    const broken = integrity.repairable.length + integrity.dead.length;
+    const usurped = integrity.usurped.length;
+    return {
+        id: 'agents.native',
+        state: broken > 0 || usurped > 0 ? 'broken' : 'healthy',
+        target: dir,
+        detail: [
+            broken > 0 ? `${broken} broken link(s)` : null,
+            usurped > 0 ? `${usurped} replaced by non-AWM content (${integrity.usurped.join(', ')})` : null,
+        ].filter(Boolean).join('; ') || undefined,
+        remediationCode: usurped > 0 ? 'reinstall-usurped-skills' : broken > 0 ? 'reinstall-native-agents' : undefined,
+    };
+}
+
+/** El ledger de propiedad, best-effort: un archivo ausente o corrupto degrada a "no
+ *  puedo detectar usurpaciones", nunca revienta un comando de diagnostico. Mismo
+ *  criterio que `safeReadArtifactState` en context.ts. */
+function safeArtifactState(): ManagedArtifactRecord[] {
+    try { return readArtifactState(); } catch { return []; }
 }
 
 function hookTrustCheck(agent: AgentTarget): ProviderCheck | null {

--- a/cli/src/core/diagnostics/types.ts
+++ b/cli/src/core/diagnostics/types.ts
@@ -52,7 +52,14 @@ export interface ProjectFacts {
      *  ninguna extension del profile — huerfanos. `activeBundles.broken` solo mira lo
      *  que el profile espera, asi que un link cuya extension se retiro no aparecia en
      *  ninguna superficie. `repairable` los puede recuperar el registry; `dead` no. */
-    orphanLinks: { repairable: string[]; dead: string[] };
+    orphanLinks: {
+        repairable: string[];
+        dead: string[];
+        /** Skills que el profile SI reclama, cuyo link fue reemplazado por contenido de
+         *  un tercero. Categoria aparte de los huerfanos porque el remedio difiere: ver
+         *  `docs/decisions.md` D-007. */
+        usurped: string[];
+    };
     sensors: { present: boolean };
     constitution: { present: boolean };
     context: { present: boolean; file?: 'CLAUDE.md' | 'AGENTS.md' };

--- a/cli/src/release/orchestrator.ts
+++ b/cli/src/release/orchestrator.ts
@@ -130,8 +130,55 @@ export function release(opts: ReleaseOpts, io: ReleaseIO): ReleaseResult {
   }
 
   if (opts.push) {
-    io.run('git', ['push', 'origin', opts.branch]);
+    // El TAG primero, y a proposito.
+    //
+    // Despues de un publish exitoso ya no hay vuelta atras: npm tiene la version. A
+    // partir de aca todo fallo de git deja a npm adelantado respecto del repo, y lo
+    // unico que decide cuan grave es eso es CUANTO alcanzo a quedar registrado.
+    //
+    // Un tag no puede entrar en conflicto — es una ref nueva —, asi que se empuja
+    // antes: en el peor caso queda el tag que identifica exactamente que se publico,
+    // y lo unico que falta es el commit de bump, que una persona puede reponer. Al
+    // reves (main primero) un push rechazado se lleva puesta tambien la identidad de
+    // la version, que es lo que paso con la 4.0.1: publicada, sin tag, sin CHANGELOG.
     io.run('git', ['push', 'origin', `v${version}`]);
+
+    // El push de `main` SI puede perder una carrera. Se reintenta rebaseando: el commit
+    // de bump toca solo `cli/package.json` y `CHANGELOG.md`, y lleva `[skip ci]`.
+    pushBranchWithRebase(io, opts.branch, version);
   }
   return { released: true, version };
+}
+
+const PUSH_ATTEMPTS = 3;
+
+/**
+ * Empuja `branch` reintentando con `pull --rebase` ante un rechazo. Si agota los
+ * intentos tira un error que NOMBRA el estado real del mundo — npm publicado, git a
+ * medias — en vez de un "failed to push some refs" que no dice que hacer.
+ *
+ * El `concurrency` de release.yml deberia hacer que esto no llegue a usarse nunca.
+ * Esta igual porque serializar evita la carrera CONOCIDA, y este es el unico punto del
+ * pipeline donde un fallo es irreversible a medias.
+ */
+function pushBranchWithRebase(io: ReleaseIO, branch: string, version: string): void {
+    for (let attempt = 1; attempt <= PUSH_ATTEMPTS; attempt++) {
+        try {
+            io.run('git', ['push', 'origin', branch]);
+            return;
+        } catch (err) {
+            if (attempt === PUSH_ATTEMPTS) {
+                throw new Error(
+                    `v${version} YA SE PUBLICO en npm, pero el commit de bump no se pudo ` +
+                    `empujar a '${branch}' despues de ${PUSH_ATTEMPTS} intentos. El tag ` +
+                    `v${version} si esta en el remoto. Para reconciliar: rebasar el commit ` +
+                    `'chore(release): v${version}' sobre origin/${branch} y empujarlo a mano. ` +
+                    `NO re-publicar. Causa: ${(err as Error).message}`,
+                );
+            }
+            // Un fallo de red no lo arregla el rebase, pero tampoco lo empeora: el
+            // siguiente intento reintenta el push igual.
+            try { io.run('git', ['pull', '--rebase', 'origin', branch]); } catch { /* el retry decide */ }
+        }
+    }
 }

--- a/cli/tests/core/diagnostics/checks.test.ts
+++ b/cli/tests/core/diagnostics/checks.test.ts
@@ -20,7 +20,7 @@ function healthyProject(): ProjectFacts {
         root: '/repo/belanz',
         profile: { present: true, extensions: ['frontend'] },
         activeBundles: { expected: ['frontend-craft'], linked: ['frontend-craft'], broken: [] },
-        orphanLinks: { repairable: [], dead: [] },
+        orphanLinks: { repairable: [], dead: [], usurped: [] },
         sensors: { present: true },
         constitution: { present: true },
         context: { present: true, file: 'CLAUDE.md' },

--- a/cli/tests/core/init/steps.test.ts
+++ b/cli/tests/core/init/steps.test.ts
@@ -36,7 +36,7 @@ function project(over: Partial<ProjectFacts> = {}): ProjectFacts {
         root: '/repo',
         profile: { present: true, extensions: [] },
         activeBundles: { expected: [], linked: [], broken: [] },
-        orphanLinks: { repairable: [], dead: [] },
+        orphanLinks: { repairable: [], dead: [], usurped: [] },
         sensors: { present: true },
         constitution: { present: true },
         context: { present: true, file: 'CLAUDE.md' },

--- a/cli/tests/core/usurped-skill-links.test.ts
+++ b/cli/tests/core/usurped-skill-links.test.ts
@@ -136,3 +136,75 @@ describe('awm doctor degrades on a usurped global skill', () => {
         expect(checkFor([]).state).not.toBe('broken');
     });
 });
+
+// ---------------------------------------------------------------------------
+// Los hermanos: `agents.native` y `workflows.global` escanean dirs igual de
+// gestionados, y no recibieron el tratamiento cuando se agrego la deteccion.
+// ---------------------------------------------------------------------------
+//
+// Encontrado validando la v5.0.0: una sonda apunto sin querer a
+// `~/.claude/agents/development-process.md`, lo reemplazo por un directorio ajeno, y
+// `doctor` siguio diciendo `healthy`. `agents.native` con renderer `link` devolvia
+// `healthy` fijo con solo mirar que el dir no estuviera vacio — ni siquiera detectaba
+// un symlink colgante. Tres hermanos, uno tratado.
+
+describe('agents.native gets the same treatment as skills.global', () => {
+    let tmpHome: string;
+    let originalHome: string | undefined;
+    let originalAwmHome: string | undefined;
+
+    beforeEach(() => {
+        tmpHome = mkCanonicalTmpDir('awm-usurp-agents-');
+        originalHome = process.env.HOME;
+        originalAwmHome = process.env.AWM_HOME;
+        process.env.HOME = tmpHome;
+        process.env.AWM_HOME = path.join(tmpHome, '.awm');
+        // registries.ts cachea AWM_HOME al require: hay que re-requerir por test.
+        jest.resetModules();
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+        if (originalHome === undefined) delete process.env.HOME; else process.env.HOME = originalHome;
+        if (originalAwmHome === undefined) delete process.env.AWM_HOME; else process.env.AWM_HOME = originalAwmHome;
+    });
+
+    /** Deja en `~/.claude/agents` una entrada real (no symlink) y la declara nuestra. */
+    function seedUsurpedAgent(name: string): void {
+        const dir = path.join(tmpHome, '.claude', 'agents');
+        fs.mkdirSync(dir, { recursive: true });
+        fs.mkdirSync(path.join(dir, name), { recursive: true });
+        const stateDir = path.join(tmpHome, '.awm', 'state');
+        fs.mkdirSync(stateDir, { recursive: true });
+        fs.writeFileSync(path.join(stateDir, 'artifacts.json'), JSON.stringify([{
+            name, type: 'agent', scope: 'global',
+            targetPath: path.join(dir, name),
+            sourcePath: '/registry/agents/' + name,
+            renderer: 'link', owners: ['claude-code'],
+        }], null, 2));
+    }
+
+    function agentsCheck() {
+        const { gatherProviderChecks } = require('../../src/core/diagnostics/provider-checks');
+        const scan = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
+        const facts = gatherProviderChecks(['claude-code'], scan);
+        return facts[0].checks.find((c: { id: string }) => c.id === 'agents.native');
+    }
+
+    it('reports broken and names the replaced agent', () => {
+        seedUsurpedAgent('development-process');
+        const check = agentsCheck();
+        expect(check.state).toBe('broken');
+        expect(check.detail).toContain('development-process');
+        expect(check.remediationCode).toBe('reinstall-usurped-skills');
+    });
+
+    it('stays healthy when the directory holds only entries AWM never claimed', () => {
+        // Lo que el usuario puso a mano sigue sin ser problema nuestro — el mismo
+        // limite que en skills.global. Sin ledger no hay usurpacion posible.
+        const dir = path.join(tmpHome, '.claude', 'agents');
+        fs.mkdirSync(dir, { recursive: true });
+        fs.mkdirSync(path.join(dir, 'my-own-agent'), { recursive: true });
+        expect(agentsCheck().state).toBe('healthy');
+    });
+});

--- a/cli/tests/release/orchestrator.test.ts
+++ b/cli/tests/release/orchestrator.test.ts
@@ -202,3 +202,60 @@ describe('parseArgs', () => {
     expect(() => parseArgs(['--branch'])).toThrow(/--branch requiere/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// D-009 — despues del publish, un fallo de git no puede quedar en silencio
+// ---------------------------------------------------------------------------
+//
+// La 4.0.1 existe en npm y no existe en git: sin tag, sin CHANGELOG. Dos corridas
+// de release concurrentes (mergear un PR mientras el release del anterior estaba en
+// vuelo) dejaron a la segunda adelantando `main`, y la primera murio en
+// `git push origin main` con non-fast-forward DESPUES de publicar.
+//
+// El publish es irreversible; el push no. Ningun test cubria el orden entre ambos ni
+// que pasa si el push falla — el happy path afirmaba que las dos lineas existen, no
+// en que orden ni con que recuperacion.
+
+describe('release — el push despues de un publish exitoso', () => {
+  it('empuja el TAG antes que la rama: en el peor caso queda la identidad de lo publicado', () => {
+    const { io, calls } = makeIO({ commits: `feat: x${US}${RS}` });
+    release(opts(), io);
+    const tagPush = calls.findIndex((c) => c === 'git push origin v2.2.0');
+    const branchPush = calls.findIndex((c) => c === 'git push origin main');
+    expect(tagPush).toBeGreaterThanOrEqual(0);
+    expect(branchPush).toBeGreaterThanOrEqual(0);
+    expect(tagPush).toBeLessThan(branchPush);
+  });
+
+  it('reintenta con rebase cuando la rama se movio bajo los pies', () => {
+    let branchPushes = 0;
+    const { io, calls } = makeIO({ commits: `feat: x${US}${RS}` });
+    const inner = io.run;
+    io.run = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'push' && args[2] === 'main') {
+        branchPushes++;
+        // Exactamente el fallo real: la primera vez rechazado, despues del rebase pasa.
+        if (branchPushes === 1) throw new Error('! [rejected] main -> main (non-fast-forward)');
+      }
+      return inner(cmd, args);
+    };
+    expect(() => release(opts(), io)).not.toThrow();
+    expect(branchPushes).toBe(2);
+    expect(calls.join('\n')).toMatch(/git pull --rebase origin main/);
+  });
+
+  it('si el push no se recupera, el error NOMBRA que npm ya tiene la version', () => {
+    const { io } = makeIO({ commits: `feat: x${US}${RS}` });
+    const inner = io.run;
+    io.run = (cmd, args) => {
+      if (cmd === 'git' && args[0] === 'push' && args[2] === 'main') {
+        throw new Error('! [rejected] main -> main (non-fast-forward)');
+      }
+      return inner(cmd, args);
+    };
+    // Un "failed to push some refs" pelado no le dice a nadie que npm quedo adelantado
+    // ni que NO hay que re-publicar. Eso es lo que se asserta, no que tire.
+    expect(() => release(opts(), io)).toThrow(/YA SE PUBLICO en npm/);
+    expect(() => release(opts(), io)).toThrow(/NO re-publicar/);
+  });
+});

--- a/cli/tests/structural/managed-dir-scans-consult-the-ledger.test.ts
+++ b/cli/tests/structural/managed-dir-scans-consult-the-ledger.test.ts
@@ -1,0 +1,91 @@
+// `classifySkillLinks` sin el ledger no puede ver una usurpacion. Ese tercer
+// argumento es opcional a proposito — hay llamadores legitimos que no tienen ledger a
+// mano — y por eso mismo es facil de omitir sin que nada se queje.
+//
+// Ya paso: cuando se agrego la deteccion (D-007) se cableo en el seam `scanSkills`,
+// que alimenta `skills.global`, y los otros dos checks del mismo archivo que llaman al
+// clasificador directo — `workflows.global` y `agents.native` — quedaron afuera. Tres
+// hermanos, uno tratado. Es el patron que mas se repitio en este repo, y la unica
+// contramedida que funciona es que el compilador o un test lo cuenten por vos.
+//
+// Este guard es deliberadamente estrecho: solo mira `core/diagnostics/`, que es donde
+// vive el reporte de salud. Un llamador de otro modulo puede omitir el ledger sin que
+// esto se queje; lo que no puede pasar es que un CHECK diga `healthy` sobre un
+// directorio gestionado que nunca comparo contra el ledger.
+import fs from 'fs';
+import path from 'path';
+
+const DIAGNOSTICS = path.join(__dirname, '..', '..', 'src', 'core', 'diagnostics');
+
+function sourceFiles(dir: string): string[] {
+    return fs.readdirSync(dir)
+        .filter((f) => f.endsWith('.ts'))
+        .map((f) => path.join(dir, f));
+}
+
+/** Cada `classifySkillLinks(...)` del archivo, con su lista de argumentos en crudo.
+ *  Contar comas de nivel superior alcanza: los argumentos reales son identificadores y
+ *  llamadas simples, sin literales de objeto ni genericos con coma. */
+function classifyCalls(source: string): { args: string; line: number }[] {
+    const out: { args: string; line: number }[] = [];
+    const needle = 'classifySkillLinks(';
+    let from = 0;
+    for (;;) {
+        const at = source.indexOf(needle, from);
+        if (at === -1) return out;
+        from = at + needle.length;
+        let depth = 1;
+        let i = from;
+        while (i < source.length && depth > 0) {
+            if (source[i] === '(') depth++;
+            else if (source[i] === ')') depth--;
+            i++;
+        }
+        out.push({
+            args: source.slice(from, i - 1),
+            line: source.slice(0, at).split('\n').length,
+        });
+    }
+}
+
+function topLevelArgCount(args: string): number {
+    if (args.trim() === '') return 0;
+    let depth = 0;
+    let count = 1;
+    for (const ch of args) {
+        if (ch === '(' || ch === '[' || ch === '{') depth++;
+        else if (ch === ')' || ch === ']' || ch === '}') depth--;
+        else if (ch === ',' && depth === 0) count++;
+    }
+    return count;
+}
+
+describe('every diagnostics scan of a managed directory consults the ownership ledger', () => {
+    it('no classifySkillLinks call under core/diagnostics/ omits the managed-targets argument', () => {
+        const offenders: string[] = [];
+
+        for (const file of sourceFiles(DIAGNOSTICS)) {
+            const source = fs.readFileSync(file, 'utf8');
+            for (const call of classifyCalls(source)) {
+                // La definicion importada no es una llamada; el parser solo ve `nombre(`.
+                if (topLevelArgCount(call.args) < 3) {
+                    offenders.push(`${path.basename(file)}:${call.line} — ${call.args.trim()}`);
+                }
+            }
+        }
+
+        expect(offenders).toEqual([]);
+    });
+
+    it('the guard can actually see a violation (it is not vacuously green)', () => {
+        // Si el parser se rompiera, el test de arriba pasaria para siempre sin mirar nada.
+        expect(topLevelArgCount('dir, contentRoots()')).toBe(2);
+        expect(topLevelArgCount('dir, contentRoots(), managedLinkTargets(state())')).toBe(3);
+    });
+
+    it('there is at least one call to guard, so the sweep is not scanning an empty set', () => {
+        const total = sourceFiles(DIAGNOSTICS)
+            .reduce((n, f) => n + classifyCalls(fs.readFileSync(f, 'utf8')).length, 0);
+        expect(total).toBeGreaterThan(0);
+    });
+});

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -14,6 +14,7 @@ Formato: qué se decidió, por qué, qué implica. Sin historia larga — eso vi
 | [D-006](#d-006) | 2026-08-09 | `awm remove` tiene modo no interactivo, simétrico con `add` | Vigente |
 | [D-007](#d-007) | 2026-08-09 | Un artefacto usurpado se **reporta**, no se auto-repara | Vigente |
 | [D-008](#d-008) | 2026-08-09 | El exit code de `awm init` responde por init, no por la salud del harness | Vigente |
+| [D-009](#d-009) | 2026-08-09 | Los releases se serializan, y el tag se empuja antes que la rama | Vigente |
 
 ---
 
@@ -174,3 +175,43 @@ leer `result` del `--json`.
 **Cómo se detuvo:** el sitio que faltaba era el test ausente — ningún test preguntaba si un
 script podía encadenar `awm init &&`. Había dos assertions de `toBe(1)`, y las dos
 *documentaban* el bug en vez de detenerlo.
+
+---
+
+## D-009
+
+**Los releases corren de a uno, y despues del publish el tag se empuja antes que la rama.**
+
+Salio de validar la v5.0.0: **`4.0.1` existe en npm y no existe en git** — sin tag `v4.0.1`,
+sin entrada de CHANGELOG, sin commit de bump. Es instalable y no hay forma de decir desde
+el repo que la produjo.
+
+**Como paso:** mergeé el PR #45 mientras el release de #44 estaba en vuelo. La corrida de
+#44 hizo commit, tag, **publish**, y recien despues `git push origin main` — que ya estaba
+atras, y fue rechazado por non-fast-forward. El job murio ahi. npm quedo con la version;
+git no se entero.
+
+**El orden importaba y estaba al reves.** El publish es irreversible; el push no. Todo lo
+que se haga despues de publicar puede fallar y dejar a npm adelantado, asi que lo unico que
+se decide es cuanto alcanza a quedar registrado.
+
+**Implica:**
+- `release.yml` declara `concurrency: { group: release-<ref>, cancel-in-progress: false }`.
+  Serializa. `cancel-in-progress: false` es la mitad importante: cancelar un release a
+  mitad de camino es justo el modo de falla que se quiere evitar — la segunda corrida
+  **espera**.
+- Despues del publish se empuja **primero el tag**, que no puede entrar en conflicto (es
+  una ref nueva). En el peor caso queda la identidad exacta de lo publicado, y lo unico
+  que falta es el commit de bump, que una persona repone.
+- El push de la rama reintenta con `pull --rebase` (3 intentos). Si igual no entra, el
+  error **nombra el estado real**: `vX.Y.Z YA SE PUBLICO en npm … NO re-publicar`, con la
+  instruccion de reconciliar a mano. Un `failed to push some refs` pelado no le dice a
+  nadie que npm quedo adelantado.
+
+**El sitio que faltaba era el test ausente:** el happy path afirmaba que las dos lineas de
+push existen — no en que orden, y nada cubria que pasa si una falla.
+
+**Pendiente, y no lo decide el codigo:** que hacer con la `4.0.1` publicada. Las opciones
+son dejarla (es funcionalmente la 4.0.0 mas el fix de `doctor`), taggearla
+retroactivamente sobre el merge de #44, o deprecarla en npm. Deprecar es visible para
+cualquiera que la instale, asi que lo decide una persona.


### PR DESCRIPTION
Dos hallazgos de **validar la v5.0.0 publicada**. Ninguno estaba en el plan; los dos salieron de mirar el resultado en vez de asumirlo.

## 1 · La `4.0.1` existe en npm y no existe en git

Sin tag `v4.0.1`, sin entrada de CHANGELOG, sin commit de bump. Es instalable, y **desde el repo no hay forma de decir qué la produjo**.

Mergeé el PR #45 mientras el release de #44 estaba en vuelo. La corrida de #44 hizo commit → tag → **publish** → `git push origin main`, que ya estaba atrás y fue rechazado por non-fast-forward. El job murió ahí. npm quedó con la versión; git no se enteró.

**El orden importaba y estaba al revés.** El publish es irreversible; el push no. Todo lo que se haga después de publicar puede fallar y dejar a npm adelantado — lo único que se decide es cuánto alcanza a quedar registrado.

- `release.yml` serializa: `concurrency: { group: release-<ref>, cancel-in-progress: false }`. El `false` es la mitad importante — cancelar un release a mitad de camino es justo el modo de falla que se quiere evitar; la segunda corrida **espera**.
- Después del publish se empuja **primero el tag**, que no puede entrar en conflicto (es una ref nueva). En el peor caso queda la identidad exacta de lo publicado, y falta solo el commit de bump, que una persona repone.
- El push de la rama reintenta con `pull --rebase` (3 intentos). Si igual no entra, el error nombra el estado real: `vX.Y.Z YA SE PUBLICO en npm … NO re-publicar`. Un `failed to push some refs` pelado no le dice a nadie que npm quedó adelantado.

## 2 · Tres hermanos sin el tratamiento de D-007

La detección de usurpaciones se cableó en el seam `scanSkills`, que alimenta `skills.global`. Los otros escaneos de directorios **igual de gestionados** quedaron afuera — y uno de ellos lo introduje yo en #46.

Lo encontró una sonda que apuntó *sin querer* a `~/.claude/agents/`: reemplacé un artefacto por un directorio ajeno y `doctor` siguió diciendo `healthy`.

| Check | Antes | Ahora |
|---|---|---|
| `agents.native` (renderer `link`) | `healthy` fijo con solo mirar que el dir no esté vacío — **ni siquiera veía un symlink colgante** | clasifica igual que skills |
| `workflows.global` | detectaba colgantes, no reemplazos | detecta ambos |
| skills de **proyecto** | ídem | fila propia `project.usurped` |

`project.usurped` es fila aparte de `project.orphans` y con **otro remedio**: `awm sync` solo toca symlinks, así que sobre un directorio real corre limpio sin cambiar nada. Mandar ahí al usuario sería peor que no ofrecer remedio.

**Guard estructural nuevo:** ningún `classifySkillLinks` bajo `core/diagnostics/` puede omitir el ledger. No es decorativo — **es el guard el que encontró el tercer hermano**; yo había arreglado dos y lo daba por cerrado. Incluye dos assertions de que no está vacuamente verde.

## Verificación

Los dos sitios que faltaban eran **tests ausentes**, no tests equivocados: el happy path del release afirmaba que las dos líneas de push existen — no en qué orden, ni qué pasa si una falla.

- **Revert probe en ambos:** 3 tests a rojo con el orden viejo de push; 2 con el `agents.native` viejo.
- Suite: **177 suites / 1736 tests**.

## Lo que no decide este PR

Qué hacer con la `4.0.1` ya publicada: dejarla (es funcionalmente 4.0.0 + el fix de `doctor`), taggearla retroactivamente sobre el merge de #44, o deprecarla en npm. **Deprecar es visible para cualquiera que la instale, así que lo decide una persona.** Anotado en D-009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_