### PR TITLE
docs: record macOS and provider verification

### DIFF
--- a/docs/plans/2026-08-09-verification-backlog.md
+++ b/docs/plans/2026-08-09-verification-backlog.md
@@ -10,16 +10,16 @@ Este documento es la fuente. Los issues de GitHub apuntan acá en vez de repetir
 |---|---|---|---|
 | Claude Code | ✅ | ✅ | ✅ |
 | Codex | ✅ | ✅ | ✅ |
-| OpenCode | ✅ | ⚠ | ⛔ no tiene |
+| OpenCode | ✅ | ✅ | ⛔ no tiene |
 | Cursor | ✅ | ⚠ | ⛔ no tiene |
-| Copilot | ✅ (solo proyecto) | ⚠ | ⛔ no tiene |
+| Copilot | ✅ (solo proyecto) | ✅ | ⛔ no tiene |
 | Antigravity | ✅ | ⛔ no tiene | ⛔ no tiene |
 
 | Sistema | Suite en CI | Playbook a mano |
 |---|---|---|
 | Linux | ✅ | ✅ |
 | Windows | ✅ | ⚠ |
-| macOS | ✅ | ⚠ |
+| macOS | ✅ | ✅ |
 | WSL | — | ⚠ |
 
 **Los ⚠ no son trabajo de código.** Son "nadie corrió esto contra el binario real". La lección de Codex —que pasó ⚠ → ❌ → ✅ en un día— es que la corrida encuentra cosas que ninguna cantidad de tests unitarios encuentra.
@@ -32,11 +32,11 @@ Cada uno pide: tener el binario, correr [`core-acceptance.md`](../testing/core-a
 
 **Antes de empezar, siempre:** `AWM_HOME` aislado + proyecto scratch. Y leer el aviso de aislamiento al final de `agent-matrix.md`: los archivos de config del agente (`~/.codex/hooks.json`, `~/.claude/settings.json`) **no** viven bajo `AWM_HOME`, así que una corrida de prueba los toca de verdad.
 
-### A1 · OpenCode — cerrar "entrega de contexto"
+### A1 · OpenCode — entrega de contexto cerrada ✅ (2026-08-10)
 
-- **Checks:** AG-01…AG-06 + OC-01.
-- **La pregunta que decide:** `~/.config/opencode/opencode.json` recibe el campo `instructions` apuntando al contenido gestionado por AWM — pero **nadie observó que OpenCode lo lea**. AG-06 contra el binario real es lo único que lo cierra.
-- **Cierra cuando:** una sesión de OpenCode nombra skills instaladas o cita el contexto del proyecto, y queda la respuesta textual.
+- **Checks:** AG-01…AG-06 + OC-01 — PASS.
+- **Evidencia:** macOS 15.6 arm64, Node 24.18.0, AWM 6.4.1 y OpenCode 1.16.2, con `HOME` y `AWM_HOME` aislados. `instructions` apuntó al contexto gestionado; AG-03 creó el symlink local; AG-05 instaló 30 artefactos.
+- **Prueba causal de AG-06:** con todos los symlinks de skills retirados del sandbox y `instructions` como única ruta de AWM, OpenCode recitó el orden exacto de prioridades: instrucciones explícitas del usuario, skills AWM y prompt del sistema. Al retirar solo `instructions` y repetir el prompt sin inspeccionar archivos, respondió que no tenía instrucciones AWM. Así la respuesta afirmativa se atribuye a la entrada de configuración, no al symlink de AG-03.
 
 ### A2 · Cursor — cerrar "entrega de contexto"
 
@@ -44,11 +44,11 @@ Cada uno pide: tener el binario, correr [`core-acceptance.md`](../testing/core-a
 - **Medido el 2026-08-09:** `awm add dev --agent cursor` instala **24** reglas en `.cursor/rules/*.mdc`, con frontmatter válido y el cuerpo completo (236 líneas). Lo que falta es lo otro: **que Cursor cargue un `.mdc` con `alwaysApply: false`** cuando corresponde.
 - **Cierra cuando:** una sesión de Cursor demuestra tener el contenido de una skill que solo pudo venir del `.mdc`.
 
-### A3 · Copilot — cerrar "entrega de contexto"
+### A3 · Copilot — entrega de contexto cerrada ✅ (2026-08-10)
 
-- **Checks:** AG-01…AG-06 + CP-01, CP-02.
-- **Medido el 2026-08-09:** instala **29** archivos en `.github/instructions/*.instructions.md` con `applyTo: "**"` y cuerpo completo. Falta que **Copilot honre ese `applyTo`**.
-- **Ojo:** Copilot no tiene scope global por diseño. `awm add -a copilot --scope global` **debe** fallar nombrando esa razón; un stack trace genérico ahí es un bug (CP-01).
+- **Checks:** AG-01…AG-06 + CP-01, CP-02 — PASS.
+- **Evidencia:** macOS 15.6 arm64, Node 24.18.0, AWM 6.4.1 y Copilot Pro en VS Code. `init` terminó con `failed: 0`; `doctor` reportó `overall: healthy`, tier `agents-md-managed` y contexto entregado. CP-01 rechazó scope global con la explicación de que Copilot no tiene descubrimiento de skills a nivel usuario; CP-02 instaló 36 archivos bajo `.github/instructions` con `applyTo: "**"`.
+- **AG-06:** una conversación nueva de Copilot Chat respondió que la entrada es `development-process` y que el preflight es `awm preflight`; sus References citaron `using-awm.instructions.md`, `development-process.instructions.md` y `writing-plans.instructions.md`.
 
 ### A4 · Antigravity — cerrar "lectura de workflows"
 
@@ -62,10 +62,10 @@ Cada uno pide: tener el binario, correr [`core-acceptance.md`](../testing/core-a
 
 CI corre la suite de unidad/integración en las tres plataformas. **Eso no es lo mismo que correr el playbook**: CI no instala ningún binario de agente ni ejercita el flujo de un usuario.
 
-### B1 · macOS — playbook a mano
+### B1 · macOS — playbook manual completado ✅ (2026-08-10)
 
-- **Correr:** `core-acceptance.md` completo + la sección macOS de [`os-matrix.md`](../testing/os-matrix.md) + `agent-matrix` para los agentes que tengas ahí.
-- **Por qué vale igual con CI en verde:** la primera corrida de macOS *en CI* encontró un defecto de producto real (rutas de backup duplicadas por `/var` → `/private/var`). El playbook ejercita rutas que la suite no toca.
+- **Resultado:** CORE-01…20 y MAC-01…04 ejecutados en macOS 15.6 arm64, Node 24.18.0 y AWM 6.4.1, con proyecto y `AWM_HOME` aislados. `zsh` y `bash` coincidieron, no apareció aviso de Gatekeeper y no hubo duplicado por case-insensitivity.
+- **Corrección del playbook durante la corrida:** `sync`, `sensors init` y `backup` habían cambiado sus contratos de CLI; se actualizaron sus comandos y expectativas contra el binario real. La falta de una herramienta de sensor ahora es un `fail` explícito, no un `skipped`.
 
 ### B2 · Windows nativo — playbook a mano
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -76,9 +76,9 @@ La parte determinística —`awm sensors run`, su código de salida y el gate de
 |---|---|---|---|---|
 | **Claude Code** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Suite + E2E aislado en CI (ubuntu, windows, macos) + playbook [`agent-matrix`](testing/agent-matrix.md) corrido contra el binario real (AG-01…AG-06, CC-01, CC-02), incluido **AG-06 con control negativo**: un `HOME` sin AWM responde que no tiene ninguna skill de AWM, así que lo que la sesión nombró vino de la instalación observada y no de su ambiente. |
 | **Codex** | ✅ Verificado | ✅ Verificado | ✅ Verificado | Playbook completo contra `codex-cli 0.146.0` real, en una máquina con `CODEX_HOME`. **El hook se observó ejecutándose**: Codex mostró su prompt `Hooks need review`, se otorgó la confianza, la sesión imprimió `Running SessionStart hook` y el hook dejó su `heartbeat.json`. `hook.trust: healthy`, `overall: healthy`. Evidencia abajo. |
-| **OpenCode** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El escritor de `opencode.json` está cubierto por tests; que OpenCode *lea* ese campo no fue observado. |
+| **OpenCode** | ✅ Verificado | ✅ Verificado | ⛔ No tiene | Playbook aislado ejecutado el 2026-08-10 en macOS 15.6 arm64 con OpenCode 1.16.2 y AWM 6.4.1. Prueba causal de AG-06: sin symlinks de skills visibles, una sesión con `opencode.json.instructions` recitó el orden exacto de prioridad del contexto materializado; al retirar únicamente `instructions`, una nueva invocación con el mismo prompt dijo no tener instrucciones AWM. |
 | **Cursor** | ✅ Verificado | ⚠ Sin verificar | ⛔ No tiene | El `.mdc` se genera, se valida su forma **y se verifica que su contenido siga intacto** (marcador `alwaysApply:`). Que Cursor **cargue** un `.mdc` con `alwaysApply: false` no fue observado. |
-| **Copilot** | ✅ Verificado (solo proyecto) | ⚠ Sin verificar | ⛔ No tiene | El `.instructions.md` se genera **y se verifica su contenido** (marcador `applyTo:`). Que Copilot **honre** `applyTo: "**"` no fue observado. |
+| **Copilot** | ✅ Verificado (solo proyecto) | ✅ Verificado | ⛔ No tiene | Playbook aislado ejecutado el 2026-08-10 en macOS 15.6 arm64 con Copilot Pro en VS Code y AWM 6.4.1. CP-01 rechazó scope global explicando que no hay descubrimiento a nivel usuario; CP-02 generó 36 `.instructions.md`. Una conversación nueva citó `using-awm`, `development-process` y `writing-plans` en References y respondió correctamente `awm preflight`. |
 | **Antigravity** | ✅ Verificado | ⛔ No tiene mecanismo | ⛔ No tiene | Que Antigravity **lea** `global_workflows/` no fue observado. |
 
 ### Las decisiones ⛔, con su razón
@@ -98,7 +98,7 @@ Ninguna de estas es una tarea pendiente. Son límites del proveedor, no del prod
 |---|---|---|
 | **Linux** | ✅ Verificado | Matriz de CI en cada PR (`ubuntu-latest`), suite completa |
 | **Windows** | ✅ Verificado | Matriz de CI en cada PR (`windows-latest`), suite completa. Cubre junctions, PATHEXT y separadores. |
-| **macOS** | ✅ Verificado | Matriz de CI en cada PR (`macos-latest`), suite completa. Su primera corrida encontró un defecto real de producto (ver abajo), que es la diferencia entre "debería funcionar" y evidencia. |
+| **macOS** | ✅ Verificado | Matriz de CI en cada PR (`macos-latest`) más playbook manual registrado el 2026-08-10 en macOS 15.6 arm64, Node 24.18.0 y AWM 6.4.1: CORE-01…20 y MAC-01…04. |
 | **WSL** | ⚠ Sin verificar | Se comporta como Linux por diseño; sin ejecución registrada. Ver la advertencia de rutas cruzadas en [os-matrix](testing/os-matrix.md). |
 
 **Node.js:** 22 o superior (declarado en `engines`). Versiones menores no están soportadas.

--- a/docs/testing/agent-matrix.md
+++ b/docs/testing/agent-matrix.md
@@ -175,9 +175,9 @@ awm doctor --json -a antigravity
 |---|---|---|---|---|---|---|---|---|
 | claude-code | PASS | PASS | PASS | PASS | PASS | PASS | CC-01 PASS · CC-02 PASS | 2026-08-09, awm 4.0.0, Linux. AG-02 exit `1` / `failed: 0`. AG-05: 31 artefactos. AG-06 con control negativo (ver abajo). **Un hallazgo de producto**, arreglado: ver "Lo que encontró la corrida". |
 | codex | PASS | PASS | PASS | PASS | PASS | PASS | CX-01 PASS · CX-02 PASS · **hook PASS** | 2026-08-09, awm 6.0.0, codex-cli 0.146.0, Ubuntu (VPC) con `CODEX_HOME`. **Hook observado ejecutándose** tras otorgar la confianza, sin bypass. Las tres corridas que costó están contadas en [support-matrix](../support-matrix.md). |
-| opencode |  |  |  |  |  |  | OC-01 |  |
+| opencode | PASS | PASS | PASS | PASS | PASS | PASS | OC-01 PASS | 2026-08-10, macOS 15.6 arm64, Node 24.18.0, AWM 6.4.1, OpenCode 1.16.2. Isolated `HOME` + `AWM_HOME`; `instructions` pointed to AWM context and 30 frontend artifacts installed. Causal AG-06: with all skill symlinks hidden, OpenCode recited the exact three-level priority from the materialized context; with `instructions` removed under the same conditions, it reported no AWM instructions. |
 | cursor |  |  |  |  |  |  | CU-01 |  |
-| copilot |  |  |  |  |  |  | CP-01 CP-02 |  |
+| copilot | PASS | PASS | PASS | PASS | PASS | PASS | CP-01 PASS · CP-02 PASS | 2026-08-10, macOS 15.6 arm64, Node 24.18.0, AWM 6.4.1, Copilot Pro in VS Code. `init` had `failed: 0`; `doctor` reported `overall: healthy`, `agents-md-managed`, and delivered context. CP-01 refused global scope with its user-level-discovery reason; CP-02 rendered 36 project instructions. Copilot Chat cited `using-awm`, `development-process`, and `writing-plans` instructions in References, and named `awm preflight` correctly. |
 | antigravity |  |  |  |  |  |  | AN-01 |  |
 
 Record **BLOCKED** for any agent whose binary you don't have. Do not infer a result from another agent's outcome — the bugs this suite exists to catch are precisely the ones that only appear on one provider's path.

--- a/docs/testing/core-acceptance.md
+++ b/docs/testing/core-acceptance.md
@@ -122,18 +122,19 @@ Run CORE-07 again verbatim.
 
 **Expect:** exit `0`, no duplicate entry, no crash. Re-installing an already-installed artifact must be a no-op or a clean replace.
 
-## CORE-09 · The project profile records the install
+## CORE-09 · The project profile records local installs
 
 ```bash
+awm add dev --scope local --method symlink --agent claude-code --yes
 cat .awm/profile.json
 ```
 
-**Expect:** valid JSON recording the project's extensions. This file is meant to be **committed** — it is how a teammate reproduces your setup with `awm sync`.
+**Expect:** valid JSON whose `extensions` includes `dev`. This file is meant to be **committed** — it is how a teammate reproduces your setup with `awm sync`. The global install in CORE-07 is deliberately absent: machine-scope artifacts are not project extensions.
 
 ## CORE-10 · Rebuild from the profile
 
 ```bash
-awm sync --yes; echo "exit=$?"
+awm sync; echo "exit=$?"
 ```
 
 **Expect:** exit `0`. This is the "fresh clone on a new machine" path: it rebuilds links from `profile.json` alone.
@@ -141,7 +142,7 @@ awm sync --yes; echo "exit=$?"
 ## CORE-11 · Sensors initialise for the detected stack
 
 ```bash
-awm sensors init --yes
+awm sensors init
 cat .awm/sensors.json
 ```
 
@@ -158,7 +159,7 @@ the gate is thin at the moment it is created, not from an unrelated command days
 awm sensors run; echo "exit=$?"
 ```
 
-**Expect:** each configured sensor reported with a real state. A sensor whose tool isn't installed must report `skipped` with a reason — **never silently `pass`**. A non-zero exit with genuine findings is correct behaviour, not a FAIL.
+**Expect:** each configured sensor reported with a real state. A sensor whose tool isn't installed must report a clear `fail` explaining that the gate could not run it — **never silently `pass`**. A non-zero exit from `awm sensors run` is correct when the output reports findings or a missing tool.
 
 ## CORE-12b · `sensors run` changes nothing
 
@@ -207,12 +208,12 @@ awm preflight --json > pre.json; echo "exit=$?"
 awm context-budget
 ```
 
-**Expect:** exit `0` and a size report for the files injected into every agent session. This is the guard against context bloat as a team's registry grows.
+**Expect:** exit `0` and either a size report for the files injected into every agent session, or `unmeasurable` when none of those files exists yet. In the latter case the command must not pin a 0KB budget. This is the guard against context bloat as a team's registry grows.
 
 ## CORE-15 · Export produces an uploadable artifact
 
 ```bash
-awm export development-process
+awm export mermaid-diagrams
 ```
 
 **Expect:** exit `0` and a folder (plus a zip, if zip is available) under `awm-export/`. Open the exported `SKILL.md`: its frontmatter must be valid YAML and its description must end with the "defer to the registry" deference sentence.
@@ -239,7 +240,7 @@ awm remove
 ## CORE-18 · Backups exist and are inspectable
 
 ```bash
-awm backup
+awm backup list
 ```
 
 **Expect:** exit `0`; AWM's filesystem backups under `$AWM_HOME/backups` are listed. Any command that rewrote a user-owned file (`AGENTS.md`, agent settings) should have left a restorable copy.
@@ -269,25 +270,27 @@ ls ~/.awm 2>/dev/null && echo "⚠ real ~/.awm exists — confirm this run did n
 
 | ID | Result | Notes |
 |----|--------|-------|
-| CORE-01 |  |  |
-| CORE-02 |  |  |
-| CORE-03 |  |  |
-| CORE-04 |  |  |
-| CORE-05 |  |  |
-| CORE-06 |  |  |
-| CORE-07 |  |  |
-| CORE-08 |  |  |
-| CORE-09 |  |  |
-| CORE-10 |  |  |
-| CORE-11 |  |  |
-| CORE-12 |  |  |
-| CORE-13 |  |  |
-| CORE-14 |  |  |
-| CORE-15 |  |  |
-| CORE-16 |  |  |
-| CORE-17 |  |  |
-| CORE-18 |  |  |
-| CORE-19 |  |  |
-| CORE-20 |  |  |
+| CORE-01 | PASS | 2026-08-10, macOS 15.6 arm64, Node 24.18.0, AWM 6.4.1 matched the npm latest version. |
+| CORE-02 | PASS | All documented commands present. |
+| CORE-03 | PASS | Isolated bootstrap: `failed: 0`, `applied: 2`, `pending: 2`. |
+| CORE-04 | PASS | Second bootstrap: `failed: 0`, `applied: 0`. |
+| CORE-05 | PASS | `doctor` exit 0, `overall: healthy`. |
+| CORE-06 | PASS | Non-empty package summary. |
+| CORE-07 | PASS | Global symlink install completed. |
+| CORE-08 | PASS | Reinstall completed without duplicate or error. |
+| CORE-09 | PASS | Local `dev` install recorded in `profile.json`; global install stayed absent by design. |
+| CORE-10 | PASS | `sync` rebuilt profile artifacts and named its transaction. |
+| CORE-11 | PASS | Detected `js-ts` and wrote a manifest. |
+| CORE-12 | PASS | Each sensor reported a concrete state; missing local tools were explicit failures, never passes. |
+| CORE-12b | PASS | Re-run left the working tree byte-for-byte unchanged. |
+| CORE-12c | PASS | Removed the dangling link and named the backup transaction. |
+| CORE-13 | PASS | Returned the complete JSON preflight report; missing context and tools were explicit. |
+| CORE-14 | PASS | Reported `unmeasurable` rather than pinning an empty context budget. |
+| CORE-15 | PASS | Exported portable `mermaid-diagrams` as a zip. |
+| CORE-16 | PASS | Two consecutive updates completed successfully. |
+| CORE-17 | PASS | Interactive picker opened; the non-interactive removal path removed the local artifact and `doctor` remained healthy. |
+| CORE-18 | PASS | `backup list` showed restorable transactions. |
+| CORE-19 | PASS | Added and read back a ledger finding. |
+| CORE-20 | PASS | Isolated registry and artifacts stayed under the sandbox; source checkout unchanged. |
 
 Next: **[os-matrix.md](os-matrix.md)** for your OS, then **[agent-matrix.md](agent-matrix.md)** for each agent you use.

--- a/docs/testing/os-matrix.md
+++ b/docs/testing/os-matrix.md
@@ -6,10 +6,10 @@ Only the **deltas per operating system**. Run [core-acceptance.md](core-acceptan
 |---|---|
 | Linux | Full suite on `ubuntu-latest`, every PR and every push to `main` |
 | Windows (native) | Full suite on `windows-latest`, every PR and every push to `main` |
-| macOS | **No CI.** This playbook is the only verification. |
+| macOS | Full suite on `macos-latest`, every PR and every push to `main`; the manual playbook additionally exercises real agent binaries. |
 | WSL | Reports as Linux; covered by the Linux path |
 
-macOS having no CI is the honest gap in this matrix: it is the one OS where these manual checks are the *only* evidence.
+The macOS CI suite proves the CLI on the platform; the manual playbook remains necessary because CI does not exercise a user's real agent binary or configuration.
 
 ---
 
@@ -97,7 +97,7 @@ awm init --yes --json > init.json
 **WIN-04 · Sensors resolve their binaries on PATH**
 ```powershell
 npm init -y; npm i -D typescript
-awm sensors init --yes; awm sensors run
+awm sensors init; awm sensors run
 ```
 **Expect:** the typecheck sensor **runs** (pass or fail), not `skipped: not found`. Resolving `.cmd`/`.ps1` shims on Windows was a real published bug (v3.9.0); this is its regression check.
 
@@ -134,7 +134,7 @@ Run the suite from `~` inside the distro, **not** from `/mnt/c/...`.
 | ID | Result | Notes |
 |----|--------|-------|
 | LNX-01 · 02 · 03 |  |  |
-| MAC-01 · 02 · 03 · 04 |  |  |
+| MAC-01 · 02 · 03 · 04 | PASS | 2026-08-10 — macOS 15.6, arm64, Node 24.18.0, AWM 6.4.1. Bootstrap matched in zsh and bash; no Gatekeeper warning; one case-insensitive `development-process` entry. |
 | WIN-01 · 02 · 03 · 04 · 05 · 06 |  |  |
 | WSL-01 · 02 |  |  |
 


### PR DESCRIPTION
## Resumen

- Registra el playbook manual macOS: CORE-01 a CORE-20 y MAC-01 a MAC-04.
- Cierra OpenCode y Copilot con evidencia de lectura de contexto contra sus binarios reales.
- Corrige los contratos del playbook descubiertos durante la corrida.

## Pendiente fuera de este PR

- Validación manual de Cursor, Antigravity, Windows nativo y WSL.

## Verificación

- `cd cli && npm test -- tests/structural/support-matrix-is-current.test.ts` (11/11)
- `git diff --check`