### PR TITLE
fix(hooks): stop reporting HEALTHY for a hook that was never seen running

### DIFF
--- a/cli/src/commands/hooks/codex.ts
+++ b/cli/src/commands/hooks/codex.ts
@@ -139,16 +139,21 @@ export function computeCodexHookStatus(agent: 'codex'): HookStatus {
     const allOk = sessionStartScript.ok && settingsEntry.ok;
     const settingsOnlyMissing = !settingsEntry.ok && sessionStartScript.ok;
 
-    let overall: HookStatus['overall'];
-    if (allOk) overall = 'HEALTHY';
-    else if (settingsOnlyMissing) overall = 'NOT_INSTALLED';
-    else overall = 'DEGRADED';
-
     // Trust only makes sense once the AWM entry is actually present in
     // hooks.json — otherwise there's nothing installed to trust.
     const trust = settingsEntry.ok
         ? computeCodexTrust(sessionStartScript, scriptPath, heartbeatPath)
         : undefined;
+
+    // `overall` IGNORABA `trust` por completo, asi que `awm hooks status` imprimia
+    // `Status: HEALTHY` dos lineas debajo de `Trust: … pending-trust`. Una corrida real
+    // del playbook leyo esa salida y concluyo que el hook andaba. `doctor --json` decia
+    // la verdad; la vista humana, no — y es la que mira una persona. Ver D-010.
+    let overall: HookStatus['overall'];
+    if (!allOk) overall = settingsOnlyMissing ? 'NOT_INSTALLED' : 'DEGRADED';
+    else if (trust === 'stale') overall = 'DEGRADED';
+    else if (trust === 'pending-trust') overall = 'PENDING_TRUST';
+    else overall = 'HEALTHY';
 
     return {
         overall,

--- a/cli/src/commands/hooks/index.ts
+++ b/cli/src/commands/hooks/index.ts
@@ -10,6 +10,17 @@ import { capabilityRoot } from '../../core/registries';
 
 const HOOK_TARGETS = AGENT_TARGETS.filter((a) => getHookConfig(a));
 
+/**
+ * `hooks` nacio con `-t, --target` y el resto del CLI (`add`, `remove`, `sync`,
+ * `update`, `doctor`) usa `-a, --agent`. La asimetria se cobro una corrida real del
+ * playbook: `awm hooks status --agent codex` fallaba con `unknown option`. Se acepta
+ * `--agent` como alias en vez de renombrar, para no romper a quien ya scriptea
+ * `--target`. Ver D-010.
+ */
+function resolveHookTarget(options: { target?: string; agent?: string }): AgentTarget {
+    return (options.agent ?? options.target ?? 'claude-code') as AgentTarget;
+}
+
 function targetOptionDescription(): string {
     return `Target harness (${HOOK_TARGETS.join('|')})`;
 }
@@ -20,9 +31,10 @@ export function registerHooksCommand(program: Command): void {
     hooks.command('install')
         .description('Install the AWM bootstrap hook into the target harness')
         .option('-t, --target <target>', targetOptionDescription(), 'claude-code')
+        .option('-a, --agent <agent>', 'Alias de --target, por simetria con el resto del CLI')
         .option('-y, --yes', 'Skip interactive confirmations', false)
-        .action(async (options: { target?: string; yes?: boolean }) => {
-            const agent = (options.target ?? 'claude-code') as AgentTarget;
+        .action(async (options: { target?: string; agent?: string; yes?: boolean }) => {
+            const agent = resolveHookTarget(options);
             const prefs = getPreferences();
 
             const hooksRoot = capabilityRoot('hooks');
@@ -72,9 +84,10 @@ export function registerHooksCommand(program: Command): void {
     hooks.command('uninstall')
         .description('Remove the AWM bootstrap hook')
         .option('-t, --target <target>', targetOptionDescription(), 'claude-code')
+        .option('-a, --agent <agent>', 'Alias de --target, por simetria con el resto del CLI')
         .option('-y, --yes', 'Skip interactive confirmations', false)
-        .action(async (options: { target?: string; yes?: boolean }) => {
-            const agent = (options.target ?? 'claude-code') as AgentTarget;
+        .action(async (options: { target?: string; agent?: string; yes?: boolean }) => {
+            const agent = resolveHookTarget(options);
 
             if (!options.yes && process.stdin.isTTY) {
                 const ok = await confirm({ message: 'Remove AWM bootstrap hook from settings.json?' });
@@ -103,8 +116,9 @@ export function registerHooksCommand(program: Command): void {
     hooks.command('status')
         .description('Check the bootstrap hook installation status')
         .option('-t, --target <target>', targetOptionDescription(), 'claude-code')
-        .action((options: { target?: string }) => {
-            const agent = (options.target ?? 'claude-code') as AgentTarget;
+        .option('-a, --agent <agent>', 'Alias de --target, por simetria con el resto del CLI')
+        .action((options: { target?: string; agent?: string }) => {
+            const agent = resolveHookTarget(options);
             try {
                 const result = computeHookStatus(agent);
                 const symbol = (ok: boolean) => ok ? pc.green('✓') : pc.red('✗');
@@ -123,10 +137,17 @@ export function registerHooksCommand(program: Command): void {
                 }
                 console.log('');
                 const overall = result.overall === 'HEALTHY' ? pc.green(result.overall) :
-                                result.overall === 'NOT_INSTALLED' ? pc.yellow(result.overall) :
-                                pc.red(result.overall);
+                                result.overall === 'NOT_INSTALLED' || result.overall === 'PENDING_TRUST'
+                                    ? pc.yellow(result.overall)
+                                    : pc.red(result.overall);
                 console.log(`  Status: ${overall}`);
-                if (result.overall !== 'HEALTHY') {
+                if (result.overall === 'PENDING_TRUST') {
+                    console.log(pc.dim('  El hook esta instalado y bien formado, pero nunca se lo vio correr.'));
+                    console.log(pc.dim('  Abri una sesion del agente; si sigue igual, no se esta disparando.'));
+                }
+                // PENDING_TRUST no sale 1: no hay nada roto que arreglar, y salir 1 en
+                // toda instalacion recien hecha convertiria el comando en ruido.
+                if (result.overall !== 'HEALTHY' && result.overall !== 'PENDING_TRUST') {
                     process.exit(1);
                 }
             } catch (e: any) {

--- a/cli/src/commands/hooks/shared.ts
+++ b/cli/src/commands/hooks/shared.ts
@@ -133,7 +133,10 @@ export function checkFile(file: string): CheckResult {
 }
 
 export type HookStatus = {
-    overall: 'HEALTHY' | 'DEGRADED' | 'NOT_INSTALLED';
+    /** `PENDING_TRUST`: instalado y bien formado, pero NUNCA se lo vio correr. No es
+     *  `HEALTHY` — un hook que nunca corrio no se puede afirmar que entregue contexto —
+     *  y tampoco `DEGRADED`, porque no hay nada roto que arreglar. Ver D-010. */
+    overall: 'HEALTHY' | 'DEGRADED' | 'NOT_INSTALLED' | 'PENDING_TRUST';
     // Codex-only: whether a runtime heartbeat confirms the installed script
     // matches what actually ran last session. Absent for agents (Claude)
     // that don't have a heartbeat mechanism.

--- a/cli/tests/commands/hooks/codex.test.ts
+++ b/cli/tests/commands/hooks/codex.test.ts
@@ -189,6 +189,30 @@ describe('installHook / computeHookStatus / uninstallHook — Codex adapter', ()
         expect(computeHookStatus('codex').trust).toBe(expected); // verifies R18
     });
 
+    // `overall` NUNCA se assertaba — solo `.trust` — y por eso el bug vivio: se calculaba
+    // ignorando trust por completo, asi que `awm hooks status` imprimia `Status: HEALTHY`
+    // dos lineas debajo de `Trust: … pending-trust`. Una corrida real del playbook leyo esa
+    // salida y concluyo que el hook andaba. Ver D-010.
+    it.each([
+        [false, 'PENDING_TRUST'],
+        [true, 'HEALTHY'],
+    ])('overall refleja el trust, no solo la presencia de archivos (heartbeat=%s)', (heartbeat, expected) => {
+        installCodexFixture({ heartbeat: heartbeat as boolean });
+        const { computeHookStatus } = require('../../../src/commands/hooks/status');
+        expect(computeHookStatus('codex').overall).toBe(expected);
+    });
+
+    it('un heartbeat obsoleto degrada: el script cambio desde la ultima corrida confirmada', () => {
+        installCodexFixture({ heartbeat: true });
+        fs.writeFileSync(path.join(codexScriptsDir, 'session-start'), '#!/usr/bin/env bash\necho "changed"', { mode: 0o755 });
+
+        const { computeHookStatus } = require('../../../src/commands/hooks/status');
+        const status = computeHookStatus('codex');
+        expect(status.trust).toBe('stale');
+        // Esto era `HEALTHY`: la rotura mas clara de las tres, reportada en verde.
+        expect(status.overall).toBe('DEGRADED');
+    });
+
     it('reports stale trust when the heartbeat hash no longer matches the installed script', () => {
         installCodexFixture({ heartbeat: true });
         fs.writeFileSync(path.join(codexScriptsDir, 'session-start'), '#!/usr/bin/env bash\necho "changed"', { mode: 0o755 });

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -15,6 +15,7 @@ Formato: qué se decidió, por qué, qué implica. Sin historia larga — eso vi
 | [D-007](#d-007) | 2026-08-09 | Un artefacto usurpado se **reporta**, no se auto-repara | Vigente |
 | [D-008](#d-008) | 2026-08-09 | El exit code de `awm init` responde por init, no por la salud del harness | Vigente |
 | [D-009](#d-009) | 2026-08-09 | Los releases se serializan, y el tag se empuja antes que la rama | Vigente |
+| [D-010](#d-010) | 2026-08-09 | Un hook que nunca corrió no se reporta `HEALTHY` | Vigente |
 
 ---
 
@@ -215,3 +216,49 @@ push existen — no en que orden, y nada cubria que pasa si una falla.
 son dejarla (es funcionalmente la 4.0.0 mas el fix de `doctor`), taggearla
 retroactivamente sobre el merge de #44, o deprecarla en npm. Deprecar es visible para
 cualquiera que la instale, asi que lo decide una persona.
+
+---
+
+## D-010
+
+**`awm hooks status` deja de decir `HEALTHY` sobre un hook que nunca se vio correr.**
+
+Salio de la corrida del playbook de Codex en el VPC. La salida real que leyo quien lo corrio:
+
+```
+  Trust:              … pending-trust
+
+  Status: HEALTHY
+```
+
+Dos lineas, contradictorias. `overall` se calculaba con `sessionStartScript.ok &&
+settingsEntry.ok` — **ignorando `trust` por completo**. Los archivos estan, entonces
+verde. Que el hook jamas se haya ejecutado no entraba en la cuenta.
+
+`doctor --json` decia la verdad (`hook.trust: pending-trust`). La vista humana no, y es la
+que mira una persona.
+
+**Implica:**
+- `overall` gana `PENDING_TRUST`: instalado y bien formado, pero nunca confirmado
+  corriendo. No es `HEALTHY` — de un hook que nunca corrio no se puede afirmar que
+  entregue contexto — y no es `DEGRADED`, porque no hay nada roto que arreglar.
+- `trust: 'stale'` (el script cambio desde la ultima corrida confirmada) ahora si degrada.
+  Era la rotura mas clara de las tres y se reportaba en verde.
+- `PENDING_TRUST` sale `0`. Salir `1` en toda instalacion recien hecha convertiria el
+  comando en ruido; el texto ya no miente, que era el problema.
+
+**El sitio que faltaba era el test ausente:** los tests de Codex afirmaban `.trust` y
+**nunca** `.overall`. El campo equivocado no lo miraba nadie.
+
+**Ademas, `hooks` acepta `-a, --agent` como alias de `-t, --target`.** `hooks` nacio con
+`--target` y el resto del CLI (`add`, `remove`, `sync`, `update`, `doctor`) usa `--agent`.
+La asimetria se cobro la misma corrida: `awm hooks status --agent codex` fallaba con
+`unknown option`. Se agrega alias en vez de renombrar, para no romper a quien ya scriptea
+`--target`.
+
+**Abierto, del mismo reporte:** `~/.codex/hooks.json` **no** vive bajo `AWM_HOME`, asi que
+una corrida "aislada" del playbook deja ahi una entrada permanente apuntando a un directorio
+temporal. La corrida del VPC termino con DOS entradas de AWM bajo `SessionStart`, ambas con
+el mismo matcher. `awm init` no la reconoce como propia porque compara contra el
+`scriptsDir` actual, y agrega otra. Falta decidir si eso se deduplica, se limpia en el
+teardown del playbook, o ambas.

--- a/docs/testing/agent-matrix.md
+++ b/docs/testing/agent-matrix.md
@@ -263,3 +263,29 @@ bootstrap, que es exactamente el uso del comando. Registrado como decisión pend
 **Nota menor, sin registrar como hallazgo:** Codex reportó ver algunas skills "duplicadas en
 dos registros". `.agents/skills` lo comparten Codex y OpenCode, y una instalación global más
 una de proyecto pueden mostrar el mismo nombre dos veces. No se investigó; queda anotado.
+
+
+---
+
+## Aviso de aislamiento — `hooks.json` NO vive bajo `AWM_HOME`
+
+Los playbooks piden `export AWM_HOME="$HOME/.awm-e2e"` para no tocar tu estado real. Ese
+aislamiento **no cubre el archivo de hooks del agente**: Codex los registra en
+`~/.codex/hooks.json` y Claude Code en `~/.claude/settings.json`, los dos en tu HOME real.
+
+Consecuencia observada en la corrida del VPC: `~/.codex/hooks.json` termino con **dos**
+entradas de AWM bajo `SessionStart`, con el mismo matcher — la de la instalacion real y la
+del entorno de prueba. `awm init` no reconoce la ajena como propia (compara contra el
+`scriptsDir` actual) y agrega la suya.
+
+Eso importa por dos razones:
+
+1. **Contamina el resultado.** Cada entrada escribe su heartbeat al lado de SU script. Si
+   mirás solo el del entorno aislado, podés concluir que el hook no disparo cuando en
+   realidad disparo el otro.
+2. **Queda para siempre.** Una entrada apuntando a un `AWM_HOME` temporal ya borrado se
+   queda ahi, y el agente intenta ejecutarla en cada sesion.
+
+**Antes de correr un playbook de hooks:** mirá `~/.codex/hooks.json` (o
+`~/.claude/settings.json`) y anotá que habia. **Al terminar:** sacá a mano la entrada del
+entorno de prueba. Es la unica parte del teardown que no resuelve borrar `$AWM_HOME`.


### PR DESCRIPTION
Dos hallazgos de la corrida del playbook de Codex en el VPC (`codex-cli 0.146.0`, `awm 5.0.1`).

## 1 · `hooks status` se contradecía a sí mismo

La salida real que leyó quien lo corrió:

```
  Trust:              … pending-trust

  Status: HEALTHY
```

Dos líneas de diferencia. `overall` se calculaba con `sessionStartScript.ok && settingsEntry.ok` — **ignorando `trust` por completo**. Los archivos están, entonces verde. Que el hook jamás se haya ejecutado no entraba en la cuenta.

`doctor --json` decía la verdad (`hook.trust: pending-trust`). La vista humana no, y es la que mira una persona.

| Estado | Antes | Ahora |
|---|---|---|
| nunca corrió (`pending-trust`) | `HEALTHY` | `PENDING_TRUST` |
| script cambió desde la última corrida (`stale`) | `HEALTHY` | `DEGRADED` |

`PENDING_TRUST` es su propio estado a propósito: no es `HEALTHY` — de un hook que nunca corrió no se puede afirmar que entregue contexto — y no es `DEGRADED`, porque no hay nada roto que arreglar. Sale `0`: el texto ya no miente, que era el problema; salir `1` en toda instalación recién hecha convertiría el comando en ruido.

El `stale` es el peor de los dos: significa que el script cambió desde la última corrida confirmada, y se reportaba en verde.

**El sitio que faltaba era el test ausente.** Los tests de Codex afirmaban `.trust` y **nunca** `.overall`. El campo equivocado no lo miraba nadie.

## 2 · `--agent` no existía en `hooks`

`awm hooks status --agent codex` fallaba con `unknown option`. `hooks` nació con `-t, --target` y el resto del CLI (`add`, `remove`, `sync`, `update`, `doctor`) usa `-a, --agent`.

Se agrega **alias**, no rename, para no romper a quien ya scriptea `--target`.

## 3 · Aviso documentado: el aislamiento del playbook tiene un agujero

`~/.codex/hooks.json` y `~/.claude/settings.json` **no viven bajo `AWM_HOME`**. Una corrida "aislada" deja ahí una entrada permanente apuntando a un directorio temporal.

La corrida del VPC terminó con **dos** entradas de AWM bajo `SessionStart`, con el mismo matcher — la instalación real y la de prueba. Importa por dos razones:

1. **Contamina el resultado.** Cada entrada escribe su heartbeat al lado de *su* script. Mirando solo el del entorno aislado se puede concluir que el hook no disparó cuando disparó el otro. Es exactamente la duda que quedó abierta en esa corrida.
2. **Queda para siempre.** Una entrada hacia un `AWM_HOME` ya borrado sigue ahí, y el agente intenta ejecutarla cada sesión.

Documentado en `agent-matrix.md` con el paso de teardown que falta. **Queda abierto** si el producto además debería deduplicar — anotado en D-010.

## Verificación

- **Revert probe:** 2 tests a rojo contra el cálculo viejo de `overall`.
- **Contra el binario construido:** `--agent` y `--target` funcionan los dos.
- Suite: **177 suites / 1739 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_