### PR TITLE
fix(providers)!: resolve each agent's config root from its own env var

### DIFF
--- a/cli/src/core/paths.ts
+++ b/cli/src/core/paths.ts
@@ -18,6 +18,26 @@ export function awmHome(): string {
   return process.env.AWM_HOME || path.join(homeDir(), '.awm');
 }
 
+/**
+ * Raiz de configuracion de un agente, honrando SU propia variable de entorno.
+ *
+ * AWM honra `AWM_HOME` para si mismo (ver `awmHome` arriba) y durante mucho tiempo le
+ * nego esa misma cortesia a todos los agentes que administra: cada ruta de proveedor se
+ * armaba desde `homeDir()` y punto. En una maquina con `CODEX_HOME` apuntando a otro
+ * lado, AWM escribia el hook en `~/.codex/hooks.json` y Codex lo leia desde
+ * `$CODEX_HOME/hooks.json` — instalacion correcta, en el archivo que nadie mira. El hook
+ * quedaba instalado y mudo, y `doctor` lo reportaba presente porque miraba el mismo
+ * lugar equivocado donde lo habia escrito.
+ *
+ * `envVar` en `null` significa "este proveedor no declara override conocido": se usa el
+ * default y listo. No se inventan variables — una que no exista de verdad seria peor que
+ * ninguna, porque prometeria una configurabilidad que no funciona.
+ */
+export function providerConfigHome(envVar: string | null, defaultDir: string): string {
+  const override = envVar ? process.env[envVar]?.trim() : undefined;
+  return override || path.join(homeDir(), defaultDir);
+}
+
 /** Raw platform string (wrapper over process.platform for testability). */
 export function platform(): NodeJS.Platform {
   return process.platform;

--- a/cli/src/providers/index.ts
+++ b/cli/src/providers/index.ts
@@ -1,6 +1,6 @@
 // src/providers/index.ts
 import path from 'path';
-import { awmHome, homeDir } from '../core/paths';
+import { awmHome, homeDir, providerConfigHome } from '../core/paths';
 
 export const AGENT_TARGETS = ['antigravity', 'opencode', 'claude-code', 'codex', 'cursor', 'copilot'] as const;
 
@@ -56,6 +56,10 @@ export type InjectionConfig =
 
 export type ProviderConfig = {
     label: string;
+    /** De donde sale la raiz de configuracion de ESTE agente. `envVar: null` significa
+     *  que no se le conoce override; nunca se inventa una variable, porque prometer una
+     *  configurabilidad que no existe es peor que no ofrecerla. Ver D-011. */
+    configHome: { envVar: string | null; dir: string; resolved: string };
     skill: ArtifactConfig;
     workflow: ArtifactConfig | null;
     agent: ArtifactConfig | null;
@@ -92,20 +96,45 @@ export function unsupportedScopeError(
     );
 }
 
+/** El override declarado por cada agente. Una sola tabla: agregar un proveedor o
+ *  descubrir la variable de otro es una edicion de UNA linea, y el guard estructural
+ *  `provider-paths-honor-config-home` verifica que TODAS sus rutas la respeten. */
+const CONFIG_HOME: Record<AgentTarget, { envVar: string | null; dir: string }> = {
+    // Confirmada contra el binario real: Codex 0.146.0 lee `$CODEX_HOME/hooks.json`.
+    // Una corrida del playbook en una maquina con CODEX_HOME seteado encontro el hook
+    // instalado donde Codex no mira. Ver docs/decisions.md D-011.
+    codex: { envVar: 'CODEX_HOME', dir: '.codex' },
+    // Los demas usan su directorio por defecto. `null` es una afirmacion honesta —
+    // "no le conocemos override"— y no un "no tiene". Cuando se confirme uno contra su
+    // binario, se cambia aca y el guard obliga a que todas sus rutas lo sigan.
+    'claude-code': { envVar: null, dir: '.claude' },
+    opencode: { envVar: null, dir: '.config/opencode' },
+    cursor: { envVar: null, dir: '.cursor' },
+    copilot: { envVar: null, dir: '.github' },
+    antigravity: { envVar: null, dir: '.gemini/antigravity' },
+};
+
+function configHomeFor(agent: AgentTarget): ProviderConfig['configHome'] {
+    const declared = CONFIG_HOME[agent];
+    return { ...declared, resolved: providerConfigHome(declared.envVar, declared.dir) };
+}
+
 export function providers(): Record<AgentTarget, ProviderConfig> {
     const home = homeDir();
     const awm = awmHome();
+    const root = (agent: AgentTarget) => configHomeFor(agent).resolved;
 
     return {
         antigravity: {
             label: 'Antigravity',
+            configHome: configHomeFor('antigravity'),
             skill: {
-                global: path.join(home, '.gemini/antigravity/skills'),
+                global: path.join(root('antigravity'), 'skills'),
                 local: '.agent/skills',
                 renderer: 'link',
             },
             workflow: {
-                global: path.join(home, '.gemini/antigravity/global_workflows'),
+                global: path.join(root('antigravity'), 'global_workflows'),
                 local: '.agent/workflows',
                 renderer: 'link',
             },
@@ -113,6 +142,7 @@ export function providers(): Record<AgentTarget, ProviderConfig> {
         },
         opencode: {
             label: 'OpenCode',
+            configHome: configHomeFor('opencode'),
             skill: {
                 global: path.join(home, '.agents/skills'),
                 local: '.agents/skills',
@@ -120,32 +150,33 @@ export function providers(): Record<AgentTarget, ProviderConfig> {
             },
             workflow: null,
             agent: {
-                global: path.join(home, '.config/opencode/agents'),
+                global: path.join(root('opencode'), 'agents'),
                 local: '.agents/profiles',
                 renderer: 'link',
             },
             injection: {
                 type: 'config-instructions',
-                configPath: path.join(home, '.config/opencode/opencode.json'),
+                configPath: path.join(root('opencode'), 'opencode.json'),
                 field: 'instructions',
             },
         },
         'claude-code': {
             label: 'Claude Code',
+            configHome: configHomeFor('claude-code'),
             skill: {
-                global: path.join(home, '.claude/skills'),
+                global: path.join(root('claude-code'), 'skills'),
                 local: '.claude/skills',
                 renderer: 'link',
             },
             workflow: null,
             agent: {
-                global: path.join(home, '.claude/agents'),
+                global: path.join(root('claude-code'), 'agents'),
                 local: '.claude/agents',
                 renderer: 'link',
             },
             hooks: {
                 type: 'cc-settings-merge',
-                settingsPath: path.join(home, '.claude/settings.json'),
+                settingsPath: path.join(root('claude-code'), 'settings.json'),
                 scriptsDir: path.join(awm, 'hooks'),
                 matcher: 'startup|clear|compact',
                 eventName: 'SessionStart',
@@ -154,6 +185,7 @@ export function providers(): Record<AgentTarget, ProviderConfig> {
         },
         codex: {
             label: 'Codex',
+            configHome: configHomeFor('codex'),
             minimumVersion: '0.145.0',
             versionCommand: { command: 'codex', args: ['--version'], versionPattern: /^codex-cli (\d+\.\d+\.\d+)$/ },
             skill: {
@@ -163,27 +195,28 @@ export function providers(): Record<AgentTarget, ProviderConfig> {
             },
             workflow: null,
             agent: {
-                global: path.join(home, '.codex/agents'),
+                global: path.join(root('codex'), 'agents'),
                 local: '.codex/agents',
                 renderer: 'codex-agent-toml',
             },
             hooks: {
                 type: 'codex-hooks-json',
-                settingsPath: path.join(home, '.codex/hooks.json'),
+                settingsPath: path.join(root('codex'), 'hooks.json'),
                 scriptsDir: path.join(awm, 'hooks/codex'),
                 matcher: 'startup|resume|clear|compact',
                 eventName: 'SessionStart',
             },
             injection: {
                 type: 'managed-agents-md',
-                globalPath: path.join(home, '.codex/AGENTS.md'),
+                globalPath: path.join(root('codex'), 'AGENTS.md'),
                 localFile: 'AGENTS.md',
             },
         },
         cursor: {
             label: 'Cursor',
+            configHome: configHomeFor('cursor'),
             skill: {
-                global: path.join(home, '.cursor/rules'),
+                global: path.join(root('cursor'), 'rules'),
                 local: '.cursor/rules',
                 renderer: 'cursor-mdc',
             },
@@ -201,6 +234,7 @@ export function providers(): Record<AgentTarget, ProviderConfig> {
         },
         copilot: {
             label: 'Copilot',
+            configHome: configHomeFor('copilot'),
             skill: {
                 global: null,
                 globalUnsupportedReason: 'GitHub Copilot has no user-level skill discovery mechanism — skills must be installed per-project.',

--- a/cli/tests/core/context/orchestrator.test.ts
+++ b/cli/tests/core/context/orchestrator.test.ts
@@ -25,7 +25,7 @@ function tmpRegistry(): string {
 
 describe('InjectionOrchestrator (claude-code dispatch via HookMergeStrategy)', () => {
     const ccOverride = {
-        label: 'Claude Code', skill: { global: '', local: '', renderer: 'link' as const }, workflow: null, agent: null,
+        label: 'Claude Code', configHome: { envVar: null, dir: '.test', resolved: '/tmp/test-config-home' }, skill: { global: '', local: '', renderer: 'link' as const }, workflow: null, agent: null,
         injection: { type: 'cc-settings-merge' as const },
         hooks: { type: 'cc-settings-merge' as const, settingsPath: '', scriptsDir: '', matcher: '', eventName: '' },
     };
@@ -69,7 +69,7 @@ describe('InjectionOrchestrator (claude-code dispatch via HookMergeStrategy)', (
     it('throws when providerOverride has no injection (does not fall through to real agent config)', () => {
         const noInjection = {
             label: 'Test',
-            skill: { global: '', local: '', renderer: 'link' as const },
+            configHome: { envVar: null, dir: '.test', resolved: '/tmp/test-config-home' }, skill: { global: '', local: '', renderer: 'link' as const },
             workflow: null,
             agent: null,
         };
@@ -92,7 +92,7 @@ describe('InjectionOrchestrator (opencode, real strategy)', () => {
         registryRoot = tmpRegistry();
         orch = new InjectionOrchestrator({
             providerOverride: {
-                label: 'OpenCode', skill: { global: '', local: '', renderer: 'link' }, workflow: null, agent: null,
+                label: 'OpenCode', configHome: { envVar: null, dir: '.test', resolved: '/tmp/test-config-home' }, skill: { global: '', local: '', renderer: 'link' }, workflow: null, agent: null,
                 injection: { type: 'config-instructions', configPath, field: 'instructions' },
             },
             contextPathOverride: absPath,
@@ -165,7 +165,7 @@ describe('InjectionOrchestrator (codex, managed AGENTS.md strategy)', () => {
         fs.writeFileSync(agentsPath, '# User rules\n');
         const orch = new InjectionOrchestrator({
             providerOverride: {
-                label: 'Codex', skill: { global: '', local: '', renderer: 'link' }, workflow: null, agent: null,
+                label: 'Codex', configHome: { envVar: null, dir: '.test', resolved: '/tmp/test-config-home' }, skill: { global: '', local: '', renderer: 'link' }, workflow: null, agent: null,
                 injection: { type: 'managed-agents-md', globalPath: agentsPath, localFile: 'AGENTS.md' },
             },
             contextPathOverride: contextPath,
@@ -220,7 +220,7 @@ describe('InjectionOrchestrator (local scope materializes under the project, not
     it('materializes to projectContextPath(projectRoot) for scope local, never to globalContextPath()', () => {
         const orch = new InjectionOrchestrator({
             providerOverride: {
-                label: 'Copilot', skill: { global: null, local: '.github/instructions', renderer: 'link' }, workflow: null, agent: null,
+                label: 'Copilot', configHome: { envVar: null, dir: '.test', resolved: '/tmp/test-config-home' }, skill: { global: null, local: '.github/instructions', renderer: 'link' }, workflow: null, agent: null,
                 injection: { type: 'managed-agents-md', globalPath: null, localFile: 'AGENTS.md' },
             },
         });

--- a/cli/tests/core/context/strategies/codex-agents.test.ts
+++ b/cli/tests/core/context/strategies/codex-agents.test.ts
@@ -339,7 +339,7 @@ describe('CodexAgentsStrategy', () => {
 function codexProvider(globalPath: string): ProviderConfig {
     return {
         label: 'Codex',
-        skill: { global: '', local: '', renderer: 'link' },
+        configHome: { envVar: null, dir: '.test', resolved: '/tmp/test-config-home' }, skill: { global: '', local: '', renderer: 'link' },
         workflow: null,
         agent: null,
         injection: { type: 'managed-agents-md', globalPath, localFile: 'AGENTS.md' },
@@ -349,7 +349,7 @@ function codexProvider(globalPath: string): ProviderConfig {
 function copilotProvider(): ProviderConfig {
     return {
         label: 'Copilot',
-        skill: { global: null, local: '.github/instructions', renderer: 'link' },
+        configHome: { envVar: null, dir: '.test', resolved: '/tmp/test-config-home' }, skill: { global: null, local: '.github/instructions', renderer: 'link' },
         workflow: null,
         agent: null,
         injection: { type: 'managed-agents-md', globalPath: null, localFile: 'AGENTS.md' },
@@ -359,7 +359,7 @@ function copilotProvider(): ProviderConfig {
 function cursorProvider(): ProviderConfig {
     return {
         label: 'Cursor',
-        skill: { global: '', local: '.cursor/rules', renderer: 'link' },
+        configHome: { envVar: null, dir: '.test', resolved: '/tmp/test-config-home' }, skill: { global: '', local: '.cursor/rules', renderer: 'link' },
         workflow: null,
         agent: null,
         injection: { type: 'managed-agents-md', globalPath: null, localFile: 'AGENTS.md' },

--- a/cli/tests/core/context/strategies/config-instructions.test.ts
+++ b/cli/tests/core/context/strategies/config-instructions.test.ts
@@ -15,7 +15,7 @@ function setup(opencodeJson?: object) {
     fs.mkdirSync(path.dirname(absPath), { recursive: true });
     fs.writeFileSync(absPath, 'CTX');
     const provider: ProviderConfig = {
-        label: 'OpenCode', skill: { global: '', local: '', renderer: 'link' }, workflow: null, agent: null,
+        label: 'OpenCode', configHome: { envVar: null, dir: '.test', resolved: '/tmp/test-config-home' }, skill: { global: '', local: '', renderer: 'link' }, workflow: null, agent: null,
         injection: { type: 'config-instructions', configPath, field: 'instructions' },
     };
     const input: InjectionInput = {

--- a/cli/tests/providers/index.test.ts
+++ b/cli/tests/providers/index.test.ts
@@ -61,6 +61,8 @@ describe('Providers Routing', () => {
     it('declares the complete Codex capability metadata', () => {
         expect(providerFor('codex')).toEqual({
             label: 'Codex',
+            // El unico proveedor con override confirmado contra su binario real (D-011).
+            configHome: { envVar: 'CODEX_HOME', dir: '.codex', resolved: path.join(tmpHome, '.codex') },
             minimumVersion: '0.145.0',
             versionCommand: { command: 'codex', args: ['--version'], versionPattern: /^codex-cli (\d+\.\d+\.\d+)$/ },
             skill: {
@@ -93,6 +95,7 @@ describe('Providers Routing', () => {
         const graph = providers();
         expect(graph.antigravity).toEqual({
             label: 'Antigravity',
+            configHome: { envVar: null, dir: '.gemini/antigravity', resolved: path.join(tmpHome, '.gemini/antigravity') },
             skill: {
                 global: path.join(tmpHome, '.gemini/antigravity/skills'),
                 local: '.agent/skills',
@@ -107,6 +110,7 @@ describe('Providers Routing', () => {
         });
         expect(graph.opencode).toEqual({
             label: 'OpenCode',
+            configHome: { envVar: null, dir: '.config/opencode', resolved: path.join(tmpHome, '.config/opencode') },
             skill: {
                 global: path.join(tmpHome, '.agents/skills'),
                 local: '.agents/skills',
@@ -126,6 +130,7 @@ describe('Providers Routing', () => {
         });
         expect(graph['claude-code']).toEqual({
             label: 'Claude Code',
+            configHome: { envVar: null, dir: '.claude', resolved: path.join(tmpHome, '.claude') },
             skill: {
                 global: path.join(tmpHome, '.claude/skills'),
                 local: '.claude/skills',

--- a/cli/tests/structural/provider-paths-honor-config-home.test.ts
+++ b/cli/tests/structural/provider-paths-honor-config-home.test.ts
@@ -1,0 +1,98 @@
+// Un proveedor que declara override de home tiene que respetarlo en TODAS sus rutas.
+//
+// El caso que lo motivo: en una maquina con `CODEX_HOME` apuntando fuera del home, AWM
+// instalaba el hook en `~/.codex/hooks.json` mientras Codex leia
+// `$CODEX_HOME/hooks.json`. Instalacion correcta, en el archivo que nadie mira — el hook
+// quedaba mudo, y `doctor` lo reportaba presente porque miraba el mismo lugar equivocado
+// donde lo habia escrito. Tres rutas afectadas (`hooks.json`, `agents/`, `AGENTS.md`), y
+// arreglar una o dos habria dejado el bug vivo en la tercera.
+//
+// Por eso el guard es una PROPIEDAD sobre la tabla entera y no una lista de rutas: no se
+// puede satisfacer arreglando un sitio, y un proveedor nuevo lo hereda sin que nadie se
+// acuerde de agregarlo. Ver docs/decisions.md D-011.
+import path from 'path';
+import { AGENT_TARGETS, AgentTarget, ProviderConfig, providers } from '../../src/providers';
+
+/** Toda ruta absoluta que la config de un proveedor declara, con su nombre de campo. */
+function absolutePaths(config: ProviderConfig): { field: string; value: string }[] {
+    const out: { field: string; value: string }[] = [];
+    const push = (field: string, value: string | null | undefined) => {
+        if (typeof value === 'string' && path.isAbsolute(value)) out.push({ field, value });
+    };
+    push('skill.global', config.skill.global);
+    push('workflow.global', config.workflow?.global);
+    push('agent.global', config.agent?.global);
+    push('hooks.settingsPath', config.hooks?.settingsPath);
+    if (config.injection?.type === 'config-instructions') push('injection.configPath', config.injection.configPath);
+    if (config.injection?.type === 'managed-agents-md') push('injection.globalPath', config.injection.globalPath);
+    return out;
+}
+
+/** Vuelve a pedir la tabla con `env` aplicado. `providers()` la reconstruye en cada
+ *  llamada leyendo el entorno, asi que no hace falta resetear modulos. */
+function providersWith(env: Record<string, string | undefined>): Record<AgentTarget, ProviderConfig> {
+    const previous: Record<string, string | undefined> = {};
+    for (const [k, v] of Object.entries(env)) {
+        previous[k] = process.env[k];
+        if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+    try {
+        return providers();
+    } finally {
+        for (const [k, v] of Object.entries(previous)) {
+            if (v === undefined) delete process.env[k]; else process.env[k] = v;
+        }
+    }
+}
+
+const HOME = path.join(path.sep, 'tmp', 'awm-guard-home');
+const ELSEWHERE = path.join(path.sep, 'tmp', 'awm-guard-elsewhere');
+
+describe('a provider that declares a config-home override honors it everywhere', () => {
+    for (const agent of AGENT_TARGETS) {
+        const declared = providersWith({ HOME })[agent].configHome;
+        if (!declared.envVar) continue;
+
+        it(`${agent}: setting ${declared.envVar} moves every path that lives under its own dir`, () => {
+            const base = providersWith({ HOME, [declared.envVar!]: undefined })[agent];
+            const moved = providersWith({ HOME, [declared.envVar!]: ELSEWHERE })[agent];
+
+            const defaultRoot = path.join(HOME, declared.dir);
+            const under = absolutePaths(base).filter((p) => p.value.startsWith(defaultRoot));
+
+            // Si esto diera 0, el test pasaria sin verificar nada — y ese es exactamente
+            // el modo de falla que hace inutil a un guard.
+            expect(under.length).toBeGreaterThan(0);
+
+            const movedByField = new Map(absolutePaths(moved).map((p) => [p.field, p.value]));
+            const stragglers = under.filter((p) => !movedByField.get(p.field)?.startsWith(ELSEWHERE));
+
+            expect(stragglers.map((p) => `${p.field} = ${movedByField.get(p.field)}`)).toEqual([]);
+        });
+
+        it(`${agent}: an empty or blank ${declared.envVar} falls back to the default, it does not resolve to nothing`, () => {
+            // Una variable exportada vacia es comun en scripts (`export CODEX_HOME=`) y
+            // tomarla al pie de la letra dejaria las rutas colgando de la raiz.
+            for (const blank of ['', '   ']) {
+                const cfg = providersWith({ HOME, [declared.envVar!]: blank })[agent];
+                expect(cfg.configHome.resolved).toBe(path.join(HOME, declared.dir));
+            }
+        });
+    }
+
+    it('shared, cross-agent conventions are NOT moved by one agent’s override', () => {
+        // `~/.agents/skills` lo comparten Codex y OpenCode: es del ecosistema, no de un
+        // agente. Moverlo con CODEX_HOME desconectaria a OpenCode de sus propias skills.
+        const moved = providersWith({ HOME, CODEX_HOME: ELSEWHERE });
+        expect(moved.codex.skill.global).toBe(path.join(HOME, '.agents/skills'));
+        expect(moved.opencode.skill.global).toBe(path.join(HOME, '.agents/skills'));
+    });
+
+    it('every agent declares a config home, so a new provider cannot skip the question', () => {
+        const table = providersWith({ HOME });
+        for (const agent of AGENT_TARGETS) {
+            expect(typeof table[agent].configHome.dir).toBe('string');
+            expect(table[agent].configHome.dir.length).toBeGreaterThan(0);
+        }
+    });
+});

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -16,6 +16,7 @@ Formato: qué se decidió, por qué, qué implica. Sin historia larga — eso vi
 | [D-008](#d-008) | 2026-08-09 | El exit code de `awm init` responde por init, no por la salud del harness | Vigente |
 | [D-009](#d-009) | 2026-08-09 | Los releases se serializan, y el tag se empuja antes que la rama | Vigente |
 | [D-010](#d-010) | 2026-08-09 | Un hook que nunca corrió no se reporta `HEALTHY` | Vigente |
+| [D-011](#d-011) | 2026-08-09 | Cada agente resuelve su raíz de configuración por su propia variable de entorno | Vigente |
 
 ---
 
@@ -262,3 +263,49 @@ temporal. La corrida del VPC termino con DOS entradas de AWM bajo `SessionStart`
 el mismo matcher. `awm init` no la reconoce como propia porque compara contra el
 `scriptsDir` actual, y agrega otra. Falta decidir si eso se deduplica, se limpia en el
 teardown del playbook, o ambas.
+
+---
+
+## D-011
+
+**Cada proveedor declara su variable de entorno de configuración, y TODAS sus rutas la respetan.**
+
+`awm hooks status` decía que el hook de Codex estaba instalado. Codex nunca lo ejecutaba. Los
+dos tenían razón: en esa máquina `CODEX_HOME` apuntaba fuera del home, Codex leía
+`$CODEX_HOME/hooks.json`, y AWM había escrito en `~/.codex/hooks.json`. **Instalación
+correcta, en el archivo que nadie mira.**
+
+Lo peor no fue el bug: fue que `doctor` lo reportara sano. Escribía y verificaba en el
+mismo lugar equivocado, así que el diagnóstico confirmaba su propia suposición. Un chequeo
+que solo puede ver lo que él mismo hizo no es un chequeo.
+
+**La asimetría de fondo:** AWM honra `AWM_HOME` para sí mismo desde siempre, y le negaba
+esa misma cortesía a todos los agentes que administra. Cada ruta de proveedor salía de
+`homeDir()` y punto.
+
+**Implica:**
+- `ProviderConfig` gana `configHome: { envVar, dir, resolved }`. Una sola tabla, `CONFIG_HOME`.
+- `codex: { envVar: 'CODEX_HOME' }` — **confirmado contra el binario real** (0.146.0).
+- Los demás quedan en `envVar: null`. Eso es *"no le conocemos override"*, no *"no tiene"*.
+  **No se inventan variables:** una que no exista prometería una configurabilidad que no
+  funciona, que es peor que no ofrecerla. Confirmar una es cambiar una línea.
+- Una variable vacía o en blanco (`export CODEX_HOME=`) cae al default. Tomarla al pie de
+  la letra dejaría las rutas colgando de la raíz.
+- **Las convenciones compartidas no se mueven.** `~/.agents/skills` lo usan Codex y
+  OpenCode: es del ecosistema, no de un agente. Moverlo con `CODEX_HOME` desconectaría a
+  OpenCode de sus propias skills.
+
+**El guard es una propiedad, no una lista.** `provider-paths-honor-config-home` recorre la
+tabla entera: para cada proveedor que declare override, setearlo tiene que mover **todas**
+sus rutas propias. Eran tres las afectadas (`hooks.json`, `agents/`, `AGENTS.md`) y
+arreglar dos habría dejado el bug vivo en la tercera — el patrón que más se repitió en este
+repo. Verificado por revert: devolver **una sola** ruta al hardcode pone el guard en rojo.
+Un proveedor nuevo lo hereda sin que nadie se acuerde.
+
+**Efecto lateral que vale:** el aislamiento de los playbooks ahora funciona de verdad. Antes
+`AWM_HOME` no alcanzaba, porque los archivos del agente viven fuera de él y una corrida de
+prueba contaminaba el `hooks.json` real — que fue justo lo que hizo dudar del resultado.
+
+**Lo que esto NO cierra:** que el hook de Codex se dispare. Sabemos por qué no se
+descubría; falta ver si, ya descubierto, la compuerta de confianza lo deja correr. Codex
+sigue en ❌ hasta que alguien lo observe.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -226,3 +226,10 @@ si no aparece, es otra cosa.
 'open-hooks-trust'` y ese código **no está explicado en ningún lado** — ni en la referencia
 del CLI, ni en la salida, ni en esta documentación. El usuario ve `→ open-hooks-trust` y no
 tiene ninguna acción que tomar.
+
+
+**Actualización (misma fecha):** la causa de que el hook no se descubriera está
+identificada y corregida — AWM ignoraba `CODEX_HOME` y escribía en `~/.codex/hooks.json`
+mientras Codex leía `$CODEX_HOME/hooks.json` (ver [`decisions.md`](decisions.md) D-011).
+**Esto no sube a Codex de ❌ todavía:** saber por qué no se descubría no es lo mismo que
+haberlo visto correr. Falta una corrida donde el hook, ya descubierto, deje su heartbeat.


### PR DESCRIPTION
El diagnóstico de la corrida en el VPC llegó al fondo, y la causa **no** era la compuerta de confianza.

> ⚠️ **Breaking change** — sale como major.

## Qué pasaba

En esa máquina `CODEX_HOME` apunta fuera del home. Codex lee `$CODEX_HOME/hooks.json`; AWM escribía en `~/.codex/hooks.json`. **Instalación correcta, en el archivo que nadie mira.** Por eso el hook nunca se descubrió — y por eso la prueba del bypass no podía aislar nada: no había hook registrado que aprobar.

Lo peor no fue el bug. Fue que **`doctor` lo reportara sano**: escribía y verificaba en el mismo lugar equivocado, así que el diagnóstico confirmaba su propia suposición. Un chequeo que solo puede ver lo que él mismo hizo no es un chequeo.

## La asimetría de fondo

**AWM honra `AWM_HOME` para sí mismo desde siempre, y le negaba esa misma cortesía a todos los agentes que administra.** Cada ruta de proveedor salía de `homeDir()` y punto.

Eso no es un bug de Codex: es una clase, y Codex fue el primero con evidencia.

## Qué cambia

- `ProviderConfig` gana `configHome: { envVar, dir, resolved }`, con una sola tabla `CONFIG_HOME`.
- `codex: { envVar: 'CODEX_HOME' }` — **confirmado contra el binario real** (0.146.0).
- Los demás quedan en `envVar: null`. Eso es *"no le conocemos override"*, no *"no tiene"*. **No se inventan variables:** una que no exista prometería una configurabilidad que no funciona, que es peor que no ofrecerla. Confirmar una es cambiar una línea.
- Una variable vacía o en blanco (`export CODEX_HOME=`) cae al default — tomarla literal dejaría las rutas colgando de la raíz.
- **Las convenciones compartidas no se mueven.** `~/.agents/skills` lo usan Codex y OpenCode: es del ecosistema, no de un agente. Moverlo con `CODEX_HOME` desconectaría a OpenCode de sus propias skills.

## El guard es una propiedad, no una lista

`provider-paths-honor-config-home` recorre la tabla entera: para cada proveedor que declare override, setearlo tiene que mover **todas** sus rutas propias.

Eran **tres** las afectadas (`hooks.json`, `agents/`, `AGENTS.md`). Arreglar dos habría dejado el bug vivo en la tercera — el patrón que más se repitió en este repo.

**Verificado por revert: devolver UNA sola ruta al hardcode pone el guard en rojo.** Un proveedor nuevo lo hereda sin que nadie se acuerde, y el guard además falla si no encuentra ninguna ruta que verificar.

## Efecto lateral que vale

El aislamiento de los playbooks ahora funciona de verdad. `AWM_HOME` no alcanzaba, porque los archivos del agente viven fuera de él y una corrida de prueba contaminaba el `hooks.json` real — que fue justo lo que hizo dudar del resultado anterior.

## Lo que esto NO cierra

**Codex sigue en ❌.** Saber por qué el hook no se descubría no es lo mismo que haberlo visto correr. Falta una corrida donde el hook, ya descubierto, deje su heartbeat. La matriz lo dice explícitamente en vez de anticiparse.

## Verificación

- **Contra el binario construido:** con `CODEX_HOME` las tres rutas se mueven; `.agents/skills` se queda.
- **Revert probe:** una ruta revertida → guard en rojo.
- Suite: **178 suites / 1743 tests**.

## Migración

En una máquina con `CODEX_HOME` seteado, AWM deja de escribir en `~/.codex` y pasa a usar `$CODEX_HOME`. Hay que correr `awm init -a codex` de nuevo; lo que quedó en `~/.codex` se puede borrar a mano. **Sin `CODEX_HOME` no cambia nada.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_