### PR TITLE
feat(sensors): gate de seguridad funcionando, y dejar de esconder los configs de sensores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,12 @@ coverage
 .agents
 skills-lock.json
 tmp/*
-*.awm.*
+# NO se ignoran los configs de sensores (`.semgrep.awm.yml`, `eslint.config.awm.mjs`,
+# `.dep-cruiser.awm.js`): son el lugar donde `harness-retro` crece las reglas ESPECÍFICAS
+# del proyecto, así que el equipo tiene que recibirlas por el repo. Un `*.awm.*` global los
+# excluía a todos — y solo `eslint.config.awm.mjs` sobrevivía, por haberse commiteado antes
+# de que la regla existiera. Resultado: el sensor `security` declarado en sensors.json
+# apuntaba a un archivo que git nunca dejaba entrar, y quedaba `inconclusive` para siempre.
 .claude/skills/
 .claude/agents/
 *.eslintcache

--- a/cli/.semgrep.awm.yml
+++ b/cli/.semgrep.awm.yml
@@ -1,0 +1,38 @@
+# AWM Semgrep rules — security patterns for JavaScript/TypeScript
+# Usage: semgrep --config .semgrep.awm.yml --json .
+
+rules:
+  - id: awm-no-eval
+    patterns:
+      - pattern: eval(...)
+    message: >
+      SENSOR[security] Avoid eval() — it executes arbitrary code and is a security risk.
+      Fix: use JSON.parse() for JSON, or refactor to avoid dynamic code execution.
+    languages: [javascript, typescript]
+    severity: ERROR
+
+  - id: awm-no-hardcoded-secrets
+    patterns:
+      - pattern: |
+          const $VAR = "..."
+      - metavariable-regex:
+          metavariable: $VAR
+          regex: (password|secret|api_key|apikey|token|passwd)
+    message: >
+      SENSOR[security] Potential hardcoded secret in variable '$VAR'.
+      Fix: use environment variables or a secrets manager instead.
+    languages: [javascript, typescript]
+    severity: WARNING
+
+  - id: awm-no-sql-concat
+    patterns:
+      - pattern: |
+          $QUERY + $VAR
+      - metavariable-regex:
+          metavariable: $QUERY
+          regex: (SELECT|INSERT|UPDATE|DELETE|DROP)
+    message: >
+      SENSOR[security] Possible SQL injection via string concatenation.
+      Fix: use parameterized queries or a query builder.
+    languages: [javascript, typescript]
+    severity: ERROR

--- a/cli/tests/structural/sensor-configs-are-present.test.ts
+++ b/cli/tests/structural/sensor-configs-are-present.test.ts
@@ -1,0 +1,48 @@
+// Guard estructural — un sensor declarado cuyo archivo de configuración no existe no es un
+// sensor: es un `fail` o un `inconclusive` permanente que entrena a ignorar el rojo.
+//
+// Pasó dos veces en este repo, y las dos veces sobrevivió meses:
+//   - `depcheck` apuntaba a `.dep-cruiser.awm.js`, que NUNCA existió en ninguna rama →
+//     `awm sensors run` daba `fail` permanente.
+//   - `security` apuntaba a `.semgrep.awm.yml`, que existía en el sensor-pack pero el
+//     `.gitignore` del repo (`*.awm.*`) impedía versionarlo → `inconclusive` permanente.
+//
+// La regla no enumera esos dos: deriva los configs del PROPIO `sensors.json`, así que un
+// sensor agregado mañana la hereda sin que nadie se acuerde de este comentario.
+import fs from 'fs';
+import path from 'path';
+
+const CLI_ROOT = path.resolve(__dirname, '..', '..');
+const SENSORS = path.join(CLI_ROOT, '.awm', 'sensors.json');
+
+/** Extrae los archivos de config que un comando de sensor referencia. Se buscan por la
+ *  convención `*.awm.*` que usan todos los packs, no por una lista de nombres — un pack
+ *  nuevo con otro linter queda cubierto igual. */
+function configFilesIn(cmd: string): string[] {
+    return cmd.split(/\s+/).filter((token) => /\.awm\./.test(token) && !token.startsWith('-'));
+}
+
+describe('configs de sensores: declarados <=> presentes', () => {
+    const manifest = fs.existsSync(SENSORS)
+        ? (JSON.parse(fs.readFileSync(SENSORS, 'utf8')) as { sensors?: Record<string, { cmd?: string; changedCmd?: string }> })
+        : null;
+
+    it('el manifiesto de sensores existe y declara sensores', () => {
+        expect(manifest?.sensors).toBeDefined();
+        expect(Object.keys(manifest!.sensors!).length).toBeGreaterThan(0);
+    });
+
+    it('cada archivo de config que un sensor referencia existe en el repo', () => {
+        const missing: string[] = [];
+        for (const [name, sensor] of Object.entries(manifest?.sensors ?? {})) {
+            for (const cmd of [sensor.cmd, sensor.changedCmd].filter((c): c is string => typeof c === 'string')) {
+                for (const file of configFilesIn(cmd)) {
+                    if (!fs.existsSync(path.join(CLI_ROOT, file))) missing.push(`${name} -> ${file}`);
+                }
+            }
+        }
+        // El mensaje nombra sensor y archivo: un rojo que no dice cuál de los dos falta
+        // termina resuelto borrando el sensor, que es la salida equivocada.
+        expect(missing.join('\n') || 'todos presentes').toBe('todos presentes');
+    });
+});


### PR DESCRIPTION
`awm sensors run` daba `not_certified` de forma permanente en el repo que distribuye el harness. El sensor `security` estaba declarado en `cli/.awm/sensors.json` desde siempre y apuntaba a un `.semgrep.awm.yml` que no estaba.

## La causa no era un olvido de copia

`.gitignore` tenía `*.awm.*` — un glob que **impide versionar los configs de sensores**. Su hermano `eslint.config.awm.mjs` sobrevivía únicamente por haberse commiteado **antes** de que la regla existiera: git no aplica ignores a archivos ya rastreados. Dos configs hermanos, uno visible y el otro invisible, por accidente de cronología.

Eso contradice la doctrina del propio repo ([`CLAUDE.md`](CLAUDE.md)): esos archivos son donde `harness-retro` crece las reglas **específicas del proyecto**, así que el equipo tiene que recibirlas por el repo. Un config de sensor gitignoreado es una regla que nadie más ve.

Verificado que AWM **no** propaga este patrón: `ensureJournalGitignored` solo escribe `.awm/`, y `ensureSkillsGitignored` deliberadamente no ignora contenido renderizado. El glob era de este repo.

## Verificado en dos direcciones, no solo "el sensor pasa"

```
typecheck: pass · lint: pass · security: pass · test: pass · mutation: skipped
overall: pass
```

Y las reglas **disparan** — con violaciones fabricadas, `awm-no-eval` y `awm-no-hardcoded-secrets` las detectan. Un sensor verde que no detecta nada es peor que no tenerlo: genera confianza falsa.

## Hallazgo: una de las tres reglas del pack nunca dispara

`awm-no-sql-concat` da **0 hallazgos** sobre casos que debería detectar. Aislado:

| Prueba | Resultado |
|---|---|
| Patrón base `"..." + $V` | matchea **4/4** |
| Regla completa (con `metavariable-regex`) | **0/4** |

El `metavariable-regex` no contempla que `$QUERY` liga el literal **con sus comillas**. Una formulación quote-aware da 4/4.

**Esto se shippea así a todo proyecto con pack `js-ts`.** El fix va en el registry —donde viven las reglas genéricas por doctrina— para que llegue por `awm update`. La copia local se deja **fiel al pack** a propósito: divergir acá haría que el fix del registry no se notara.

## El guard, y por qué no enumera los dos casos

`tests/structural/sensor-configs-are-present.test.ts` deriva los configs del **propio `sensors.json`**, no de una lista. Un sensor agregado mañana lo hereda sin que nadie recuerde este PR.

Habría atrapado **las dos** ocurrencias: esta, y el `depcheck` que apuntaba a un `.dep-cruiser.awm.js` que nunca existió en ninguna rama (removido en #63). Un sensor cuyo config falta no es un sensor: es un rojo permanente que entrena a ignorar el rojo.

Verificado por revert: esconder el config lo pone en rojo nombrando **sensor y archivo** — un mensaje que solo dijera "falta algo" se resuelve borrando el sensor, que es la salida equivocada.

## Verificación

**205 suites / 2105 tests** en verde · `awm sensors run` → `overall: pass`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCB18W1k1j9V3cFZW8YZYc)_