### PR TITLE
feat(hooks): make the pending-trust remedy executable, and close Codex at verified

### DIFF
--- a/cli/src/commands/hooks/index.ts
+++ b/cli/src/commands/hooks/index.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { pendingTrustGuidance } from './trust-guidance';
 import pc from 'picocolors';
 import { confirm, isCancel } from '@clack/prompts';
 import { getPreferences } from '../../utils/config';
@@ -142,8 +143,7 @@ export function registerHooksCommand(program: Command): void {
                                     : pc.red(result.overall);
                 console.log(`  Status: ${overall}`);
                 if (result.overall === 'PENDING_TRUST') {
-                    console.log(pc.dim('  El hook esta instalado y bien formado, pero nunca se lo vio correr.'));
-                    console.log(pc.dim('  Abri una sesion del agente; si sigue igual, no se esta disparando.'));
+                    for (const line of pendingTrustGuidance(agent)) console.log(pc.dim(`  ${line}`));
                 }
                 // PENDING_TRUST no sale 1: no hay nada roto que arreglar, y salir 1 en
                 // toda instalacion recien hecha convertiria el comando en ruido.

--- a/cli/src/commands/hooks/trust-guidance.ts
+++ b/cli/src/commands/hooks/trust-guidance.ts
@@ -1,0 +1,35 @@
+// Texto accionable para un hook instalado que nunca corrio.
+//
+// Vive aparte de `index.ts` a proposito: ese modulo registra comandos y arrastra medio
+// CLI al importarlo, asi que un test que solo quiere leer este texto no deberia pagar eso.
+import { AgentTarget } from '../../providers';
+
+/**
+ * Que hacer con un hook instalado que nunca corrio.
+ *
+ * `doctor` emitia el codigo `open-hooks-trust` y NADA mas — ni en la referencia del CLI,
+ * ni en la salida, ni en la doc. El usuario leia `→ open-hooks-trust` y no tenia ninguna
+ * accion que tomar. Un remedio que no se puede ejecutar no es un remedio.
+ *
+ * El texto de abajo es el que Codex 0.146.0 muestra de verdad, copiado de una corrida
+ * observada — no una parafrasis de lo que suponemos que dice.
+ */
+export function pendingTrustGuidance(agent: AgentTarget): string[] {
+    if (agent === 'codex') {
+        return [
+            'El hook esta instalado y registrado, pero Codex todavia no lo ejecuto.',
+            'Abri una sesion de Codex en cualquier proyecto: va a mostrar',
+            '',
+            '    Hooks need review',
+            '    1 hook is new or changed.',
+            '    Hooks can run outside the sandbox after you trust them.',
+            '',
+            'Elegi "Trust all and continue". Desde esa sesion el hook corre y este',
+            'comando pasa a HEALTHY. Si elegis "Continue without trusting", no corre.',
+        ];
+    }
+    return [
+        'El hook esta instalado y bien formado, pero nunca se lo vio correr.',
+        'Abri una sesion del agente; si sigue igual, no se esta disparando.',
+    ];
+}

--- a/cli/tests/commands/hooks/codex.test.ts
+++ b/cli/tests/commands/hooks/codex.test.ts
@@ -287,3 +287,27 @@ describe('installHook / computeHookStatus / uninstallHook — Codex adapter', ()
         expect(result.backupPath).toBeNull();
     });
 });
+
+// El remedio tiene que ser ejecutable, no un codigo.
+//
+// `doctor` emitia `open-hooks-trust` y nada mas — ni en la referencia del CLI, ni en la
+// salida, ni en la doc. Una corrida real leyo `→ open-hooks-trust` y no tenia que hacer.
+// El texto que se muestra ahora es el que Codex 0.146.0 emite de verdad, observado en una
+// corrida, no una parafrasis. Ver D-010.
+describe('pending-trust tells the user what to actually do', () => {
+    it('names the exact prompt Codex shows and the option that grants trust', () => {
+        const { pendingTrustGuidance } = require('../../../src/commands/hooks/trust-guidance');
+        const text = pendingTrustGuidance('codex').join('\n');
+        expect(text).toContain('Hooks need review');
+        expect(text).toContain('Trust all and continue');
+    });
+
+    it('falls back to a generic message for an agent whose prompt we have not observed', () => {
+        // No se inventa el texto de un prompt que nadie vio: seria peor que uno generico,
+        // porque mandaria a buscar algo que quiza no existe.
+        const { pendingTrustGuidance } = require('../../../src/commands/hooks/trust-guidance');
+        const text = pendingTrustGuidance('claude-code').join('\n');
+        expect(text).not.toContain('Hooks need review');
+        expect(text).toContain('nunca se lo vio correr');
+    });
+});

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -257,6 +257,12 @@ La asimetria se cobro la misma corrida: `awm hooks status --agent codex` fallaba
 `unknown option`. Se agrega alias en vez de renombrar, para no romper a quien ya scriptea
 `--target`.
 
+**Cerrado después:** el código `open-hooks-trust` era un remedio inejecutable — `doctor` lo
+emitía y no estaba explicado en ningún lado. `awm hooks status` ahora reproduce el prompt
+exacto que Codex muestra (`Hooks need review` / `Trust all and continue`), **texto observado
+en una corrida real, no parafraseado**. Para un agente cuyo prompt nadie vio, el mensaje
+queda genérico: inventarlo sería peor, porque mandaría a buscar algo que quizá no existe.
+
 **Abierto, del mismo reporte:** `~/.codex/hooks.json` **no** vive bajo `AWM_HOME`, asi que
 una corrida "aislada" del playbook deja ahi una entrada permanente apuntando a un directorio
 temporal. La corrida del VPC termino con DOS entradas de AWM bajo `SessionStart`, ambas con
@@ -306,6 +312,8 @@ Un proveedor nuevo lo hereda sin que nadie se acuerde.
 `AWM_HOME` no alcanzaba, porque los archivos del agente viven fuera de él y una corrida de
 prueba contaminaba el `hooks.json` real — que fue justo lo que hizo dudar del resultado.
 
-**Lo que esto NO cierra:** que el hook de Codex se dispare. Sabemos por qué no se
-descubría; falta ver si, ya descubierto, la compuerta de confianza lo deja correr. Codex
-sigue en ❌ hasta que alguien lo observe.
+**Cerrado el mismo día.** Con el hook registrado donde Codex mira, Codex mostró su prompt
+`Hooks need review`, se otorgó la confianza y el hook corrió — sin bypass. Codex pasa a ✅
+en las tres columnas. La compuerta de confianza era real pero **no** era la causa: nunca se
+llegaba a ella. Una hipótesis plausible que resultó falsa, y solo el diagnóstico de la ruta
+la separó del síntoma.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -75,7 +75,7 @@ La parte determinística —`awm sensors run`, su código de salida y el gate de
 | Proveedor | Instalación de artefactos | Entrega de contexto | Hooks | Evidencia |
 |---|---|---|---|---|
 | **Claude Code** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Suite + E2E aislado en CI (ubuntu, windows, macos) + playbook [`agent-matrix`](testing/agent-matrix.md) corrido contra el binario real (AG-01…AG-06, CC-01, CC-02), incluido **AG-06 con control negativo**: un `HOME` sin AWM responde que no tiene ninguna skill de AWM, así que lo que la sesión nombró vino de la instalación observada y no de su ambiente. |
-| **Codex** | ✅ Verificado | ✅ Verificado | ❌ **Verificado que NO funciona** | Instalación y contexto: playbook contra `codex-cli 0.146.0` real. **Los hooks no se disparan.** Evidencia abajo — no es "falta verificar", se verificó y no corre. |
+| **Codex** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Playbook completo contra `codex-cli 0.146.0` real, en una máquina con `CODEX_HOME`. **El hook se observó ejecutándose**: Codex mostró su prompt `Hooks need review`, se otorgó la confianza, la sesión imprimió `Running SessionStart hook` y el hook dejó su `heartbeat.json`. `hook.trust: healthy`, `overall: healthy`. Evidencia abajo. |
 | **OpenCode** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El escritor de `opencode.json` está cubierto por tests; que OpenCode *lea* ese campo no fue observado. |
 | **Cursor** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El `.mdc` se genera y se valida su forma. Que Cursor **cargue** un `.mdc` con `alwaysApply: false` no fue observado. |
 | **Copilot** | ✅ Verificado (solo proyecto) | ⚠ Sin verificar | ⛔ No tiene | El `.instructions.md` se genera. Que Copilot **honre** `applyTo: "**"` no fue observado. |
@@ -163,7 +163,6 @@ Enunciado como trabajo, no como defecto. Esto es lo que hay que construir para s
 | 3 | **Reconciliación de scope de proyecto en `awm update`** | `update` reconcilia artefactos de máquina; los de proyecto son trabajo de `awm sync`. Un proyecto sin `sync` queda desactualizado en silencio. | Elimina un paso manual |
 | 4 | **Pruebas de los packs `python` y `shell` contra proyectos reales** | Existen y están completos; nadie los corrió contra un repo Python o de shell de verdad. | Sube 2 packs a ✅ |
 | 5 | **Un séptimo proveedor** | El modelo de capacidades ya lo soporta como una edición localizada (tabla de renderers + entrada de provider). No hay ninguno pedido todavía. | Amplía la cobertura |
-| 6 | **Hacer que el hook de Codex se dispare** | No es "falta verificarlo": se verificó y **no corre**. AWM declara a Codex `hooks-native` — un tier que promete que los gates de fase se *aplican* —, y hoy Codex solo recibe el contexto por `AGENTS.md`, que es el camino `agents-md-managed`. La causa más probable es la compuerta de confianza de Codex, que AWM nunca le explica al usuario. | Sube Codex a ✅ y vuelve cierto su tier |
 
 ---
 
@@ -183,51 +182,43 @@ Los playbooks están escritos para que los corras vos **o para que se los pases 
 
 ---
 
-## Evidencia — los hooks de Codex no se disparan (2026-08-09)
+## Evidencia — los hooks de Codex, de ❌ a ✅ en el mismo día (2026-08-09)
 
-Corrida del playbook contra `codex-cli 0.146.0` en Ubuntu, con `awm 5.0.1`.
+Vale contarlo entero porque es el caso que justifica los cinco niveles.
 
-**Lo que SÍ funciona:** el script está bien. Ejecutado a mano emite el JSON correcto,
-sale `0`, y escribe su `heartbeat.json`:
+**Primera corrida — ❌.** El script era sano (a mano emitía su JSON y escribía el heartbeat),
+pero tras una sesión real de Codex no aparecía heartbeat en **ninguna** de las dos rutas
+registradas. La matriz pasó de ⚠ a ❌: no era "falta verificar", se verificó y no corría.
+
+**La causa no era la que suponíamos.** La hipótesis era la compuerta de confianza. El
+diagnóstico encontró otra cosa: esa máquina define `CODEX_HOME`, Codex lee
+`$CODEX_HOME/hooks.json`, y AWM escribía en `~/.codex/hooks.json`. Instalación correcta, en
+el archivo que nadie mira — y `doctor` lo reportaba presente porque verificaba en el mismo
+lugar equivocado donde había escrito. Corregido en la v6.0.0 (ver
+[`decisions.md`](decisions.md) D-011).
+
+**Segunda corrida — ✅.** Con el hook registrado donde Codex mira, Codex mostró:
 
 ```
-{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"AWM is active. …"}}
-exit=0
--rw------- 1 … 155 Aug  9 04:33 …/hooks/codex/heartbeat.json
+Hooks need review
+1 hook is new or changed.
+Hooks can run outside the sandbox after you trust them.
 ```
 
-**Lo que no:** tras abrir y cerrar una sesión interactiva normal de Codex, **no apareció
-ningún heartbeat** — ni el del entorno de prueba ni el de la instalación real. Las dos
-rutas se comprobaron por separado, porque `~/.codex/hooks.json` tenía **dos** entradas de
-AWM y cada hook escribe al lado de su propio script:
+Otorgada la confianza (`Trust all and continue`), la sesión imprimió `Running SessionStart
+hook: Loading AWM session state` → `SessionStart hook (completed)` y entregó el contexto de
+AWM. El hook dejó su `heartbeat.json`, y `awm hooks status` pasó a `Trust: ✓ healthy`,
+`Status: HEALTHY`. **Sin bypass** — sesión normal.
 
-```
-ls: cannot access '…/.awm-e2e/hooks/codex/heartbeat.json': No such file or directory
-ls: cannot access '…/.awm/hooks/codex/heartbeat.json': No such file or directory
-```
+**Lo que deja el episodio:**
 
-El esquema registrado (`hooks` → `SessionStart` → entradas con `matcher` y `hooks` de tipo
-`command`) coincide con el que documenta Codex. No hubo prompt de confianza de hooks en la
-sesión.
-
-**Por qué esto no lo cierra AG-06.** La sesión de Codex sí reconoció las skills de AWM —
-pero eso se explica entero por el bloque gestionado en `AGENTS.md` (`context.global:
-delivered`), que es un camino independiente del hook. Atribuirle ese resultado al hook
-sería justo el error que la matriz de cuatro niveles existe para evitar.
-
-**Sospecha principal, sin confirmar:** Codex 0.146.0 expone
-`--dangerously-bypass-hook-trust`, así que la compuerta de confianza es un concepto vigente
-en esa versión. Si los hooks no se ejecutan hasta ser aprobados, y AWM nunca le dice al
-usuario cómo aprobarlos, el hook queda instalado y mudo para siempre. **La prueba que lo
-confirmaría** es una sesión con ese flag: si el heartbeat aparece, la causa es la confianza;
-si no aparece, es otra cosa.
-
-**Agujero relacionado en el producto:** `doctor` emite `remediationCode:
-'open-hooks-trust'` y ese código **no está explicado en ningún lado** — ni en la referencia
-del CLI, ni en la salida, ni en esta documentación. El usuario ve `→ open-hooks-trust` y no
-tiene ninguna acción que tomar.
-
-
+- La compuerta de confianza era real, pero **no** era la causa: nunca se llegó a ella
+  porque el hook no estaba donde Codex lo busca. Una hipótesis plausible que resultó falsa,
+  y solo el diagnóstico de la ruta lo separó.
+- `hooks-native` para Codex ahora es una promesa con evidencia detrás.
+- El código `open-hooks-trust` era un remedio inejecutable: `doctor` lo emitía y no estaba
+  explicado en ningún lado. Ahora `awm hooks status` reproduce el prompt exacto que Codex
+  muestra y nombra la opción que otorga la confianza — texto observado, no parafraseado.
 **Actualización (misma fecha):** la causa de que el hook no se descubriera está
 identificada y corregida — AWM ignoraba `CODEX_HOME` y escribía en `~/.codex/hooks.json`
 mientras Codex leía `$CODEX_HOME/hooks.json` (ver [`decisions.md`](decisions.md) D-011).

--- a/docs/testing/agent-matrix.md
+++ b/docs/testing/agent-matrix.md
@@ -174,7 +174,7 @@ awm doctor --json -a antigravity
 | Agent | AG-01 | AG-02 | AG-03 | AG-04 | AG-05 | AG-06 | Extras | Notes |
 |---|---|---|---|---|---|---|---|---|
 | claude-code | PASS | PASS | PASS | PASS | PASS | PASS | CC-01 PASS · CC-02 PASS | 2026-08-09, awm 4.0.0, Linux. AG-02 exit `1` / `failed: 0`. AG-05: 31 artefactos. AG-06 con control negativo (ver abajo). **Un hallazgo de producto**, arreglado: ver "Lo que encontró la corrida". |
-| codex | PASS¹ | PASS¹ | PASS | PASS | PASS | PASS | CX-01 PASS¹ · CX-02 PASS · **hook FAIL** | 2026-08-09, codex-cli 0.146.0, Node 24.19.0, Ubuntu (VPC). AG-05: 30 symlinks. **El hook NO se dispara** — verificado en las dos rutas registradas, ninguna dejó heartbeat. Evidencia en [support-matrix](../support-matrix.md). |
+| codex | PASS | PASS | PASS | PASS | PASS | PASS | CX-01 PASS · CX-02 PASS · **hook PASS** | 2026-08-09, awm 6.0.0, codex-cli 0.146.0, Ubuntu (VPC) con `CODEX_HOME`. **Hook observado ejecutándose** tras otorgar la confianza, sin bypass. Las tres corridas que costó están contadas en [support-matrix](../support-matrix.md). |
 | opencode |  |  |  |  |  |  | OC-01 |  |
 | cursor |  |  |  |  |  |  | CU-01 |  |
 | copilot |  |  |  |  |  |  | CP-01 CP-02 |  |


### PR DESCRIPTION
La corrida final en el VPC (`awm 6.0.0`, `codex-cli 0.146.0`, máquina con `CODEX_HOME`) cerró el último hueco: **el hook se observó ejecutándose.**

```
Hooks need review
1 hook is new or changed.
Hooks can run outside the sandbox after you trust them.
```

Otorgada la confianza, la sesión imprimió `Running SessionStart hook: Loading AWM session state` → `SessionStart hook (completed)`, y el hook dejó su `heartbeat.json`. **Sin bypass**, sesión normal. `hook.trust: healthy`, `overall: healthy`.

## El remedio que no se podía ejecutar

`doctor` emitía `remediationCode: 'open-hooks-trust'` y **nada más** — ni en la referencia del CLI, ni en la salida, ni en la documentación. El usuario leía `→ open-hooks-trust` y no tenía ninguna acción que tomar.

Ahora `awm hooks status` reproduce el prompt exacto de Codex y nombra la opción que otorga la confianza. **El texto es el observado en la corrida, no una paráfrasis** de lo que suponemos que dice.

Para un agente cuyo prompt nadie vio, el mensaje queda genérico — inventarlo sería peor, porque mandaría a buscar algo que quizá no existe. Hay un test que fija ese límite.

`pendingTrustGuidance` vive en su propio módulo: `index.ts` registra comandos y arrastra medio CLI al importarlo, tanto que jest ni podía parsearlo desde un test.

## Codex queda ✅ en las tres columnas

| Codex | Instalación | Contexto | Hooks |
|---|---|---|---|
| esta mañana | ✅ | ✅ | ⚠ |
| después de la 1ª corrida | ✅ | ✅ | ❌ |
| ahora | ✅ | ✅ | ✅ |

El ítem *"hacer que el hook de Codex se dispare"* sale de lo pendiente.

## Por qué la evidencia queda contada entera

Es el caso que justifica los cinco niveles, y el aprendizaje no está en el resultado sino en el camino:

- La hipótesis era **la compuerta de confianza**. Era real — el prompt existe — pero **no era la causa**: nunca se llegaba a ella, porque el hook no estaba donde Codex lo busca (`CODEX_HOME`).
- Una hipótesis plausible que resultó falsa, y solo el diagnóstico de la ruta la separó del síntoma. Si se hubiera "arreglado" la confianza primero, el bug seguiría vivo.
- El ⚠ inicial era honesto, el ❌ también, y el ✅ también. Cada uno con su evidencia, ninguno anticipado.

## Verificación

Suite: **178 suites / 1745 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_