### PR TITLE
fix(sync,doctor,update-check): close the last two open items

### DIFF
--- a/cli/src/core/diagnostics/provider-checks.ts
+++ b/cli/src/core/diagnostics/provider-checks.ts
@@ -123,20 +123,24 @@ function skillsGlobalCheck(
         // generados NO: quedan con el contenido de la version anterior hasta que alguien
         // corra `awm sync`, y hasta ahora nada lo decia.
         const stale = staleRendered(dir, artifacts);
+        const names = stale.map((r) => path.basename(r.targetPath));
         return {
             id: 'skills.global',
             state: stale.length > 0 ? 'stale' : 'supported',
             target: dir,
             owners: owners.length > 1 ? owners : undefined,
             detail: stale.length > 0
-                ? `${stale.length} rendered file(s) no longer match the installed registry (${stale.slice(0, 3).join(', ')})`
+                ? `${stale.length} rendered file(s) no longer match the installed registry (${names.slice(0, 3).join(', ')})`
                 : undefined,
-            // `reinstall-bundle`, y NO `awm-sync` ni `awm-init`: se midio cual de los
-            // cuatro comandos refresca de verdad un renderizado viejo, y solo `awm add`
-            // lo hace. `init` y `sync` son idempotentes por presencia —ven el archivo y
-            // no lo tocan— y `update` refresca el registry, no lo derivado de el. Ofrecer
-            // un remedio que corre limpio sin cambiar nada es peor que no ofrecer ninguno.
-            remediationCode: stale.length > 0 ? 'reinstall-bundle' : undefined,
+            // El remedio depende del ALCANCE, y se midio cual funciona en cada uno:
+            // `awm update` reconcilia los artefactos de maquina, `awm sync` los que el
+            // profile del proyecto declara. Ofrecer el equivocado seria mandar al usuario
+            // a un comando que corre limpio sin cambiar nada — el defecto que ya tuvo
+            // `open-hooks-trust` (D-010), y que la primera version de ESTE chequeo
+            // repitio: ofrecia `reinstall-bundle` porque dos mediciones mias estaban mal.
+            remediationCode: stale.length > 0
+                ? (stale.some((r) => r.scope === 'local') ? 'awm-sync' : 'awm-update')
+                : undefined,
         };
     }
     const shared = owners.length > 1;
@@ -194,7 +198,7 @@ function skillsGlobalCheck(
  * Un archivo ilegible cuenta como corrupto: no poder leerlo no es evidencia de que este
  * bien. Es la misma disciplina que el resto de los checks — nunca verde por no mirar.
  */
-function staleRendered(dir: string, records: ManagedArtifactRecord[]): string[] {
+function staleRendered(dir: string, records: ManagedArtifactRecord[]): ManagedArtifactRecord[] {
     return records
         .filter((r) => r.renderer !== 'link' && path.dirname(r.targetPath) === dir)
         .filter((r) => {
@@ -208,8 +212,7 @@ function staleRendered(dir: string, records: ManagedArtifactRecord[]): string[] 
                 // corresponden. Aca "no puedo comparar" no se convierte en "esta viejo".
                 return false;
             }
-        })
-        .map((r) => path.basename(r.targetPath));
+        });
 }
 
 function corruptRendered(dir: string, files: string[], renderer: RendererId): string[] {

--- a/cli/src/core/profile.ts
+++ b/cli/src/core/profile.ts
@@ -160,5 +160,19 @@ export function ensureSkillsGitignored(root: string, agents: AgentTarget[]): voi
  * project extensions and stay out of `.awm/profile.json`.
  */
 export function shouldRecordExtension(bundleScope: BundleScope, effective: Scope): boolean {
-    return bundleScope === 'project' && effective === 'local';
+    // El criterio es el ALCANCE EFECTIVO, no el del bundle.
+    //
+    // Antes exigia ademas `bundleScope === 'project'`, asi que un bundle baseline
+    // instalado explicitamente con `--scope local` no quedaba registrado en ningun lado:
+    // `awm sync` reconcilia lo que declara el profile, y esos artefactos no estaban ahi.
+    // Resultado: nadie los refrescaba nunca. `update` cubre lo global y `sync` lo del
+    // profile; eso caia en el medio.
+    //
+    // Y no es un caso raro: `awm add dev --scope local` es exactamente lo que el playbook
+    // de aceptacion (AG-03) le pide correr a cualquiera que verifique un proveedor.
+    //
+    // Si alguien pidio artefactos de proyecto, el profile lo dice — que es lo que hace
+    // que un companero que clona el repo y corre `awm sync` obtenga lo mismo.
+    void bundleScope;
+    return effective === 'local';
 }

--- a/cli/src/core/update-check.ts
+++ b/cli/src/core/update-check.ts
@@ -71,7 +71,11 @@ export function maybeNotifyUpdate(opts?: { now?: number; spawnWorker?: () => voi
     const spawnWorker = opts?.spawnWorker ?? spawnRefreshWorker;
     const cache = readUpdateCache();
     if (cache?.latest && isNewer(cache.latest, cliVersion())) {
-        console.log(pc.dim(`\n⬆ awm v${cache.latest} available → npm i -g ${CLI_PACKAGE_NAME}`));
+        // stderr, NO stdout. Este aviso se imprime al final de CUALQUIER comando, asi
+        // que en stdout se mezclaba con la salida de `--json` y rompia a cualquiera que
+        // parsee: `awm doctor --json | jq` fallaba con un SyntaxError que no menciona la
+        // causa. stdout es la interfaz de maquina; los avisos al humano van por stderr.
+        process.stderr.write(pc.dim(`\n⬆ awm v${cache.latest} available → npm i -g ${CLI_PACKAGE_NAME}\n`));
     }
     if (!cache || now - cache.lastCheck > TTL_MS) spawnWorker();
 }

--- a/cli/tests/core/diagnostics/provider-tier.test.ts
+++ b/cli/tests/core/diagnostics/provider-tier.test.ts
@@ -309,9 +309,9 @@ describe('skillsGlobalCheck — renderer-aware (Task 4.4 / deferred Task 4.3 fin
             .checks.find((c: { id: string }) => c.id === 'skills.global');
         expect(stale?.state).toBe('stale');
         expect(stale?.detail).toContain('using-awm.mdc');
-        // Medido, no supuesto: de `init`/`update`/`sync`/`add`, solo `add` refresca un
-        // renderizado viejo. Los otros tres corren limpios y no cambian nada.
-        expect(stale?.remediationCode).toBe('reinstall-bundle');
+        // El remedio depende del alcance, y se midio: `awm update` reconcilia los
+        // artefactos de maquina; `awm sync`, los que declara el profile del proyecto.
+        expect(stale?.remediationCode).toBe('awm-update');
 
         fs.rmSync(source, { recursive: true, force: true });
     });

--- a/cli/tests/core/profile.test.ts
+++ b/cli/tests/core/profile.test.ts
@@ -118,11 +118,19 @@ describe('ensureSkillsGitignored', () => {
 });
 
 describe('shouldRecordExtension', () => {
-    it('records only project-scope bundles installed locally', () => {
+    it('no registra nada instalado a nivel maquina, sea cual sea el bundle', () => {
         expect(shouldRecordExtension('project', 'local')).toBe(true);
         expect(shouldRecordExtension('project', 'global')).toBe(false);
         expect(shouldRecordExtension('baseline', 'global')).toBe(false);
-        expect(shouldRecordExtension('baseline', 'local')).toBe(false);
         expect(shouldRecordExtension('ambient', 'global')).toBe(false);
+    });
+
+    it('records a BASELINE bundle too when it was installed with --scope local', () => {
+        // Antes devolvia false, y esos artefactos quedaban fuera del profile: `awm sync`
+        // reconcilia lo que el profile declara, asi que nadie los refrescaba nunca —
+        // `update` cubre lo global y esto caia en el medio. No es un caso raro:
+        // `awm add dev --scope local` es lo que el playbook AG-03 pide correr.
+        expect(shouldRecordExtension('baseline', 'local')).toBe(true);
+        expect(shouldRecordExtension('ambient', 'local')).toBe(true);
     });
 });

--- a/cli/tests/core/update-check.test.ts
+++ b/cli/tests/core/update-check.test.ts
@@ -55,12 +55,14 @@ describe('update-check', () => {
     it('maybeNotifyUpdate avisa si el cache trae versión más nueva y NO refresca cache fresco', () => {
         const m = require('../../src/core/update-check');
         m.writeUpdateCache({ lastCheck: 1_000_000, latest: '99.0.0' });
-        const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+        // stderr, no stdout: el aviso sale al final de cualquier comando y en stdout
+        // rompia la salida de `--json`.
+        const err = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
         const spawnWorker = jest.fn();
         m.maybeNotifyUpdate({ now: 1_000_000 + 1000, spawnWorker });
-        expect(log.mock.calls.flat().join('\n')).toContain('99.0.0');
+        expect(err.mock.calls.flat().join('\n')).toContain('99.0.0');
         expect(spawnWorker).not.toHaveBeenCalled();
-        log.mockRestore();
+        err.mockRestore();
     });
 
     it('cache viejo (>24h) dispara refresh en background', () => {
@@ -102,5 +104,31 @@ describe('update-check', () => {
         expect(cache).not.toBeNull();
         expect(cache.latest).toBe('2.0.0');
         expect(cache.lastCheck).toBeGreaterThan(0);
+    });
+});
+
+// El aviso de version nueva va por stderr, no por stdout.
+//
+// Se imprime al final de CUALQUIER comando, asi que en stdout se mezclaba con la salida
+// de `--json` y rompia a cualquiera que parsee. Encontrado tropezando con el:
+// `awm doctor --json | node -e 'JSON.parse(...)'` fallaba con un SyntaxError que no
+// menciona la causa. stdout es la interfaz de maquina.
+describe('the update banner never contaminates stdout', () => {
+    it('writes to stderr so `--json` output stays parseable', () => {
+        const stdout = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+        try {
+            const { maybeNotifyUpdate } = require('../../src/core/update-check');
+            maybeNotifyUpdate({ spawnWorker: () => {} });
+            const onStdout = stdout.mock.calls.map((c) => String(c[0])).join('')
+                + log.mock.calls.map((c) => String(c[0])).join('');
+            expect(onStdout).not.toContain('available');
+            // Y si habia aviso, salio por stderr — no se perdio, se movio.
+            const emitted = stderr.mock.calls.map((c) => String(c[0])).join('');
+            if (emitted.length > 0) expect(emitted).toContain('available');
+        } finally {
+            stdout.mockRestore(); stderr.mockRestore(); log.mockRestore();
+        }
     });
 });

--- a/docs/plans/2026-08-09-verification-backlog.md
+++ b/docs/plans/2026-08-09-verification-backlog.md
@@ -116,7 +116,7 @@ Para `.mdc` y `.instructions.md`, el diagnóstico comprobaba que el archivo **ex
 
 **De paso, un cuarto duplicado menos:** `codex-agent-toml` era el único renderer con verificación de contenido, y su marcador estaba horneado dentro de `tomlAgentsHealthy`. Ahora los tres salen de la tabla, así que un renderer nuevo no puede agregarse sin declarar el suyo. El guard estructural del registry detectó —durante este mismo cambio— que yo había escrito `'.toml'` a mano en el sitio nuevo.
 
-### C4 · Los artefactos **renderizados** quedan viejos y nada los refresca — parcialmente cerrado 2026-08-09
+### ~~C4 · Los artefactos **renderizados** quedan viejos~~ — ✅ cerrado 2026-08-09
 
 **El enunciado original estaba mal, y medirlo lo corrigió.** No es "scope de proyecto": es **formato de instalación**.
 
@@ -129,18 +129,44 @@ Así que solo Cursor, Copilot y los perfiles de agente de Codex quedan viejos �
 
 **Cerrado: la detección.** `awm doctor` re-renderiza cada artefacto desde la fuente que el ledger declara y compara. Si difiere, reporta `stale`, nombra el archivo y degrada `overall`. Es una comparación **exacta**, no una heurística de timestamps: un registry re-clonado no produce falsos positivos.
 
-**Medido, no supuesto — cuál comando refresca:**
+**Medido — y la primera medición estuvo mal, así que vale decir cómo.** La tabla inicial
+afirmaba que ningún comando refrescaba salvo `awm add`. Dos errores míos: `awm update --yes`
+no existe (el comando erroró y nunca corrió), y editar el `SKILL.md` del registry a mano no
+sirve como fuente de verdad porque `awm update` hace `git pull` y descarta esa edición. Al
+medirlo bien, corrompiendo el **destino** en vez de la fuente:
 
-| Comando | ¿Refresca un renderizado viejo? |
+| Artefacto | Comando que lo refresca |
 |---|---|
-| `awm init` | **No** — idempotente por presencia: ve el archivo y no lo toca |
-| `awm update` | **No** — refresca el registry, no lo derivado de él |
-| `awm sync` | **No** (verificado en scope global) |
-| `awm add <bundle>` | **Sí** |
+| Global (baseline, máquina) | **`awm update`** ✅ |
+| Proyecto, declarado en `profile.json` | **`awm sync`** ✅ |
+| Proyecto, bundle **baseline** con `--scope local` | **ninguno** ❌ |
 
-Por eso el remedio es `reinstall-bundle`. Ofrecer `awm sync` habría sido un remedio que corre limpio sin cambiar nada — el mismo defecto que `open-hooks-trust` tenía y que D-010 cerró.
+**Ese tercer caso era el hueco real**, y no era raro: `awm add dev --scope local` es
+exactamente lo que el playbook AG-03 pide correr para verificar cualquier proveedor.
+`shouldRecordExtension` exigía que el bundle fuese de scope `project`, así que un baseline
+instalado localmente no entraba al profile — y `awm sync` reconcilia lo que el profile
+declara. Esos artefactos no los tocaba nadie.
 
-**Abierto: la reconciliación automática.** Lo correcto a futuro es que `awm update` **re-renderice los artefactos derivados**, porque son exactamente eso — derivados del registry que acaba de actualizar. Hoy el usuario tiene que verlo en `doctor` y correr `awm add` a mano. La detección lo hace visible; la automatización queda pendiente, ahora con la evidencia de qué comando toca cambiar.
+**Resuelto:** el criterio pasa a ser el **alcance efectivo**, no el del bundle. Si alguien
+pidió artefactos de proyecto, el profile lo dice — que es además lo que hace que un
+compañero que clona el repo y corre `awm sync` obtenga lo mismo.
+
+El remedio que `doctor` ofrece depende del alcance: `awm update` para lo global, `awm sync`
+para lo de proyecto. La primera versión de este chequeo ofrecía `reinstall-bundle`, basada
+en la medición equivocada — el mismo defecto de "remedio que corre limpio sin cambiar nada"
+que D-010 cerró, repetido y corregido.
+
+**Verificado contra el binario:** artefacto de proyecto viejo → `awm sync` lo arregla;
+artefacto global viejo → `awm update` lo arregla; `profile.json` registra el install local.
+
+### ~~C7 · El aviso de versión nueva contamina `--json`~~ — ✅ cerrado 2026-08-09
+
+`⬆ awm vX available` se imprimía por **stdout** al final de cualquier comando, así que se
+mezclaba con la salida de `--json` y rompía a cualquiera que parsee: `awm doctor --json | jq`
+fallaba con un `SyntaxError` que no menciona la causa. Encontrado tropezando con él mientras
+se verificaba C4.
+
+**Resuelto:** va por `stderr`. stdout es la interfaz de máquina; los avisos al humano no van ahí.
 
 ### C5 · Packs `python` y `shell` contra proyectos reales
 


### PR DESCRIPTION
Cierra lo que quedaba abierto. `Closes #57`.

## 1 · Un install de proyecto de un bundle baseline no lo reconciliaba nadie

`shouldRecordExtension` exigía que el bundle fuese de scope `project`, así que `awm add dev --scope local` **no entraba al profile** — y `awm sync` reconcilia lo que el profile declara. Esos artefactos quedaban huérfanos: `update` cubre lo global, `sync` lo del profile, y esto caía **en el medio**.

No es un caso raro: `awm add dev --scope local` es exactamente lo que el playbook AG-03 le pide correr a cualquiera que verifique un proveedor.

El criterio pasa a ser el **alcance efectivo**, no el del bundle. Si alguien pidió artefactos de proyecto, el profile lo dice — que es además lo que hace que un compañero que clona el repo y corre `awm sync` obtenga lo mismo.

## 2 · El aviso de versión contaminaba `--json`

`⬆ awm vX available` salía por **stdout** al final de cualquier comando, así que `awm doctor --json | jq` fallaba con un `SyntaxError` que no menciona la causa. Va por stderr. **stdout es la interfaz de máquina.**

## Y una corrección mía

El chequeo de frescura que salió en el PR anterior ofrecía `reinstall-bundle`, basado en **dos mediciones equivocadas**:

- `awm update --yes` no existe — el comando erroró y nunca corrió, y leí el resultado como "update no refresca".
- Editar el `SKILL.md` del registry a mano no sirve como fuente: `update` hace `git pull` y descarta la edición.

Medido bien —corrompiendo el **destino** en vez de la fuente— el cuadro real es:

| Artefacto | Comando |
|---|---|
| Global (máquina) | **`awm update`** ✅ |
| Proyecto, en `profile.json` | **`awm sync`** ✅ |
| Proyecto, baseline con `--scope local` | ninguno → **arreglado acá** |

El remedio de `doctor` ahora depende del alcance. Era el mismo defecto que D-010 cerró — *"un remedio que corre limpio sin cambiar nada"* — repetido por mí y corregido antes de que llegue a nadie.

## Verificación

Contra el binario construido, los cuatro puntos:

1. `profile.json` registra el install local → `{"extensions":["dev"]}`
2. Artefacto de proyecto viejo → `awm sync` lo arregla
3. Artefacto global viejo → `awm update` lo arregla
4. `awm doctor --json` parsea limpio

Suite: **178 suites / 1756 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_