### PR TITLE
fix(doctor): verify the CONTENT of rendered artifacts, not just their extension

### DIFF
--- a/cli/src/core/diagnostics/provider-checks.ts
+++ b/cli/src/core/diagnostics/provider-checks.ts
@@ -17,7 +17,7 @@ import { assertProviderSupported } from '../provider-version';
 import { computeHookStatus } from '../../commands/hooks/status';
 import { InjectionOrchestrator } from '../context/orchestrator';
 import { capabilityRoot, contentRoots } from '../registries';
-import { rendererExtension } from '../renderers/registry';
+import { rendererExtension, rendererIntegrityMarker } from '../renderers/registry';
 
 export type ScanSkills = (dir: string) => SkillIntegrity;
 
@@ -55,13 +55,13 @@ function binaryVersionCheck(agent: AgentTarget): ProviderCheck {
  *  `dir` is null — i.e. the provider has no global skill discovery mechanism at all
  *  (today: Copilot, see `globalUnsupportedReason` in providers/index.ts).
  *
- *  `renderer` gates which verification is possible: `classifySkillLinks` (via `integrity`)
- *  only ever sees symlinks — `if (!lst.isSymbolicLink()) continue;` — so for a rendered
- *  format (`cursor-mdc`, `copilot-instructions`) it scans a directory of real files and
- *  finds nothing, which would make `broken` silently read 0 regardless of whether the
- *  rendered files are actually well-formed. Reporting `'healthy'` from a scan that
- *  structurally can't see the files it's supposed to check would be a false green, so for
- *  any non-`'link'` renderer this reports presence only, honestly, via `detail`. */
+ *  `renderer` parte la verificacion en dos caminos distintos porque los artefactos son
+ *  distintos: `classifySkillLinks` solo ve symlinks — `if (!lst.isSymbolicLink()) continue;`
+ *  — asi que sobre un directorio de archivos renderizados no encuentra nada. Durante un
+ *  tiempo esa rama reporto SOLO presencia, y lo decia en el `detail` para no fingir una
+ *  verificacion que no ocurria. Ahora tambien comprueba contenido, con el marcador que
+ *  declara el renderer (`rendererIntegrityMarker`): un archivo con la extension correcta
+ *  y el cuerpo vacio o truncado ya no pasa como sano. */
 function skillsGlobalCheck(
     dir: string | null,
     owners: AgentTarget[],
@@ -86,23 +86,37 @@ function skillsGlobalCheck(
         // Require at least one entry with the extension this renderer actually produces,
         // not just ANY file — a directory non-empty only because of the user's own
         // pre-existing, unrelated rule/instructions file must not read as "AWM installed".
-        // Still not full integrity verification (a stray file with the right extension but
-        // wrong content still passes) — that residual gap is the same honest tradeoff this
-        // function's doc comment already accepts for the non-`'link'` branch generally.
         // `rendererExtension` (core/renderers/registry.ts) is the ONE table mapping a
         // renderer to the file it produces. This site used to keep its own partial copy —
         // the fourth such copy in the codebase, and the exact drift that made a rendered
         // artifact invisible to the "is it installed" check for a whole release. A new
         // renderer must not be able to be added without this reading it.
         const ext = rendererExtension(renderer);
-        const present = ext ? entries.some((e) => e.endsWith(ext)) : entries.length > 0;
+        const rendered = ext ? entries.filter((e) => e.endsWith(ext)) : entries;
+        const present = rendered.length > 0;
+        if (!present) {
+            return {
+                id: 'skills.global', state: 'absent', target: dir,
+                owners: owners.length > 1 ? owners : undefined,
+                remediationCode: 'awm-init',
+            };
+        }
+        // Ya no se reporta "content integrity not verified": AHORA se verifica.
+        // Comprobar presencia y extension dejaba pasar un archivo correcto por fuera y
+        // vacio o truncado por dentro — el agente cargaba nada y doctor decia que si.
+        const corrupt = corruptRendered(dir, rendered, renderer);
         return {
             id: 'skills.global',
-            state: present ? 'supported' : 'absent',
+            state: corrupt.length > 0 ? 'broken' : 'supported',
             target: dir,
             owners: owners.length > 1 ? owners : undefined,
-            detail: present ? 'rendered install — content integrity not verified' : undefined,
-            remediationCode: present ? undefined : 'awm-init',
+            detail: corrupt.length > 0
+                ? `${corrupt.length} rendered file(s) missing their expected content (${corrupt.slice(0, 3).join(', ')})`
+                : undefined,
+            // Codigo propio: no es una usurpacion (nadie lo reemplazo por otra cosa) ni un
+            // symlink colgante. Es nuestro archivo, con el contenido incompleto — lo
+            // arregla re-instalar el bundle, que lo reescribe.
+            remediationCode: corrupt.length > 0 ? 'reinstall-rendered-artifacts' : undefined,
         };
     }
     const shared = owners.length > 1;
@@ -149,21 +163,29 @@ function skillsGlobalCheck(
     };
 }
 
-/** R8: verify the Codex `.toml` agents this run's renderer would have produced still parse. */
-function tomlAgentsHealthy(dir: string, entries: string[]): { broken: number } {
-    const tomls = entries.filter((e) => e.endsWith('.toml'));
-    const broken = tomls.filter((file) => {
+/**
+ * Archivos renderizados cuyo contenido ya no es lo que el renderer escribe.
+ *
+ * El marcador sale de `rendererIntegrityMarker` — la MISMA tabla que da la extension —
+ * y no de una copia local. Antes solo `codex-agent-toml` tenia esta verificacion, con su
+ * marcador horneado en esta funcion: el tercer renderer en agregarse habria pasado sin
+ * verificar y nadie se habria enterado.
+ *
+ * Un archivo ilegible cuenta como corrupto: no poder leerlo no es evidencia de que este
+ * bien. Es la misma disciplina que el resto de los checks — nunca verde por no mirar.
+ */
+function corruptRendered(dir: string, files: string[], renderer: RendererId): string[] {
+    const marker = rendererIntegrityMarker(renderer);
+    if (marker === null) return [];
+    return files.filter((file) => {
         try {
-            const content = fs.readFileSync(path.join(dir, file), 'utf8');
-            // renderCodexAgent (Task 4) always emits this key — its absence means the
-            // file was hand-edited or truncated, not a shape `awm` would have written.
-            return !content.includes('developer_instructions = ');
+            return !fs.readFileSync(path.join(dir, file), 'utf8').includes(marker);
         } catch {
             return true;
         }
-    }).length;
-    return { broken };
+    });
 }
+
 
 /**
  * Returns `null` when a check doesn't structurally apply to `agent` (e.g. Antigravity
@@ -250,7 +272,10 @@ function agentsNativeCheck(agent: AgentTarget): ProviderCheck | null {
     if (entries.length === 0) return null;
 
     if (provider.agent.renderer === 'codex-agent-toml') {
-        const { broken } = tomlAgentsHealthy(dir, entries);
+        // La extension sale de la tabla, no de un literal: escribir '.toml' aca fue
+        // exactamente lo que el guard estructural existe para detener, y lo detuvo.
+        const tomlExt = rendererExtension('codex-agent-toml') as string;
+        const broken = corruptRendered(dir, entries.filter((e) => e.endsWith(tomlExt)), 'codex-agent-toml').length;
         return {
             id: 'agents.native',
             state: broken > 0 ? 'broken' : 'healthy',

--- a/cli/src/core/renderers/registry.ts
+++ b/cli/src/core/renderers/registry.ts
@@ -32,6 +32,27 @@ const RENDERER_EXTENSION: Record<RendererId, string | null> = {
     'copilot-instructions': '.instructions.md',
 };
 
+/**
+ * Cadena que el renderer SIEMPRE estampa en lo que produce, y que por lo tanto
+ * distingue "el archivo existe" de "el archivo sigue siendo lo que escribimos".
+ *
+ * Vive en esta tabla, al lado de la extension, por la misma razon que la extension:
+ * son los dos hechos que un renderer nuevo tiene que declarar, y tenerlos juntos hace
+ * imposible agregar uno y olvidarse del segundo. `codex-agent-toml` ya tenia su marcador
+ * — horneado dentro de `tomlAgentsHealthy` en provider-checks.ts — y era el UNICO de los
+ * tres renderers con verificacion de contenido. Los otros dos comprobaban presencia y
+ * extension: un archivo correcto por fuera y vacio o truncado por dentro pasaba como sano.
+ *
+ * `null` en `link`: ahi la integridad la responde el clasificador de symlinks, que
+ * ademas distingue colgante de usurpado (D-007). Un marcador de texto no aplica.
+ */
+const RENDERER_INTEGRITY_MARKER: Record<RendererId, string | null> = {
+    link: null,
+    'codex-agent-toml': 'developer_instructions = ',
+    'cursor-mdc': 'alwaysApply:',
+    'copilot-instructions': 'applyTo:',
+};
+
 /** `.md` es la unica extension que un `installName` de artefacto puede traer.
  *  Deliberadamente NO se usa `path.parse().name`: eso corta desde el ULTIMO
  *  punto, asi que un skill llamado `v1.2-migration` se truncaria a `v1`,
@@ -58,4 +79,10 @@ export function renderedFilename(installName: string, renderer: RendererId): str
  *  renderizado en este directorio?") en vez de un nombre concreto. */
 export function rendererExtension(renderer: RendererId): string | null {
     return RENDERER_EXTENSION[renderer];
+}
+
+/** Marcador de integridad del renderer, o `null` cuando no aplica (`link`).
+ *  Ver `RENDERER_INTEGRITY_MARKER`. */
+export function rendererIntegrityMarker(renderer: RendererId): string | null {
+    return RENDERER_INTEGRITY_MARKER[renderer];
 }

--- a/cli/tests/core/diagnostics/provider-tier.test.ts
+++ b/cli/tests/core/diagnostics/provider-tier.test.ts
@@ -195,7 +195,27 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
 
         expect(skillsCheck?.state).not.toBe('healthy');
         expect(skillsCheck?.state).toBe('supported');
-        expect(skillsCheck?.detail).toContain('not verified');
+        // Antes decia 'content integrity not verified' — honesto entonces, porque no se
+        // verificaba. Ahora SI se verifica, y este archivo tiene su marcador, asi que no
+        // hay nada que reportar.
+        expect(skillsCheck?.detail).toBeUndefined();
+    });
+
+    it('a rendered file with the right extension but a truncated body is reported broken', () => {
+        // El hueco que cerraba C3: presencia + extension dejaba pasar un archivo correcto
+        // por fuera y vacio por dentro. El agente cargaba nada y doctor decia que si.
+        const rulesDir = path.join(tmpHome, '.cursor/rules');
+        fs.mkdirSync(rulesDir, { recursive: true });
+        fs.writeFileSync(path.join(rulesDir, 'development-process.mdc'), '---\ndescription: x\n');
+
+        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
+        const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');
+        const facts = gatherProviderChecks(['cursor'], scanSkills);
+        const skillsCheck = facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');
+
+        expect(skillsCheck?.state).toBe('broken');
+        expect(skillsCheck?.detail).toContain('development-process.mdc');
+        expect(skillsCheck?.remediationCode).toBe('reinstall-rendered-artifacts');
     });
 
     it('Gap B — non-link renderer (cursor-mdc) against REAL renderer/pipeline output, not a hand-written approximation', () => {
@@ -242,7 +262,10 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
         const skillsCheck = facts[0].checks.find((c: { id: string }) => c.id === 'skills.global');
 
         expect(skillsCheck).toMatchObject({ id: 'skills.global', state: 'supported', target: rulesDir });
-        expect(skillsCheck?.detail).toContain('not verified');
+        // La verificacion de contenido corre sobre la salida REAL del renderer, no sobre
+        // una aproximacion escrita a mano: si el marcador declarado en la tabla no
+        // coincidiera con lo que el renderer emite de verdad, este test lo detectaria.
+        expect(skillsCheck?.detail).toBeUndefined();
 
         fs.rmSync(content, { recursive: true, force: true });
     });

--- a/docs/plans/2026-08-09-verification-backlog.md
+++ b/docs/plans/2026-08-09-verification-backlog.md
@@ -108,9 +108,13 @@ D-011 redujo el daño (las rutas del agente ahora se resuelven bien), pero la ac
 
 **Resuelto:** `awm init` poda las entradas con **nuestra forma** cuyo script ya no existe, en Claude Code y en Codex. Tres condiciones, porque es el archivo de configuración del usuario y no se le borran líneas por parecido vago: el `matcher` es exactamente el nuestro, el ejecutable se llama como el script que AWM instala, y esa ruta **no existe**. Una instalación paralela viva no cumple la tercera, así que sobrevive intacta — y la entrada del `AWM_HOME` actual nunca se poda, aunque su script todavía no esté en disco.
 
-### C3 · Integridad de contenido en artefactos renderizados
+### ~~C3 · Integridad de contenido en artefactos renderizados~~ — ✅ cerrado 2026-08-09
 
-Para `.mdc` y `.instructions.md`, el diagnóstico comprueba que el archivo **existe y tiene la extensión correcta** — no que su contenido esté intacto. Un archivo correcto por fuera y corrupto por dentro pasa como sano. Hueco conocido y declarado en `support-matrix.md`.
+Para `.mdc` y `.instructions.md`, el diagnóstico comprobaba que el archivo **existía y tenía la extensión correcta** — no que su contenido estuviera intacto. Un archivo correcto por fuera y vacío o truncado por dentro pasaba como sano: el agente cargaba nada y `doctor` decía que sí.
+
+**Resuelto:** cada renderer declara su **marcador de integridad** en la misma tabla que ya declaraba su extensión (`core/renderers/registry.ts`), y el check lo consume. Un `.mdc` sin `alwaysApply:` o un `.instructions.md` sin `applyTo:` se reporta `broken`, con el nombre del archivo y remedio propio (`reinstall-rendered-artifacts` — no es una usurpación ni un symlink colgante: es nuestro archivo incompleto).
+
+**De paso, un cuarto duplicado menos:** `codex-agent-toml` era el único renderer con verificación de contenido, y su marcador estaba horneado dentro de `tomlAgentsHealthy`. Ahora los tres salen de la tabla, así que un renderer nuevo no puede agregarse sin declarar el suyo. El guard estructural del registry detectó —durante este mismo cambio— que yo había escrito `'.toml'` a mano en el sitio nuevo.
 
 ### C4 · `awm update` no reconcilia el scope de proyecto
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -77,8 +77,8 @@ La parte determinística —`awm sensors run`, su código de salida y el gate de
 | **Claude Code** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Suite + E2E aislado en CI (ubuntu, windows, macos) + playbook [`agent-matrix`](testing/agent-matrix.md) corrido contra el binario real (AG-01…AG-06, CC-01, CC-02), incluido **AG-06 con control negativo**: un `HOME` sin AWM responde que no tiene ninguna skill de AWM, así que lo que la sesión nombró vino de la instalación observada y no de su ambiente. |
 | **Codex** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Playbook completo contra `codex-cli 0.146.0` real, en una máquina con `CODEX_HOME`. **El hook se observó ejecutándose**: Codex mostró su prompt `Hooks need review`, se otorgó la confianza, la sesión imprimió `Running SessionStart hook` y el hook dejó su `heartbeat.json`. `hook.trust: healthy`, `overall: healthy`. Evidencia abajo. |
 | **OpenCode** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El escritor de `opencode.json` está cubierto por tests; que OpenCode *lea* ese campo no fue observado. |
-| **Cursor** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El `.mdc` se genera y se valida su forma. Que Cursor **cargue** un `.mdc` con `alwaysApply: false` no fue observado. |
-| **Copilot** | ✅ Verificado (solo proyecto) | ⚠ Sin verificar | ⛔ No tiene | El `.instructions.md` se genera. Que Copilot **honre** `applyTo: "**"` no fue observado. |
+| **Cursor** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El `.mdc` se genera, se valida su forma **y se verifica que su contenido siga intacto** (marcador `alwaysApply:`). Que Cursor **cargue** un `.mdc` con `alwaysApply: false` no fue observado. |
+| **Copilot** | ✅ Verificado (solo proyecto) | ⚠ Sin verificar | ⛔ No tiene | El `.instructions.md` se genera **y se verifica su contenido** (marcador `applyTo:`). Que Copilot **honre** `applyTo: "**"` no fue observado. |
 | **Antigravity** | ✅ Verificado | ⛔ No tiene mecanismo | ⛔ No tiene | Que Antigravity **lea** `global_workflows/` no fue observado. |
 
 ### Las decisiones ⛔, con su razón
@@ -159,7 +159,6 @@ Enunciado como trabajo, no como defecto. Esto es lo que hay que construir para s
 | # | Falta | Por qué importa | Qué destraba |
 |---|---|---|---|
 | 1 | **CI con binarios de agente reales** | Es la única razón por la que Cursor, Copilot, OpenCode y Antigravity siguen en ⚠. Ninguna cantidad de tests unitarios la sustituye. | Sube 4 proveedores de ⚠ a ✅ |
-| 2 | **Verificación de integridad de contenido en artefactos renderizados** | Para `.mdc` / `.instructions.md` el diagnóstico comprueba que el archivo *existe y tiene la extensión correcta*, no que su contenido esté intacto. Un archivo correcto por fuera y corrupto por dentro pasa. | Cierra un hueco conocido en `skills.global` |
 | 3 | **Reconciliación de scope de proyecto en `awm update`** | `update` reconcilia artefactos de máquina; los de proyecto son trabajo de `awm sync`. Un proyecto sin `sync` queda desactualizado en silencio. | Elimina un paso manual |
 | 4 | **Pruebas de los packs `python` y `shell` contra proyectos reales** | Existen y están completos; nadie los corrió contra un repo Python o de shell de verdad. | Sube 2 packs a ✅ |
 | 5 | **Un séptimo proveedor** | El modelo de capacidades ya lo soporta como una edición localizada (tabla de renderers + entrada de provider). No hay ninguno pedido todavía. | Amplía la cobertura |


### PR DESCRIPTION
C3 del backlog — cierra el tercer ítem de #57.

## El hueco

Para `.mdc` y `.instructions.md`, el diagnóstico comprobaba que el archivo **existiera y tuviera la extensión correcta** — no que su contenido estuviera intacto. Un archivo correcto por fuera y vacío o truncado por dentro pasaba como sano: **el agente cargaba nada y `doctor` decía que sí**.

El propio `detail` lo admitía — *"content integrity not verified"*. Era honesto, pero no era una verificación.

## El fix

Cada renderer declara ahora su **marcador de integridad** en la misma tabla que ya declaraba su extensión (`core/renderers/registry.ts`): la cadena que siempre estampa en lo que produce.

| Renderer | Marcador |
|---|---|
| `cursor-mdc` | `alwaysApply:` |
| `copilot-instructions` | `applyTo:` |
| `codex-agent-toml` | `developer_instructions = ` |
| `link` | — (ahí la integridad la responde el clasificador de symlinks, D-007) |

Un archivo sin su marcador se reporta `broken`, nombrándolo, con remedio propio: **`reinstall-rendered-artifacts`**. No es una usurpación ni un symlink colgante — es *nuestro* archivo incompleto, y lo arregla reinstalar el bundle.

Un archivo ilegible cuenta como corrupto. No poder leerlo no es evidencia de que esté bien: misma disciplina que el resto del diagnóstico — nunca verde por no mirar.

## Un cuarto duplicado menos

`codex-agent-toml` era el **único** renderer con verificación de contenido, y su marcador estaba horneado dentro de `tomlAgentsHealthy`. Los tres salen ahora de la tabla, así que un renderer nuevo no puede agregarse sin declarar el suyo — exactamente la razón por la que la extensión ya vivía ahí.

**El guard estructural del registry hizo su trabajo durante este mismo cambio:** detectó que yo había escrito `'.toml'` a mano en el sitio nuevo, y lo puso en rojo.

## Tests

Los dos que afirmaban *"presence-only, not verified"* codificaban el contrato viejo — actualizados. El que corre contra la salida **real** del renderer ahora además prueba que el marcador declarado coincide con lo que el renderer emite de verdad: si divergieran, ese test lo detectaría.

Test nuevo para el caso truncado, **verificado por revert**. Suite: **178 suites / 1753 tests**.

## Lo que queda de #57

Solo **C4** (`awm update` y el scope de proyecto), que es una pregunta de diseño y no una corrección — necesita tu decisión. **C5** y **C6** necesitan proyectos y binarios reales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_