### PR TITLE
feat(doctor): detect rendered artifacts that no longer match the registry

### DIFF
--- a/cli/src/core/diagnostics/provider-checks.ts
+++ b/cli/src/core/diagnostics/provider-checks.ts
@@ -17,7 +17,7 @@ import { assertProviderSupported } from '../provider-version';
 import { computeHookStatus } from '../../commands/hooks/status';
 import { InjectionOrchestrator } from '../context/orchestrator';
 import { capabilityRoot, contentRoots } from '../registries';
-import { rendererExtension, rendererIntegrityMarker } from '../renderers/registry';
+import { rendererExtension, rendererIntegrityMarker, renderArtifact } from '../renderers/registry';
 
 export type ScanSkills = (dir: string) => SkillIntegrity;
 
@@ -67,6 +67,7 @@ function skillsGlobalCheck(
     owners: AgentTarget[],
     integrity: SkillIntegrity,
     renderer: RendererId,
+    artifacts: ManagedArtifactRecord[],
 ): ProviderCheck | null {
     if (dir === null) return null;
     if (renderer !== 'link') {
@@ -105,18 +106,37 @@ function skillsGlobalCheck(
         // Comprobar presencia y extension dejaba pasar un archivo correcto por fuera y
         // vacio o truncado por dentro — el agente cargaba nada y doctor decia que si.
         const corrupt = corruptRendered(dir, rendered, renderer);
+        if (corrupt.length > 0) {
+            return {
+                id: 'skills.global', state: 'broken', target: dir,
+                owners: owners.length > 1 ? owners : undefined,
+                detail: `${corrupt.length} rendered file(s) missing their expected content (${corrupt.slice(0, 3).join(', ')})`,
+                // Codigo propio: no es una usurpacion (nadie lo reemplazo por otra cosa) ni
+                // un symlink colgante. Es nuestro archivo, con el contenido incompleto — lo
+                // arregla re-instalar el bundle, que lo reescribe.
+                remediationCode: 'reinstall-rendered-artifacts',
+            };
+        }
+        // Frescura, DESPUES de integridad: un archivo truncado tambien difiere de su
+        // fuente, y "incompleto" es mas util que "viejo". Solo aplica a renderizados — un
+        // symlink apunta al registry, asi que `awm update` lo actualiza solo. Los
+        // generados NO: quedan con el contenido de la version anterior hasta que alguien
+        // corra `awm sync`, y hasta ahora nada lo decia.
+        const stale = staleRendered(dir, artifacts);
         return {
             id: 'skills.global',
-            state: corrupt.length > 0 ? 'broken' : 'supported',
+            state: stale.length > 0 ? 'stale' : 'supported',
             target: dir,
             owners: owners.length > 1 ? owners : undefined,
-            detail: corrupt.length > 0
-                ? `${corrupt.length} rendered file(s) missing their expected content (${corrupt.slice(0, 3).join(', ')})`
+            detail: stale.length > 0
+                ? `${stale.length} rendered file(s) no longer match the installed registry (${stale.slice(0, 3).join(', ')})`
                 : undefined,
-            // Codigo propio: no es una usurpacion (nadie lo reemplazo por otra cosa) ni un
-            // symlink colgante. Es nuestro archivo, con el contenido incompleto — lo
-            // arregla re-instalar el bundle, que lo reescribe.
-            remediationCode: corrupt.length > 0 ? 'reinstall-rendered-artifacts' : undefined,
+            // `reinstall-bundle`, y NO `awm-sync` ni `awm-init`: se midio cual de los
+            // cuatro comandos refresca de verdad un renderizado viejo, y solo `awm add`
+            // lo hace. `init` y `sync` son idempotentes por presencia —ven el archivo y
+            // no lo tocan— y `update` refresca el registry, no lo derivado de el. Ofrecer
+            // un remedio que corre limpio sin cambiar nada es peor que no ofrecer ninguno.
+            remediationCode: stale.length > 0 ? 'reinstall-bundle' : undefined,
         };
     }
     const shared = owners.length > 1;
@@ -174,6 +194,24 @@ function skillsGlobalCheck(
  * Un archivo ilegible cuenta como corrupto: no poder leerlo no es evidencia de que este
  * bien. Es la misma disciplina que el resto de los checks — nunca verde por no mirar.
  */
+function staleRendered(dir: string, records: ManagedArtifactRecord[]): string[] {
+    return records
+        .filter((r) => r.renderer !== 'link' && path.dirname(r.targetPath) === dir)
+        .filter((r) => {
+            try {
+                const expected = renderArtifact(r.renderer, r.sourcePath);
+                if (expected === null) return false;
+                return fs.readFileSync(r.targetPath, 'utf8') !== expected;
+            } catch {
+                // Fuente ausente (el registry ya no la trae) o target ilegible: no es
+                // desactualizacion, es otra cosa, y la reportan los checks que
+                // corresponden. Aca "no puedo comparar" no se convierte en "esta viejo".
+                return false;
+            }
+        })
+        .map((r) => path.basename(r.targetPath));
+}
+
 function corruptRendered(dir: string, files: string[], renderer: RendererId): string[] {
     const marker = rendererIntegrityMarker(renderer);
     if (marker === null) return [];
@@ -404,6 +442,11 @@ export function gatherProviderChecks(agents: AgentTarget[], scanSkills: ScanSkil
         scansByDir.set(dir, scanSkills(dir));
     }
 
+    // El ledger se lee UNA vez por corrida y se comparte: es la unica forma de saber
+    // que fuente produjo cada artefacto renderizado, y por lo tanto de preguntar si
+    // sigue coincidiendo con ella.
+    const artifacts = safeArtifactState();
+
     return agents.map((agent) => {
         const provider = providerFor(agent);
         const dir = provider.skill.global;
@@ -413,7 +456,7 @@ export function gatherProviderChecks(agents: AgentTarget[], scanSkills: ScanSkil
 
         const checks: ProviderCheck[] = [
             binaryVersionCheck(agent),
-            skillsGlobalCheck(dir, owners, integrity, provider.skill.renderer),
+            skillsGlobalCheck(dir, owners, integrity, provider.skill.renderer, artifacts),
             agentsNativeCheck(agent),
             workflowsGlobalCheck(agent),
             hookTrustCheck(agent),

--- a/cli/src/core/install-transaction.ts
+++ b/cli/src/core/install-transaction.ts
@@ -21,9 +21,7 @@ import { InstallPlan, PlannedOperation } from './install-planner';
 import { mergeArtifactRecords, readArtifactState, writeArtifactState } from './artifact-state';
 import { awmHome } from './paths';
 import { writeFileAtomic } from './atomic-file';
-import { renderCodexAgent } from './renderers/codex-agent';
-import { renderCursorMdc } from './renderers/cursor-mdc';
-import { renderCopilotInstructions } from './renderers/copilot-instructions';
+import { renderArtifact } from './renderers/registry';
 import { stageArtifact, replaceArtifact } from './executor';
 
 /**
@@ -295,10 +293,6 @@ function stageRenderedFile(content: string, targetPath: string): string {
  * are sourced from that directory's SKILL.md, so every call site needs this
  * same one-line join instead of reading `op.sourcePath` directly.
  */
-function readSkillMdSource(op: PlannedOperation): string {
-    return fs.readFileSync(path.join(op.sourcePath, 'SKILL.md'), 'utf8');
-}
-
 /**
  * The real, filesystem-touching TransactionDeps used by applyInstallPlan by
  * default. Renders `codex-agent-toml`/`cursor-mdc`/`copilot-instructions`
@@ -318,13 +312,10 @@ export function defaultTransactionDeps(): TransactionDeps {
             }
             // Renders without writing anything, purely to surface parse errors
             // before any backup/replace happens.
-            if (op.renderer === 'codex-agent-toml') {
-                renderCodexAgent(fs.readFileSync(op.sourcePath, 'utf8'));
-            } else if (op.renderer === 'cursor-mdc') {
-                renderCursorMdc(readSkillMdSource(op));
-            } else if (op.renderer === 'copilot-instructions') {
-                renderCopilotInstructions(readSkillMdSource(op));
-            }
+            // Renderiza y descarta: el objetivo es que un error de parseo salte ANTES
+            // de tocar nada. El dispatch sale de la tabla (`renderArtifact`), no de una
+            // copia local — esta era una de las dos que habia en este archivo.
+            renderArtifact(op.renderer, op.sourcePath);
         },
 
         backup(op, backupDir) {
@@ -342,19 +333,11 @@ export function defaultTransactionDeps(): TransactionDeps {
         },
 
         stage(op) {
-            if (op.renderer === 'codex-agent-toml') {
-                const rendered = renderCodexAgent(fs.readFileSync(op.sourcePath, 'utf8'));
-                return stageRenderedFile(rendered, op.targetPath);
-            }
-            if (op.renderer === 'cursor-mdc') {
-                const rendered = renderCursorMdc(readSkillMdSource(op));
-                return stageRenderedFile(rendered, op.targetPath);
-            }
-            if (op.renderer === 'copilot-instructions') {
-                const rendered = renderCopilotInstructions(readSkillMdSource(op));
-                return stageRenderedFile(rendered, op.targetPath);
-            }
-            return stageArtifact(op.sourcePath, op.targetPath, op.method);
+            const rendered = renderArtifact(op.renderer, op.sourcePath);
+            // `null` = renderer `link`: no genera contenido, se instala el artefacto tal cual.
+            return rendered === null
+                ? stageArtifact(op.sourcePath, op.targetPath, op.method)
+                : stageRenderedFile(rendered, op.targetPath);
         },
 
         replace(op, staged) {

--- a/cli/src/core/renderers/registry.ts
+++ b/cli/src/core/renderers/registry.ts
@@ -21,7 +21,12 @@
 // renderer nuevo, se agrega aca y todos los consumidores quedan correctos por
 // construccion — que es lo que convierte "agregar un provider" en un cambio
 // localizado en vez de una caceria por seis archivos.
+import fs from 'fs';
+import path from 'path';
 import type { RendererId } from '../../providers';
+import { renderCodexAgent } from './codex-agent';
+import { renderCursorMdc } from './cursor-mdc';
+import { renderCopilotInstructions } from './copilot-instructions';
 
 /** Extension que el renderer estampa sobre el nombre base, o `null` cuando el
  *  artefacto se instala con el nombre tal cual (renderer `link`). */
@@ -85,4 +90,38 @@ export function rendererExtension(renderer: RendererId): string | null {
  *  Ver `RENDERER_INTEGRITY_MARKER`. */
 export function rendererIntegrityMarker(renderer: RendererId): string | null {
     return RENDERER_INTEGRITY_MARKER[renderer];
+}
+
+/**
+ * Contenido que `renderer` produce AHORA a partir de `sourcePath`, o `null` para `link`
+ * (no genera nada: instala el artefacto tal cual).
+ *
+ * Es la tercera cosa que un renderer tiene que declarar, junto con su extension y su
+ * marcador — y por eso vive en esta tabla. El dispatch `renderer id → funcion` estaba
+ * escrito DOS veces dentro de `install-transaction.ts` (una en `validate`, otra en
+ * `stage`), y agregar un consumidor mas —el chequeo de frescura del diagnostico— habria
+ * hecho tres. Es exactamente la duplicacion que el comentario de arriba de este modulo
+ * describe como el bug que costo una release.
+ *
+ * Puro: lee la fuente y devuelve texto. No escribe nada, asi que sirve igual para
+ * instalar, para validar antes de instalar, y para preguntar "¿lo instalado sigue
+ * coincidiendo con la fuente?".
+ */
+export function renderArtifact(renderer: RendererId, sourcePath: string): string | null {
+    switch (renderer) {
+        case 'link':
+            return null;
+        case 'codex-agent-toml':
+            return renderCodexAgent(fs.readFileSync(sourcePath, 'utf8'));
+        case 'cursor-mdc':
+            return renderCursorMdc(readSkillMd(sourcePath));
+        case 'copilot-instructions':
+            return renderCopilotInstructions(readSkillMd(sourcePath));
+    }
+}
+
+/** Las skills se rinden desde el `SKILL.md` de su directorio; los agentes de Codex,
+ *  desde el archivo directo. La diferencia la sabe cada rama de `renderArtifact`. */
+function readSkillMd(sourceDir: string): string {
+    return fs.readFileSync(path.join(sourceDir, 'SKILL.md'), 'utf8');
 }

--- a/cli/tests/core/diagnostics/provider-tier.test.ts
+++ b/cli/tests/core/diagnostics/provider-tier.test.ts
@@ -270,6 +270,52 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
         fs.rmSync(content, { recursive: true, force: true });
     });
 
+    it('a rendered file that no longer matches its registry source is reported stale', () => {
+        // El caso que C4 realmente pedia. Un symlink apunta al registry, asi que
+        // `awm update` lo actualiza solo — por eso claude-code/codex/opencode nunca
+        // quedan viejos. Un `.mdc` es un archivo GENERADO: se queda con el contenido de
+        // la version anterior hasta que alguien corra `awm sync`, y nada lo decia.
+        const source = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-stale-src-'));
+        fs.mkdirSync(path.join(source, 'using-awm'), { recursive: true });
+        const skillMd = path.join(source, 'using-awm', 'SKILL.md');
+        fs.writeFileSync(skillMd, '---\nname: using-awm\ndescription: original\n---\n\nCuerpo v1.\n');
+
+        const rulesDir = path.join(tmpHome, '.cursor/rules');
+        fs.mkdirSync(rulesDir, { recursive: true });
+        const target = path.join(rulesDir, 'using-awm.mdc');
+        const { renderArtifact } = require('../../../src/core/renderers/registry');
+        fs.writeFileSync(target, renderArtifact('cursor-mdc', path.join(source, 'using-awm')));
+
+        const stateDir = path.join(tmpHome, '.awm', 'state');
+        fs.mkdirSync(stateDir, { recursive: true });
+        fs.writeFileSync(path.join(stateDir, 'artifacts.json'), JSON.stringify([{
+            name: 'using-awm', type: 'skill', scope: 'global',
+            targetPath: target, sourcePath: path.join(source, 'using-awm'),
+            renderer: 'cursor-mdc', owners: ['cursor'],
+        }]));
+
+        const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
+        const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');
+
+        // Recien instalado: coincide con su fuente.
+        const fresh = gatherProviderChecks(['cursor'], scanSkills)[0]
+            .checks.find((c: { id: string }) => c.id === 'skills.global');
+        expect(fresh?.state).toBe('supported');
+
+        // `awm update` trae una version nueva de la skill upstream.
+        fs.writeFileSync(skillMd, '---\nname: using-awm\ndescription: original\n---\n\nCuerpo v2, cambiado upstream.\n');
+
+        const stale = gatherProviderChecks(['cursor'], scanSkills)[0]
+            .checks.find((c: { id: string }) => c.id === 'skills.global');
+        expect(stale?.state).toBe('stale');
+        expect(stale?.detail).toContain('using-awm.mdc');
+        // Medido, no supuesto: de `init`/`update`/`sync`/`add`, solo `add` refresca un
+        // renderizado viejo. Los otros tres corren limpios y no cambian nada.
+        expect(stale?.remediationCode).toBe('reinstall-bundle');
+
+        fs.rmSync(source, { recursive: true, force: true });
+    });
+
     it('non-link renderer with an empty/missing dir reports absent, not a false healthy', () => {
         const scanSkills = jest.fn(() => ({ valid: [], repairable: [], dead: [], usurped: [] }));
         const { gatherProviderChecks } = require('../../../src/core/diagnostics/provider-checks');

--- a/docs/plans/2026-08-09-verification-backlog.md
+++ b/docs/plans/2026-08-09-verification-backlog.md
@@ -116,9 +116,31 @@ Para `.mdc` y `.instructions.md`, el diagnóstico comprobaba que el archivo **ex
 
 **De paso, un cuarto duplicado menos:** `codex-agent-toml` era el único renderer con verificación de contenido, y su marcador estaba horneado dentro de `tomlAgentsHealthy`. Ahora los tres salen de la tabla, así que un renderer nuevo no puede agregarse sin declarar el suyo. El guard estructural del registry detectó —durante este mismo cambio— que yo había escrito `'.toml'` a mano en el sitio nuevo.
 
-### C4 · `awm update` no reconcilia el scope de proyecto
+### C4 · Los artefactos **renderizados** quedan viejos y nada los refresca — parcialmente cerrado 2026-08-09
 
-`update` reconcilia artefactos de máquina; los de proyecto son trabajo de `awm sync`. Un proyecto en el que nadie corre `sync` queda desactualizado en silencio.
+**El enunciado original estaba mal, y medirlo lo corrigió.** No es "scope de proyecto": es **formato de instalación**.
+
+| Instalación | ¿Se actualiza sola con `awm update`? |
+|---|---|
+| **Symlink** (`claude-code`, `codex`, `opencode`, `antigravity`) | **Sí.** Apunta al registry: el cambio se ve al instante, en todos los proyectos a la vez. |
+| **Renderizada** (`.mdc`, `.instructions.md`, `.toml`) | **No.** Son archivos generados: se quedan con el contenido de la versión anterior. |
+
+Así que solo Cursor, Copilot y los perfiles de agente de Codex quedan viejos — y nada lo decía.
+
+**Cerrado: la detección.** `awm doctor` re-renderiza cada artefacto desde la fuente que el ledger declara y compara. Si difiere, reporta `stale`, nombra el archivo y degrada `overall`. Es una comparación **exacta**, no una heurística de timestamps: un registry re-clonado no produce falsos positivos.
+
+**Medido, no supuesto — cuál comando refresca:**
+
+| Comando | ¿Refresca un renderizado viejo? |
+|---|---|
+| `awm init` | **No** — idempotente por presencia: ve el archivo y no lo toca |
+| `awm update` | **No** — refresca el registry, no lo derivado de él |
+| `awm sync` | **No** (verificado en scope global) |
+| `awm add <bundle>` | **Sí** |
+
+Por eso el remedio es `reinstall-bundle`. Ofrecer `awm sync` habría sido un remedio que corre limpio sin cambiar nada — el mismo defecto que `open-hooks-trust` tenía y que D-010 cerró.
+
+**Abierto: la reconciliación automática.** Lo correcto a futuro es que `awm update` **re-renderice los artefactos derivados**, porque son exactamente eso — derivados del registry que acaba de actualizar. Hoy el usuario tiene que verlo en `doctor` y correr `awm add` a mano. La detección lo hace visible; la automatización queda pendiente, ahora con la evidencia de qué comando toca cambiar.
 
 ### C5 · Packs `python` y `shell` contra proyectos reales
 


### PR DESCRIPTION
C4 — **con el enunciado corregido por la medición.**

## El enunciado estaba mal

C4 decía *"`awm update` no reconcilia el scope de proyecto"*. No es scope. Es **formato de instalación**:

| Instalación | ¿Se actualiza sola con `awm update`? |
|---|---|
| **Symlink** (claude-code, codex, opencode, antigravity) | **Sí** — apunta al registry: el cambio se ve al instante, en todos los proyectos a la vez |
| **Renderizada** (`.mdc`, `.instructions.md`, `.toml`) | **No** — son archivos generados, se quedan con el contenido de la versión anterior |

Así que la mitad de la preocupación original no existía, y la que sí existe afecta exactamente a **Cursor, Copilot y los perfiles de agente de Codex**. Nada lo decía.

## La detección

`doctor` re-renderiza cada artefacto desde la fuente que el ledger declara y compara. Si difiere → `stale`, nombra el archivo, degrada `overall`.

Es una comparación **exacta**, no una heurística de timestamps: un registry re-clonado tiene mtimes nuevos en todo y habría reportado todo viejo. Comparar contenido no tiene ese falso positivo.

## El remedio se midió, no se supuso

**La primera versión de este PR ofrecía `awm sync`, y la verificación end-to-end mostró que no arregla nada.** Medí los cuatro candidatos:

| Comando | ¿Refresca un renderizado viejo? |
|---|---|
| `awm init` | **No** — idempotente por presencia: ve el archivo y no lo toca |
| `awm update` | **No** — refresca el registry, no lo derivado de él |
| `awm sync` | **No** (verificado en scope global) |
| `awm add <bundle>` | **Sí** |

Por eso el remedio es `reinstall-bundle`. Un remedio que corre limpio sin cambiar nada es peor que ninguno — es el defecto exacto que tenía `open-hooks-trust` y que D-010 cerró hace unas horas. Casi lo repito.

## Dos duplicados menos

El dispatch `renderer id → función` estaba escrito **dos veces** dentro de `install-transaction.ts` (`validate` y `stage`). Agregar el chequeo de frescura habría hecho tres — la duplicación que el comentario de cabecera de `renderers/registry.ts` describe como *el bug que costó una release*.

`renderArtifact` vive ahora en esa tabla, junto a la extensión y al marcador de integridad: **las tres cosas que un renderer tiene que declarar, en un solo lugar.**

## Lo que queda abierto, dicho explícitamente

Que `awm update` **re-renderice** los artefactos derivados — porque son exactamente eso, derivados del registry que acaba de actualizar. Hoy el usuario lo ve en `doctor` y corre `awm add` a mano.

La detección lo hace visible; la automatización queda pendiente, ahora con la evidencia de qué comando hay que tocar. Preferí eso a cerrar C4 declarándolo resuelto.

## Verificación

- **Revert probe.**
- **Contra el binario construido:** `supported` → `stale` tras un cambio upstream → `supported` tras `awm add`.
- Suite: **178 suites / 1754 tests**.

## Hallazgo suelto, sin arreglar acá

El aviso de versión nueva (`⬆ awm vX available`) se imprime por **stdout**, así que contamina `awm doctor --json` y rompe cualquier consumidor que parsee. Lo encontré tropezando con él en esta verificación. No lo toco en este PR para no mezclarlo; queda para uno propio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_