### PR TITLE
fix(context-budget,hooks): stop pinning at zero, and prune dead hook entries

### DIFF
--- a/cli/src/commands/context-budget/budget.ts
+++ b/cli/src/commands/context-budget/budget.ts
@@ -33,8 +33,9 @@ export const CONFIG_FILE = path.join('.awm', 'context-budget.json');
 export type BudgetConfig = { files: string[]; maxBytes: number };
 
 export type BudgetReport = {
-    /** 'pinned' on the first check; 'within' under budget; 'over' past it. */
-    status: 'pinned' | 'within' | 'over';
+    /** 'pinned' on the first check; 'within' under budget; 'over' past it;
+     *  'unmeasurable' cuando NINGUNO de los archivos existe todavia. */
+    status: 'pinned' | 'within' | 'over' | 'unmeasurable';
     totalBytes: number;
     maxBytes: number;
     /** Per-file sizes, in the order declared. Absent files are omitted. */
@@ -103,6 +104,19 @@ export function checkBudget(cwd: string): BudgetReport {
     const config = readConfig(cwd);
     if (!config) {
         const { total, breakdown } = measure(cwd, DEFAULT_FILES);
+        // Fijar sobre CERO archivos es una trampa, no una linea base.
+        //
+        // En un proyecto recien inicializado ninguno de los tres existe todavia: los
+        // escribe una sesion de agente, y `awm init` los reporta como pasos `pending`.
+        // El 0KB no es un error de medicion — no hay nada que medir. Pero dejar
+        // `maxBytes: 0` en disco hace que la corrida SIGUIENTE, apenas el agente escribe
+        // AGENTS.md (el flujo documentado), reporte "excedido". Una alarma que siempre
+        // suena se aprende a ignorar, y ahi se pierde el gate entero.
+        //
+        // Se reporta y NO se escribe config: el proximo run, ya con contexto, fija bien.
+        if (breakdown.length === 0) {
+            return { status: 'unmeasurable', totalBytes: 0, maxBytes: 0, breakdown };
+        }
         writeConfig(cwd, { files: DEFAULT_FILES, maxBytes: total });
         return { status: 'pinned', totalBytes: total, maxBytes: total, breakdown };
     }

--- a/cli/src/commands/context-budget/index.ts
+++ b/cli/src/commands/context-budget/index.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import pc from 'picocolors';
-import { checkBudget, estimateTokens, CONFIG_FILE, BudgetReport } from './budget';
+import { checkBudget, estimateTokens, CONFIG_FILE, DEFAULT_FILES, BudgetReport } from './budget';
 
 const KB = (bytes: number) => `${(bytes / 1024).toFixed(0)}KB`;
 
@@ -18,6 +18,14 @@ export function formatReport(report: BudgetReport): string {
     const tokens = `~${estimateTokens(report.totalBytes)}k tokens`;
     const breakdown = report.breakdown.map(b => `${b.file} ${KB(b.bytes)}`).join(', ');
 
+    if (report.status === 'unmeasurable') {
+        // Ni verde ni alarma: no hay nada que reportar todavia, y decir "0KB fijado"
+        // seria afirmar una medicion que no ocurrio.
+        return `${pc.dim('·')}  Nothing to measure yet: none of ${DEFAULT_FILES.join(', ')} exists.\n`
+            + `   These are written by an agent session (\`awm init\` lists them as pending).\n`
+            + `   Re-run this once they exist — pinning a budget of 0 would report every\n`
+            + `   later run as over budget.\n`;
+    }
     if (report.status === 'pinned') {
         return `${pc.green('✔')}  Context budget pinned at ${KB(report.totalBytes)} (${tokens} per session).\n`
             + `   ${breakdown}\n`

--- a/cli/src/commands/hooks/claude.ts
+++ b/cli/src/commands/hooks/claude.ts
@@ -9,7 +9,7 @@
 import fs from 'fs';
 import path from 'path';
 import { getSettingsMergeHookConfig } from '../../providers';
-import { backupManagedFile, syncExecutable, checkExecutable, checkFile } from './shared';
+import { isDeadAwmHookEntry, backupManagedFile, syncExecutable, checkExecutable, checkFile } from './shared';
 import type { InstallOptions, InstallResult, UninstallResult, HookStatus, CheckResult } from './shared';
 
 function isAwmEntry(entry: any, scriptsDir: string, matcher: string): boolean {
@@ -68,7 +68,12 @@ export function installClaudeHook(options: InstallOptions): InstallResult {
     if (!settings.hooks) settings.hooks = {};
     if (!settings.hooks[config.eventName]) settings.hooks[config.eventName] = [];
 
-    const entries: any[] = settings.hooks[config.eventName];
+    // Misma poda que en codex.ts: restos nuestros apuntando a un AWM_HOME ya borrado.
+    // `settings.hooks[eventName]` se reasigna porque el objeto se serializa entero abajo.
+    const entries: any[] = settings.hooks[config.eventName]
+        .filter((e: unknown) => !isDeadAwmHookEntry(e, config.matcher, 'run-hook.cmd', config.scriptsDir));
+    const pruned = settings.hooks[config.eventName].length !== entries.length;
+    settings.hooks[config.eventName] = entries;
     const awmEntryIdx = entries.findIndex((e) => isAwmEntry(e, config.scriptsDir, config.matcher));
     const newEntry = {
         matcher: config.matcher,
@@ -81,7 +86,9 @@ export function installClaudeHook(options: InstallOptions): InstallResult {
 
     let status: InstallResult['status'];
     if (awmEntryIdx >= 0) {
-        if (JSON.stringify(entries[awmEntryIdx]) === JSON.stringify(newEntry)) {
+        // Igual que en codex.ts: si la poda saco algo, hay que escribir aunque nuestra
+        // entrada ya este identica — si no, la limpieza se calcula y se tira.
+        if (!pruned && JSON.stringify(entries[awmEntryIdx]) === JSON.stringify(newEntry)) {
             return { status: 'already-up-to-date', scriptsDir: config.scriptsDir, settingsPath: config.settingsPath, backupPath: null };
         }
         entries[awmEntryIdx] = newEntry;

--- a/cli/src/commands/hooks/codex.ts
+++ b/cli/src/commands/hooks/codex.ts
@@ -9,7 +9,7 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import { getHookConfig } from '../../providers';
-import { backupManagedFile, syncExecutable, readStrictJson, checkExecutable } from './shared';
+import { isDeadAwmHookEntry, backupManagedFile, syncExecutable, readStrictJson, checkExecutable } from './shared';
 import { writeFileAtomic } from '../../core/atomic-file';
 import type { InstallOptions, InstallResult, UninstallResult, HookStatus, CheckResult } from './shared';
 
@@ -55,7 +55,11 @@ export function installCodexHook(options: InstallOptions): InstallResult {
     const hooks = current.hooks && typeof current.hooks === 'object'
         ? current.hooks as Record<string, unknown>
         : {};
-    const entries: any[] = Array.isArray(hooks.SessionStart) ? hooks.SessionStart : [];
+    const raw: any[] = Array.isArray(hooks.SessionStart) ? hooks.SessionStart : [];
+    // Se podan primero las entradas nuestras que apuntan a un script inexistente: son
+    // restos de otro AWM_HOME ya borrado, y el agente las intenta ejecutar cada sesion.
+    // Una instalacion paralela VIVA no se toca — su script existe. Ver isDeadAwmHookEntry.
+    const entries = raw.filter((entry) => !isDeadAwmHookEntry(entry, codexMatcher(), 'session-start', config.scriptsDir));
     const matches = entries.filter((entry) => isAwmCodexEntry(entry, config.scriptsDir));
     if (matches.length > 1) {
         throw new Error('multiple AWM SessionStart entries in Codex hooks.json');
@@ -63,7 +67,11 @@ export function installCodexHook(options: InstallOptions): InstallResult {
 
     const newEntry = awmCodexEntry(config.scriptsDir);
 
-    if (matches.length === 1 && JSON.stringify(matches[0]) === JSON.stringify(newEntry)) {
+    // `pruned` gana sobre el early-return: si se saco basura hay que ESCRIBIRLA, aunque
+    // nuestra entrada ya este identica. Sin esto la poda se calculaba y se tiraba, y el
+    // archivo quedaba igual — lo detecto su propio test.
+    const pruned = raw.length !== entries.length;
+    if (!pruned && matches.length === 1 && JSON.stringify(matches[0]) === JSON.stringify(newEntry)) {
         return { status: 'already-up-to-date', scriptsDir: config.scriptsDir, settingsPath: config.settingsPath, backupPath: null };
     }
 

--- a/cli/src/commands/hooks/shared.ts
+++ b/cli/src/commands/hooks/shared.ts
@@ -150,3 +150,46 @@ export type HookStatus = {
         settingsEntry: CheckResult;
     };
 };
+
+/**
+ * Entradas de hook con NUESTRA forma cuyo script ya no existe en disco.
+ *
+ * `awm init` reconoce como propia solo la entrada que apunta al `AWM_HOME` actual, asi
+ * que instalar con otro `AWM_HOME` AGREGA una segunda en vez de reemplazar. Una corrida
+ * de playbook aislada deja en el archivo real una entrada permanente hacia un directorio
+ * temporal ya borrado, y el agente intenta ejecutarla en cada sesion, para siempre.
+ * Observado en una corrida real: `~/.codex/hooks.json` con dos entradas de AWM.
+ *
+ * Tres condiciones, a proposito — es el archivo de configuracion DEL USUARIO y no se le
+ * borran lineas por parecido vago:
+ *   1. el `matcher` es exactamente el nuestro,
+ *   2. el ejecutable se llama como el script que AWM instala, y
+ *   3. esa ruta NO existe.
+ *
+ * Una instalacion paralela viva no cumple (3), asi que sobrevive intacta. Lo unico que
+ * se poda es basura que AWM misma dejo y que ya no puede funcionar.
+ */
+export function isDeadAwmHookEntry(
+    entry: unknown,
+    matcher: string,
+    scriptBasename: string,
+    currentScriptsDir: string,
+): boolean {
+    const e = entry as { matcher?: unknown; hooks?: unknown };
+    if (e?.matcher !== matcher || !Array.isArray(e.hooks)) return false;
+    return e.hooks.some((h: unknown) => {
+        const command = (h as { command?: unknown })?.command;
+        if (typeof command !== 'string' || command.length === 0) return false;
+        // Claude invoca `<ruta>/run-hook.cmd session-start`: el ejecutable es el primer
+        // token. Codex invoca la ruta pelada. Partir por espacio cubre las dos formas.
+        const executable = command.split(' ')[0];
+        if (path.basename(executable) !== scriptBasename) return false;
+        // La entrada del AWM_HOME ACTUAL nunca es basura, aunque el script todavia no
+        // este en disco: en una instalacion nueva el archivo aparece unos pasos despues.
+        // Sin esta guarda, un `hooks.json` con dos entradas duplicadas del home actual se
+        // podaba entero y el guard de duplicados (R17) dejaba de dispararse — lo detecto
+        // su propio test al agregar la poda.
+        if (path.dirname(executable) === currentScriptsDir) return false;
+        return !fs.existsSync(executable);
+    });
+}

--- a/cli/tests/commands/context-budget/budget.test.ts
+++ b/cli/tests/commands/context-budget/budget.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import { checkBudget, readConfig, CONFIG_FILE } from '../../../src/commands/context-budget/budget';
 import { exitCodeFor, formatReport } from '../../../src/commands/context-budget';
+import { mkCanonicalTmpDir } from '../../support/tmp';
 
 function project(files: Record<string, number>): string {
     // CLAUDE.md: no test may reach the real ~/.awm. Everything here is a tmpdir.
@@ -116,5 +117,46 @@ describe('reporting', () => {
         expect(out).toContain('Raise');
         expect(out).toContain('Accept');
         expect(out).toMatch(/~5[0-9]k tokens/);
+    });
+});
+
+// Fijar sobre cero archivos garantiza una falsa alarma en la corrida siguiente.
+//
+// `context-budget` mide AGENTS.md / CONSTITUTION.md / CLAUDE.md. En un proyecto recien
+// inicializado NINGUNO existe: los escribe una sesion de agente, y `awm init` los reporta
+// como pasos `pending`. El 0KB no es un error de medicion — no hay nada que medir. El
+// problema es FIJAR sobre eso: apenas el agente escribe AGENTS.md, que es el flujo
+// documentado, el comando reporta "excedido". Una alarma que siempre suena se aprende a
+// ignorar. Ver issue #56.
+describe('pinning refuses to happen when there is nothing to measure', () => {
+    let cwd: string;
+
+    beforeEach(() => { cwd = mkCanonicalTmpDir('awm-budget-zero-'); });
+    afterEach(() => { fs.rmSync(cwd, { recursive: true, force: true }); });
+
+    it('does not pin a budget on a project whose context files do not exist yet', () => {
+        const report = checkBudget(cwd);
+        expect(report.status).toBe('unmeasurable');
+        expect(report.totalBytes).toBe(0);
+        // Lo que importa: NO deja config. Un `maxBytes: 0` en disco es la trampa.
+        expect(fs.existsSync(path.join(cwd, CONFIG_FILE))).toBe(false);
+    });
+
+    it('the very next run, after the agent writes AGENTS.md, is not "over budget"', () => {
+        checkBudget(cwd);                                    // primer intento: nada que medir
+        fs.writeFileSync(path.join(cwd, 'AGENTS.md'), 'x'.repeat(3000));
+
+        const report = checkBudget(cwd);
+        // Este es el bug entero: antes daba 'over' — 3KB contra un maximo de 0.
+        expect(report.status).toBe('pinned');
+        expect(report.maxBytes).toBe(3000);
+    });
+
+    it('still pins normally when at least one context file exists', () => {
+        fs.writeFileSync(path.join(cwd, 'CLAUDE.md'), 'y'.repeat(500));
+        const report = checkBudget(cwd);
+        expect(report.status).toBe('pinned');
+        expect(report.maxBytes).toBe(500);
+        expect(fs.existsSync(path.join(cwd, CONFIG_FILE))).toBe(true);
     });
 });

--- a/cli/tests/commands/hooks/codex.test.ts
+++ b/cli/tests/commands/hooks/codex.test.ts
@@ -340,8 +340,11 @@ describe('installHook / computeHookStatus / uninstallHook — Codex adapter', ()
 
             const after = JSON.parse(fs.readFileSync(hooksJson, 'utf-8')).hooks.SessionStart;
             expect(after).toHaveLength(1);
-            expect(JSON.stringify(after)).toContain(tmpHome);
-            expect(JSON.stringify(after)).not.toContain('awm-e2e-gone');
+            // Sobre la ESTRUCTURA, no sobre el JSON serializado: en Windows las barras
+            // invertidas van escapadas dentro del string, asi que un `toContain(tmpHome)`
+            // compara `C:\Users\...` contra `C:\\Users\\...` y falla sobre un producto
+            // que se comporta bien. Paso en CI — `platform-property-assumed-universal`.
+            expect(after[0].hooks[0].command).toBe(path.join(codexScriptsDir, 'session-start'));
         });
     });
 });

--- a/cli/tests/commands/hooks/codex.test.ts
+++ b/cli/tests/commands/hooks/codex.test.ts
@@ -286,6 +286,64 @@ describe('installHook / computeHookStatus / uninstallHook — Codex adapter', ()
         expect(result.status).toBe('not-installed');
         expect(result.backupPath).toBeNull();
     });
+
+    // Restos de otro AWM_HOME: se podan, pero solo si estan MUERTOS.
+    //
+    // `awm init` reconoce como propia solo la entrada del AWM_HOME actual, asi que instalar
+    // con otro AGREGA una segunda. Una corrida de playbook aislada deja en el archivo real
+    // una entrada permanente hacia un directorio temporal ya borrado, y el agente la intenta
+    // ejecutar cada sesion. Observado: `~/.codex/hooks.json` con dos entradas de AWM. Ver
+    // backlog §C2.
+    describe('stale AWM entries from another AWM_HOME are pruned, live ones are not', () => {
+        /** Una entrada con nuestra forma apuntando a `scriptPath`. */
+        function entryFor(scriptPath: string) {
+            return {
+                matcher: 'startup|resume|clear|compact',
+                hooks: [{ type: 'command', command: scriptPath, statusMessage: 'Loading AWM session state' }],
+            };
+        }
+
+        it('drops an entry whose script no longer exists', () => {
+            const { isDeadAwmHookEntry } = require('../../../src/commands/hooks/shared');
+            const dead = entryFor('/tmp/awm-home-that-was-deleted/hooks/codex/session-start');
+            expect(isDeadAwmHookEntry(dead, 'startup|resume|clear|compact', 'session-start', codexScriptsDir)).toBe(true);
+        });
+
+        it('keeps a parallel install whose script DOES exist', () => {
+            // Es la diferencia entre limpiar basura propia y romperle la instalacion a alguien.
+            const { isDeadAwmHookEntry } = require('../../../src/commands/hooks/shared');
+            const alive = entryFor(path.join(codexScriptsDir, 'session-start'));
+            fs.mkdirSync(codexScriptsDir, { recursive: true });
+            fs.writeFileSync(path.join(codexScriptsDir, 'session-start'), '#!/bin/sh\n', { mode: 0o755 });
+            expect(isDeadAwmHookEntry(alive, 'startup|resume|clear|compact', 'session-start', codexScriptsDir)).toBe(false);
+        });
+
+        it('leaves a foreign hook alone even when its path is dead', () => {
+            // Mismo matcher, ruta muerta, pero NO es nuestro script: no se toca.
+            const { isDeadAwmHookEntry } = require('../../../src/commands/hooks/shared');
+            const foreign = entryFor('/tmp/someone-elses/my-own-hook');
+            expect(isDeadAwmHookEntry(foreign, 'startup|resume|clear|compact', 'session-start', codexScriptsDir)).toBe(false);
+        });
+
+        it('install removes the stale entry instead of accumulating a second one', () => {
+            installCodexFixture({ heartbeat: false });
+            const hooksJson = path.join(tmpHome, '.codex', 'hooks.json');
+            const current = JSON.parse(fs.readFileSync(hooksJson, 'utf-8'));
+            // Simular la corrida anterior con otro AWM_HOME, ya borrado.
+            current.hooks.SessionStart.unshift(entryFor('/tmp/awm-e2e-gone/hooks/codex/session-start'));
+            fs.writeFileSync(hooksJson, JSON.stringify(current, null, 2));
+            expect(JSON.parse(fs.readFileSync(hooksJson, 'utf-8')).hooks.SessionStart).toHaveLength(2);
+
+            writeRegistry();
+            const { installHook } = require('../../../src/commands/hooks/install');
+            installHook({ agent: 'codex', registryRoot: tmpRegistry, installMethod: 'copy' });
+
+            const after = JSON.parse(fs.readFileSync(hooksJson, 'utf-8')).hooks.SessionStart;
+            expect(after).toHaveLength(1);
+            expect(JSON.stringify(after)).toContain(tmpHome);
+            expect(JSON.stringify(after)).not.toContain('awm-e2e-gone');
+        });
+    });
 });
 
 // El remedio tiene que ser ejecutable, no un codigo.

--- a/docs/plans/2026-08-09-verification-backlog.md
+++ b/docs/plans/2026-08-09-verification-backlog.md
@@ -83,7 +83,7 @@ CI corre la suite de unidad/integración en las tres plataformas. **Eso no es lo
 
 No bloquea nada hoy, y está enunciada como trabajo, no como defecto oculto.
 
-### C1 · `awm context-budget` fija la línea base en cero — falsa alarma garantizada
+### ~~C1 · `awm context-budget` fija la línea base en cero~~ — ✅ cerrado 2026-08-09 (#56)
 
 **Reproducido el 2026-08-09 con la v6.0.0.** El comando mide `AGENTS.md`, `CONSTITUTION.md` y `CLAUDE.md`. En un proyecto recién inicializado esos archivos **todavía no existen** — son pasos `pending` que escribe una sesión de agente. Entonces:
 
@@ -98,13 +98,15 @@ $ awm context-budget
 
 El 0KB no es un error de medición: no hay nada que medir todavía. El problema es **fijar** sobre eso. El camino feliz garantiza una falsa alarma en la corrida siguiente, y una alarma que siempre suena se aprende a ignorar.
 
-**Dirección:** negarse a fijar cuando no hay ningún archivo presente, diciendo que se corra después de que exista el contexto. No inventar un default.
+**Resuelto:** con cero archivos presentes el comando reporta `unmeasurable`, **no escribe config**, y explica que esos archivos los escribe una sesión de agente. La corrida siguiente fija bien. Sale `0` — no es un error, es "todavía no hay nada que medir".
 
-### C2 · `hooks.json` acumula una entrada por cada `AWM_HOME` usado
+### ~~C2 · `hooks.json` acumula una entrada por cada `AWM_HOME` usado~~ — ✅ cerrado 2026-08-09
 
 Abierto desde D-010. `awm init` reconoce como propia solo la entrada que apunta al `AWM_HOME` actual; con otro, **agrega una segunda**. Una corrida de playbook aislada deja en el `hooks.json` real una entrada permanente hacia un directorio temporal ya borrado, y el agente intenta ejecutarla en cada sesión.
 
-D-011 redujo el daño (las rutas del agente ahora se resuelven bien), pero la acumulación sigue. **Falta decidir** si se deduplica en el producto, si alcanza con el paso de teardown que ya documenta `agent-matrix.md`, o ambas.
+D-011 redujo el daño (las rutas del agente ahora se resuelven bien), pero la acumulación seguía.
+
+**Resuelto:** `awm init` poda las entradas con **nuestra forma** cuyo script ya no existe, en Claude Code y en Codex. Tres condiciones, porque es el archivo de configuración del usuario y no se le borran líneas por parecido vago: el `matcher` es exactamente el nuestro, el ejecutable se llama como el script que AWM instala, y esa ruta **no existe**. Una instalación paralela viva no cumple la tercera, así que sobrevive intacta — y la entrada del `AWM_HOME` actual nunca se poda, aunque su script todavía no esté en disco.
 
 ### C3 · Integridad de contenido en artefactos renderizados
 


### PR DESCRIPTION
Los dos ítems del backlog que eran desarrollo puro y no dependían de tener un binario delante.

Closes #56 · cierra C2 de #57

## 1 · `context-budget` fijaba la línea base en 0KB

Mide `AGENTS.md`, `CONSTITUTION.md` y `CLAUDE.md`. En un proyecto recién inicializado **ninguno existe todavía**: los escribe una sesión de agente, y `awm init` los reporta como pasos `pending`.

El `0KB` no era error de medición — no había nada que medir. El problema era **fijar** sobre eso: apenas el agente escribía `AGENTS.md`, que es el flujo documentado, la corrida siguiente reportaba *"excedido"*. Una alarma que siempre suena se aprende a ignorar, y ahí se pierde el gate entero.

Ahora reporta `unmeasurable`, **no escribe config**, y explica quién escribe esos archivos. Verificado contra el binario construido:

```
· Nothing to measure yet: none of AGENTS.md, CONSTITUTION.md, CLAUDE.md exists.
✔ Context budget pinned at 3KB   ← la corrida siguiente, ya con AGENTS.md
⚠ Context budget exceeded: 9KB vs 3KB   ← y sigue detectando crecimiento real
```

## 2 · `hooks.json` acumulaba una entrada por cada `AWM_HOME` usado

`awm init` reconoce como propia solo la entrada del `AWM_HOME` actual, así que instalar con otro **agregaba una segunda**. Una corrida de playbook aislada dejaba en el archivo real una entrada permanente hacia un directorio temporal ya borrado, y el agente la intentaba ejecutar cada sesión. Observado en el VPC: `~/.codex/hooks.json` con dos entradas de AWM.

Se poda, con **tres condiciones** — es el archivo de configuración del usuario y no se le borran líneas por parecido vago:

1. el `matcher` es exactamente el nuestro,
2. el ejecutable se llama como el script que AWM instala,
3. esa ruta **no existe**.

Una instalación paralela **viva** no cumple (3) y sobrevive intacta. Aplicado a **Claude Code y Codex**, no solo al que reportó el problema.

## Dos fallos propios los encontraron los tests, no yo

- Podar por *"el script no existe"* también mataba la entrada del `AWM_HOME` **actual** en una instalación nueva — y eso desarmaba el guard de duplicados (R17), que falló y lo mostró. Ahora la entrada del `scriptsDir` actual nunca se considera muerta.
- La poda **se calculaba y se tiraba**: el early-return de *"ya está al día"* ganaba y el archivo quedaba igual. Ahora una poda fuerza la escritura.

Vale decirlo porque es el argumento entero a favor de escribir el test antes: los dos son fallos que un revisor humano no habría visto leyendo el diff.

## Verificación

- **Revert probe en los dos.**
- Contra el binario construido para `context-budget`.
- Suite: **178 suites / 1752 tests**.

## Lo que queda de #57

**C3** (integridad de contenido en artefactos renderizados) y **C4** (`awm update` y el scope de proyecto) siguen abiertos — C4 es una pregunta de diseño, no una corrección. **C5** y **C6** necesitan proyectos y binarios reales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_