### PR TITLE
docs(agents-setup): document CODEX_HOME and the trust prompt where people look

### DIFF
--- a/docs/agents-setup.md
+++ b/docs/agents-setup.md
@@ -69,6 +69,36 @@ awm init -a codex
 
 If Codex is below `0.145.0`, `awm init -a codex` refuses with exit `2` and names the minimum. That's a correct refusal, not a bug — upgrade Codex and re-run.
 
+**Si tenés `CODEX_HOME` seteado, esas rutas cambian.** Codex lee su configuración desde
+`$CODEX_HOME` cuando esa variable existe, y AWM la respeta desde la **v6.0.0**: `hooks.json`,
+`agents/` y el `AGENTS.md` global pasan a colgar de ahí. Las skills **no** se mueven —
+`~/.agents/skills` es una convención compartida con OpenCode, no un directorio de Codex.
+
+Comprobalo antes de dar nada por instalado:
+
+```bash
+echo "$CODEX_HOME"
+awm doctor --json -a codex     # los `target` deben empezar con tu $CODEX_HOME
+```
+
+> Antes de la v6.0.0 AWM ignoraba esa variable y escribía en `~/.codex`: instalación
+> correcta, en el archivo que Codex no lee. El hook quedaba instalado y mudo, y `doctor`
+> lo reportaba presente porque verificaba en el mismo lugar equivocado donde había
+> escrito. Si venís de una versión anterior, corré `awm init -a codex` de nuevo y borrá a
+> mano lo que haya quedado en `~/.codex`.
+
+**La primera sesión te va a pedir confianza.** Codex no ejecuta hooks hasta aprobarlos:
+
+```
+Hooks need review
+1 hook is new or changed.
+Hooks can run outside the sandbox after you trust them.
+```
+
+Elegí **"Trust all and continue"**. Hasta entonces `awm hooks status --agent codex` reporta
+`PENDING_TRUST` — instalado, nunca ejecutado. Si elegís "Continue without trusting", el hook
+no corre y AWM no tiene forma de forzarlo.
+
 ## `opencode` — config-managed
 
 ```bash


### PR DESCRIPTION
Hueco encontrado auditando la documentación contra las iteraciones nuevas.

`CODEX_HOME` (D-011) y el prompt de confianza (D-010) quedaron escritos en `support-matrix.md`, `decisions.md` y el playbook — **los tres lugares donde va alguien que ya sabe que el problema existe.** En la guía de setup, que es donde va alguien instalando, no estaban.

## Qué se agrega a la sección de Codex

- **Qué rutas se mueven con `CODEX_HOME`** (`hooks.json`, `agents/`, `AGENTS.md` global) y cuáles **no**: las skills viven en `~/.agents/skills`, que es convención compartida con OpenCode, no un directorio de Codex.
- **El comando para comprobarlo** en vez de suponerlo: `awm doctor --json -a codex` y verificar que los `target` empiecen con `$CODEX_HOME`.
- **Nota de migración** desde versiones previas — antes AWM ignoraba la variable y escribía en `~/.codex`: instalación correcta, en el archivo que Codex no lee.
- **El texto exacto del prompt de confianza** y la opción que hay que elegir. Es lo primero que va a ver alguien en su primera sesión, y hasta ahora no estaba escrito en ningún lado accesible.

## Sin cambios de código

Guards estructurales verdes (27 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_