### PR TITLE
docs(decisions): close DA-3..DA-6 and sequence the SDD initiative to its end

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -17,6 +17,10 @@ Formato: qué se decidió, por qué, qué implica. Sin historia larga — eso vi
 | [D-009](#d-009) | 2026-08-09 | Los releases se serializan, y el tag se empuja antes que la rama | Vigente |
 | [D-010](#d-010) | 2026-08-09 | Un hook que nunca corrió no se reporta `HEALTHY` | Vigente |
 | [D-011](#d-011) | 2026-08-09 | Cada agente resuelve su raíz de configuración por su propia variable de entorno | Vigente |
+| [D-012](#d-012) | 2026-08-09 | Worktree con fallback serial, no requisito duro (cierra DA-3) | Vigente |
+| [D-013](#d-013) | 2026-08-09 | El set de referencia de sensores vive en el `pack.json` del registry (cierra DA-4) | Vigente |
+| [D-014](#d-014) | 2026-08-09 | La detección de cobertura **reporta**, nunca instala ni configura (cierra DA-6) | Vigente |
+| [D-015](#d-015) | 2026-08-09 | Umbral empírico ≥2, y es señal, no compuerta (cierra DA-5) | Vigente |
 
 ---
 
@@ -317,3 +321,77 @@ prueba contaminaba el `hooks.json` real — que fue justo lo que hizo dudar del 
 en las tres columnas. La compuerta de confianza era real pero **no** era la causa: nunca se
 llegaba a ella. Una hipótesis plausible que resultó falsa, y solo el diagnóstico de la ruta
 la separó del síntoma.
+
+---
+
+## D-012
+
+**El worktree es el camino preferido, con fallback serial. No es requisito duro.** (Cierra DA-3.)
+
+La duda era si R5 debía exigir worktrees o degradar a ejecución serial cuando no estén
+disponibles. **La respuesta ya estaba en el código:** el reducer de R5 implementa
+`FALLBACK_PENDING` → `SERIAL` con `begin-fallback`, y la restricción C2 define exactamente
+cuándo se permite — solo cuando todos los tracks están `REMOVED` o nunca pasaron de
+`DECLARED`.
+
+Lo importante es lo que ese diseño **no** hace: `BLOCKED` significa *"no pude probar de
+quién es este recurso"* y **jamás** habilita serial. Mientras haya un track bloqueado, la
+cohorte espera evidencia de una persona. Degradar a serial con worktrees ajenos vivos sería
+correr encima de algo que no probamos que sea nuestro.
+
+**Implica:** exigir worktrees habría hecho a R5 inutilizable donde no se pueden crear, y no
+hay ninguna garantía que se gane con esa exigencia — el fallback ya es seguro por
+construcción. Se cierra a favor de lo ya construido.
+
+---
+
+## D-013
+
+**El set de referencia de cada sensor-pack vive en su `pack.json`, en `awm-baseline-registry`.** (Cierra DA-4.)
+
+R2 necesita saber qué sensores *debería* tener un stack para reportar cuáles faltan. La
+pregunta era dónde vive esa lista y quién la mantiene.
+
+`sensor-packs/<pack>/pack.json` ya existe para `generic`, `js-ts`, `python` y `shell`. El
+set de referencia es una propiedad **del pack**, no del CLI: se versiona con él, se
+distribuye con él y se actualiza por el mismo flujo — editar el registry → tag → `awm update`.
+
+**Por qué no en el CLI:** metería conocimiento de stacks concretos dentro del binario, que
+es exactamente lo que se sacó al eliminar `FALLBACK_DEFAULTS`. El CLI compara; el registry
+declara.
+
+**Quién lo mantiene:** quien mantiene el pack. Un pack sin set de referencia no es un error
+— es un pack que todavía no declara cobertura esperada, y R2 lo reporta como tal en vez de
+inventar un default.
+
+---
+
+## D-014
+
+**La detección de cobertura reporta lo que falta. No lo instala ni lo configura.** (Cierra DA-6.)
+
+Es la misma frontera que el brief ya declara fuera de alcance (*"auto-instalar/configurar
+sensores"*) y la misma disciplina de D-007: cuando la acción correctiva toca el estado del
+usuario, AWM la **nombra** y la ejecuta una persona.
+
+**Implica:** R2 emite qué sensor falta para qué clase de defecto, y **con qué comando
+agregarlo**. No lo corre. Un remedio nombrado y ejecutable es el estándar que fijó D-010; un
+remedio auto-aplicado sobre la configuración de calidad de un proyecto ajeno no lo es.
+
+---
+
+## D-015
+
+**Umbral empírico ≥2 por defecto, y es una señal, no una compuerta.** (Cierra DA-5.)
+
+R3 detecta clusters de defectos convergentes en el ledger que ningún sensor cubre. El
+umbral por defecto es **2**, por consistencia con lo que ya existe: `awm ledger recurring
+--min 2` es lo que `harness-retro` usa hoy para decidir si vale estructuralizar.
+
+**Lo que NO significa:** que 1 ocurrencia se ignore. `harness-retro` ya documenta que la
+recurrencia es *"una señal a sopesar, no un umbral que pasar"* — un hallazgo único de alta
+severidad puede estructuralizarse igual. R3 hereda ese criterio: ordena y destaca, no filtra
+en silencio.
+
+Un umbral que descarta sin decirlo convierte a la herramienta en un lugar donde la evidencia
+se pierde, que es lo contrario de para lo que existe el ledger.

--- a/docs/plans/2026-08-09-verification-backlog.md
+++ b/docs/plans/2026-08-09-verification-backlog.md
@@ -189,3 +189,64 @@ Las reglas están en [`docs/testing/README.md`](../testing/README.md) y no son f
 Y las dos que invalidan una corrida entera: no arreglar el entorno para que un check pase y después declararlo PASS, y no editar a mano nada bajo `$AWM_HOME`.
 
 Un nivel de la matriz sube **citando la evidencia**, no la intención. Si algo se verifica y no funciona, va a ❌ — perder evidencia negativa es peor que no haberla tenido.
+
+---
+
+## D · Iniciativa de optimización del ciclo SDD (issue #20) — plan de cierre
+
+Los dos dolores medidos en el diagnóstico original pesan hoy, y atacan cosas distintas:
+
+| Dolor | Qué lo ataca | Estado |
+|---|---|---|
+| **Tiempo de ciclo** (~115 min post-plan, tracks independientes en serie) | **R5** — paralelismo por worktree | construido 95/117, sin verificar |
+| **Costo en tokens** (1.57M, revisión:implementación 4.2:1) | **R2/R3** — detectar clases de defecto sin sensor, para que las agarre un linter y no un revisor | sin empezar |
+
+**El orden es R5 → R2 → R3, y no por antigüedad.**
+
+R5 primero porque está a tres tareas del final y **cada día que espera cuesta más**: seis
+días parado produjeron 136 commits de divergencia. No es apego a lo hecho — es que 4223
+líneas ya revisadas son el valor más barato disponible, y su costo de integración crece solo.
+
+R2 antes que R3 porque R3 lee del mismo vocabulario de cobertura que R2 define; construir R3
+primero significaría inventarlo dos veces.
+
+### D1 · Cerrar R5 — Tasks 15, 16, 17
+
+- [ ] **Task 15 — E2E local de aceptación (CA-4.1–4.3).** Workload determinista con modo
+      serial y paralelo; CA-4.1 sobre *tree hash*, no historial (dos órdenes de merge
+      distintos producen el mismo árbol: comparar historial daría un falso rojo); CA-4.2 con
+      seam de `worktreeAdder`; CA-4.3 con un solo lockfile, que es el caso que C5 declara
+      invalidante. Se corre acá.
+- [ ] **Task 16 — E2E contra binarios reales.** El validador **se escribe antes** de
+      recolectar evidencia, para que la matriz salga solo de lo observado. Claude Code se
+      corre acá; Codex va al VPC. Precondición ya cumplida: los dos proveedores quedaron
+      verificados el 2026-08-09.
+- [ ] **Task 17 — Regresión, documentación operativa y handoff.** Incluye el flujo diario y
+      el fallback (hoy `awm track` no tiene una línea de doc), auto-verificación del CLI
+      compilado, y `post-implementation-qa` + `harness-retro`.
+
+**Hasta que 15–17 estén, el PR #63 no se mergea.** Publicar `awm track` sin documentación
+operativa ni criterios de aceptación ejecutados sería aplicarle a 4223 líneas un estándar
+más bajo que el que este repo le aplica a un cambio de tres.
+
+**Riesgo activo mientras espera:** la divergencia. #63 se rebasa cada vez que `main` se
+mueve, en vez de dejarlo envejecer otros seis días.
+
+### D2 · R2 — cobertura de sensores declarada vs configurada
+
+Desbloqueado por [D-013](../decisions.md#d-013) (el set de referencia vive en el `pack.json`
+del registry) y [D-014](../decisions.md#d-014) (reporta, nunca instala).
+
+Compara lo que el pack declara esperado contra lo que el proyecto tiene configurado, y
+nombra lo que falta **con el comando para agregarlo**. Un pack sin set de referencia se
+reporta como tal; no se inventa un default — misma razón por la que se eliminaron los
+`FALLBACK_DEFAULTS`.
+
+### D3 · R3 — detección empírica desde el ledger
+
+Desbloqueado por [D-015](../decisions.md#d-015) (umbral ≥2, señal y no compuerta).
+Depende de R2: usa su vocabulario de cobertura para responder "este cluster converge y
+**ningún sensor lo cubre**".
+
+Ordena y destaca; no filtra en silencio. Un umbral que descarta sin decirlo convierte al
+ledger en el lugar donde la evidencia se pierde.


### PR DESCRIPTION
Las cuatro decisiones abiertas de #20 bloqueaban R2, R3 y el merge de R5. Se cierran **con fundamento en el código y en la doctrina ya escrita**, no con opinión.

## Las cuatro

| # | Cierra | Decisión | De dónde sale |
|---|---|---|---|
| **D-012** | DA-3 | Worktree con **fallback serial**, no requisito duro | Ya estaba construido: el reducer implementa `FALLBACK_PENDING → SERIAL` |
| **D-013** | DA-4 | El set de referencia vive en `sensor-packs/<pack>/pack.json` del registry | `pack.json` ya existe para los 4 packs |
| **D-014** | DA-6 | R2 **reporta**, nunca instala ni configura | El brief ya lo declara fuera de alcance; misma disciplina que D-007 |
| **D-015** | DA-5 | Umbral **≥2**, y es señal, no compuerta | Consistencia con `awm ledger recurring --min 2` |

Dos detalles que valen más que el título:

- **D-012:** lo importante no es que haya fallback, sino lo que **no** hace — `BLOCKED` significa *"no pude probar de quién es este recurso"* y **jamás** habilita serial. Degradar con worktrees ajenos vivos sería correr encima de algo no probado.
- **D-013:** meter el set de referencia en el CLI habría repuesto el conocimiento de stacks concretos que se sacó al eliminar `FALLBACK_DEFAULTS`. **El CLI compara; el registry declara.**

## El plan de cierre, con su orden y su razón

Los dos dolores medidos atacan cosas distintas, y los dos pesan:

| Dolor | Qué lo ataca | Estado |
|---|---|---|
| Tiempo de ciclo (~115 min, tracks en serie) | **R5** — paralelismo | 95/117, sin verificar |
| Costo en tokens (1.57M, revisión:impl 4.2:1) | **R2/R3** — sensores que eviten escalar a revisores | sin empezar |

**Orden: R5 → R2 → R3.** R5 primero no por antigüedad sino porque está a tres tareas del final y **su costo de integración crece solo** — seis días parado produjeron 136 commits de divergencia. R2 antes que R3 porque R3 lee el vocabulario de cobertura que R2 define.

## Y algo que queda explícito

**#63 no se mergea hasta que las Tasks 15–17 estén.** Publicar `awm track` sin documentación operativa ni criterios de aceptación ejecutados sería aplicarle a 4223 líneas un estándar más bajo que el que este repo le aplica a un cambio de tres líneas.

Mientras espera, #63 se rebasa cada vez que `main` se mueve — en vez de dejarlo envejecer otros seis días.

## Sin cambios de código

Guards estructurales verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_