### PR TITLE
fix: 4 real Windows bugs found running issue #55's playbook

### DIFF
--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -17,6 +17,7 @@ export type RunAddBundleOptions = {
     name: string;
     agent?: string;
     scope?: string;
+    method?: string;
     cwd?: string;
 };
 
@@ -75,13 +76,31 @@ export function runAddBundleCore(
         return { code: 1, selectedAgents };
     }
 
+    // `--method` used to be accepted here and silently discarded — this branch
+    // hardcoded 'symlink' regardless of what was passed. Since D-001 made bundle
+    // names the ONLY thing `add [name]` resolves against, this is the sole live
+    // path for any real invocation; the interactive/`--all` path below still has
+    // its own (correct) method resolution, but a valid bundle name never reaches
+    // it. Found running the issue #55 Windows playbook's WIN-02: `--method copy`
+    // on native Windows still produced a Junction, because 'symlink' was the
+    // only value that ever actually reached the installer. The no-flag default
+    // stays 'symlink' (unchanged) — only the explicit-override case was broken.
+    let methodVal: 'symlink' | 'copy' = 'symlink';
+    if (options.method) {
+        if (options.method !== 'symlink' && options.method !== 'copy') {
+            console.error(pc.red(`Invalid method "${options.method}". Use: symlink or copy.`));
+            return { code: 1, selectedAgents };
+        }
+        methodVal = options.method;
+    }
+
     let result: AddBundleResult;
     try {
         result = d.addBundle({
             bundleName: matchedBundle.name,
             bundles,
             agents: selectedAgents,
-            method: 'symlink',
+            method: methodVal,
             projectRoot: projectRoot ?? cwd,
             scopeOverride,
         });

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -125,8 +125,16 @@ export async function runInit(opts: RunInitOptions = {}): Promise<number> {
     // Fires at most once per `awm init` run (native Windows only) — this is
     // the single emission point; `renderReport`/`renderInitOutcome` below do
     // NOT also embed it (that used to triple-fire the same text: once here,
-    // once in the "Initial state" render, once in "Final state").
-    noteWindowsCaveat((m) => console.log(pc.dim(`ℹ ${m}`)));
+    // once in the "Initial state" render, once in "Final state"). In `--json`
+    // mode it goes to stderr instead of stdout: stdout must stay pure JSON for
+    // `awm init --yes --json > init.json` (documented in core-acceptance.md
+    // CORE-03) — a stray banner ahead of the `{` broke that contract on every
+    // native-Windows `--json` run.
+    if (opts.json) {
+        noteWindowsCaveat((m) => process.stderr.write(pc.dim(`ℹ ${m}`) + '\n'));
+    } else {
+        noteWindowsCaveat((m) => console.log(pc.dim(`ℹ ${m}`)));
+    }
 
     const cwd = opts.cwd ?? process.cwd();
     const agent: AgentTarget = opts.agent === undefined ? 'claude-code' : requireAgentTarget(opts.agent);

--- a/cli/src/core/provider-version.ts
+++ b/cli/src/core/provider-version.ts
@@ -4,6 +4,7 @@ import {
 } from 'child_process';
 import { AgentTarget, providerFor } from '../providers';
 import { compareSemver } from './versioning';
+import { isWindowsNative } from './paths';
 
 type Exec = (
     command: string,
@@ -26,6 +27,17 @@ export function assertProviderSupported(
             encoding: 'utf8',
             stdio: ['ignore', 'pipe', 'pipe'],
             timeout: 5000,
+            // Windows can't CreateProcess a `.cmd` shim directly (npm installs
+            // `codex` as `codex.cmd`, not `codex.exe`) — execFileSync needs a
+            // shell to resolve and run it, or it throws ENOENT even though
+            // typing `codex --version` in the same shell works fine. Safe here
+            // (unlike sensors.json's `cmd`, core/paths.ts's resolveOnPath):
+            // `provider.versionCommand.command`/`args` are hardcoded first-party
+            // config (providers/index.ts), never attacker-controlled input.
+            // Found running the issue #55 Windows playbook: `awm init -a codex`
+            // reported "Codex is not installed" on a machine where it plainly
+            // was — `codex --version` worked fine typed directly.
+            shell: isWindowsNative(),
         }).toString();
     } catch (error) {
         const code = (error as NodeJS.ErrnoException).code;

--- a/cli/src/core/provider-version.ts
+++ b/cli/src/core/provider-version.ts
@@ -40,14 +40,26 @@ export function assertProviderSupported(
             shell: isWindowsNative(),
         }).toString();
     } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
+        const err = error as NodeJS.ErrnoException & { stderr?: Buffer | string };
         // `provider.label` y `versionCommand`, no "Codex" literal. Esta funcion es
         // generica sobre AgentTarget desde siempre, pero cada mensaje y el patron de
         // parseo nombraban al unico provider que hoy declara `versionCommand` — el
         // segundo en declararlo habria reportado "Codex no esta instalado" al no
         // encontrar SU binario, y habria fallado a parsear una salida perfectamente
         // valida contra el formato de otro programa.
-        if (code === 'ENOENT') {
+        //
+        // Two distinct "not found" shapes to catch now that Windows goes through
+        // a shell (see `shell: isWindowsNative()` above): without a shell, a
+        // missing binary is a spawn-level ENOENT; through cmd.exe, the shell
+        // itself spawns fine and the missing command instead surfaces as a
+        // non-zero exit with "'codex' is not recognized..." on stderr — no
+        // ENOENT anywhere. Missing this second shape was a real regression:
+        // windows-latest CI (no codex installed at all) started reporting
+        // "version probe failed" instead of "not installed", because the exit
+        // code alone doesn't say WHY the shell failed.
+        const shellCommandNotFound = isWindowsNative()
+            && /is not recognized as an internal or external command/i.test(String(err.stderr ?? ''));
+        if (err.code === 'ENOENT' || shellCommandNotFound) {
             throw new Error(
                 `${provider.label} is not installed or not available on PATH ` +
                 `(tried \`${provider.versionCommand.command}\`). Install it, then re-run.`,

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -131,7 +131,7 @@ program.command('add [name]')
       if (name) {
           const allBundles = discoverAllBundles();
           const prefs = getPreferences();
-          const outcome = runAddBundleCore({ name, agent: options.agent, scope: options.scope }, prefs, allBundles);
+          const outcome = runAddBundleCore({ name, agent: options.agent, scope: options.scope, method: options.method }, prefs, allBundles);
           if (outcome.code !== 0) process.exit(outcome.code);
           outro('Done.');
           return;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { intro, outro, spinner, select, multiselect, confirm, isCancel } from '@clack/prompts';
 import { Command } from 'commander';
-import { enableAgent, getPreferences, savePreferences } from './utils/config';
+import { enableAgent, getPreferences, savePreferences, resolveScopeOption } from './utils/config';
 import { buildGroupedOptions } from './utils/grouping';
 import { buildPackageView, packageSummaryLines, packageDetailLines, findPackage, packagePickerItems, artifactPickerItems, resolveLevel2Selection, ALL_SENTINEL, ArtifactView, artifactValue } from './utils/registry-view';
 import { isInteractive } from './ui/tty';
@@ -588,12 +588,17 @@ program.command('remove [name]')
       }
 
       let scopeVal: Scope;
-      if (options.scope) {
-          if (options.scope !== 'local' && options.scope !== 'global') {
-              console.error(pc.red(`Invalid scope "${options.scope}". Use: local or global.`));
+      if (options.scope || options.yes) {
+          // Same reasoning as the --agent default just above: `--yes` means ZERO
+          // prompts. Without the `options.yes` half of this condition, `awm remove
+          // <bundle> --yes` still opened the scope picker and hung any
+          // non-interactive caller — the flag promised no-interactive and wasn't.
+          const resolved = resolveScopeOption(options.scope, prefs.defaultScope);
+          if (!resolved.ok) {
+              console.error(pc.red(resolved.error));
               process.exit(1);
           }
-          scopeVal = options.scope;
+          scopeVal = resolved.scope;
       } else {
           const scopeChoice = await select({
               message: 'Scope?',

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -1,7 +1,7 @@
 // src/utils/config.ts
 import fs from 'fs';
 import path from 'path';
-import { AgentTarget, isAgentTarget } from '../providers';
+import { AgentTarget, isAgentTarget, Scope } from '../providers';
 import { awmHome } from '../core/paths';
 import { writeFileAtomic } from '../core/atomic-file';
 
@@ -185,4 +185,22 @@ export function enableAgent(prefs: AwmPreferences, agent: AgentTarget): AwmPrefe
     return prefs.enabledAgents.includes(agent)
         ? prefs
         : { ...prefs, enabledAgents: [...prefs.enabledAgents, agent] };
+}
+
+export type ScopeResolution = { ok: true; scope: Scope } | { ok: false; error: string };
+
+/**
+ * Resolve `--scope` the same way across every non-interactive command path: an
+ * explicit value wins (validated), otherwise fall back to the caller's default
+ * instead of prompting. Pulled out of `remove`'s Commander closure (D-006) after
+ * `--yes` was found to still open the scope picker with no `--scope` given —
+ * `--yes` means zero prompts, and this is the one call site that had drifted
+ * from that rule (the sibling --agent default sits right next to it in index.ts).
+ */
+export function resolveScopeOption(explicit: string | undefined, fallback: Scope): ScopeResolution {
+    if (explicit === undefined) return { ok: true, scope: fallback };
+    if (explicit !== 'local' && explicit !== 'global') {
+        return { ok: false, error: `Invalid scope "${explicit}". Use: local or global.` };
+    }
+    return { ok: true, scope: explicit };
 }

--- a/cli/tests/commands/add.test.ts
+++ b/cli/tests/commands/add.test.ts
@@ -109,3 +109,70 @@ it('awm add demo materializes a real Copilot .instructions.md file end-to-end', 
     fs.rmSync(content, { recursive: true, force: true });
     fs.rmSync(projectRoot, { recursive: true, force: true });
 });
+
+// Regression for WIN-02 (issue #55 Windows playbook): `--method copy` was
+// silently discarded by this exact function — `runAddBundleCore` hardcoded
+// 'symlink' regardless of what the CLI parsed, so a real Windows machine got
+// a Junction back no matter what `--method` asked for.
+describe('runAddBundleCore --method', () => {
+    const claudeCodePrefs: AwmPreferences = {
+        defaultAgent: 'claude-code', enabledAgents: ['claude-code'], installMethod: 'symlink', defaultScope: 'local',
+    };
+
+    it('honours an explicit --method copy: a real directory, not a symlink', () => {
+        const content = makeContentFixture();
+        const projectRoot = makeProjectRoot();
+        const bundles = discoverBundles(content);
+
+        const outcome = runAddBundleCore(
+            { name: 'demo', agent: 'claude-code', method: 'copy', cwd: projectRoot },
+            claudeCodePrefs,
+            bundles,
+        );
+
+        expect(outcome.code).toBe(0);
+        const skillPath = path.join(projectRoot, '.claude/skills/demo-skill');
+        expect(fs.lstatSync(skillPath).isSymbolicLink()).toBe(false);
+        expect(fs.readFileSync(path.join(skillPath, 'SKILL.md'), 'utf8')).toContain('Follow the demo skill body.');
+
+        fs.rmSync(content, { recursive: true, force: true });
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    it('still defaults to symlink when --method is omitted (unchanged behavior)', () => {
+        const content = makeContentFixture();
+        const projectRoot = makeProjectRoot();
+        const bundles = discoverBundles(content);
+
+        const outcome = runAddBundleCore(
+            { name: 'demo', agent: 'claude-code', cwd: projectRoot },
+            claudeCodePrefs,
+            bundles,
+        );
+
+        expect(outcome.code).toBe(0);
+        const skillPath = path.join(projectRoot, '.claude/skills/demo-skill');
+        expect(fs.lstatSync(skillPath).isSymbolicLink()).toBe(true);
+
+        fs.rmSync(content, { recursive: true, force: true });
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    it('rejects an invalid --method value without touching the filesystem', () => {
+        const content = makeContentFixture();
+        const projectRoot = makeProjectRoot();
+        const bundles = discoverBundles(content);
+
+        const outcome = runAddBundleCore(
+            { name: 'demo', agent: 'claude-code', method: 'bogus', cwd: projectRoot },
+            claudeCodePrefs,
+            bundles,
+        );
+
+        expect(outcome.code).toBe(1);
+        expect(fs.existsSync(path.join(projectRoot, '.claude/skills/demo-skill'))).toBe(false);
+
+        fs.rmSync(content, { recursive: true, force: true });
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+    });
+});

--- a/cli/tests/commands/init.test.ts
+++ b/cli/tests/commands/init.test.ts
@@ -109,6 +109,30 @@ describe('runInit', () => {
             const caveatCalls = logSpy.mock.calls.filter((c) => /awm watch/i.test(String(c[0])));
             expect(caveatCalls).toHaveLength(0);
         });
+
+        // Regression: `awm init --yes --json > init.json` on native Windows used to
+        // write the caveat to stdout via console.log AHEAD of the JSON payload,
+        // so the documented core-acceptance.md CORE-03 flow produced a file that
+        // wasn't valid JSON (banner text, then `{...}`). The caveat must still
+        // reach the operator — it now goes to stderr instead of vanishing.
+        it('does not pollute --json stdout with the caveat on native Windows', async () => {
+            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+            const errSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+            const { runInit } = require('../../src/commands/init');
+            await runInit({
+                cwd: tmpHome,
+                yes: true,
+                json: true,
+                actions: { syncCache: async () => {}, installHook: () => ({ status: 'installed' }) },
+            });
+            const written = writeSpy.mock.calls.map((c) => c[0]).join('');
+            expect(() => JSON.parse(written)).not.toThrow();
+            const caveatOnStdout = logSpy.mock.calls.filter((c) => /awm watch/i.test(String(c[0])));
+            expect(caveatOnStdout).toHaveLength(0);
+            const caveatOnStderr = errSpy.mock.calls.filter((c) => /awm watch/i.test(String(c[0])));
+            expect(caveatOnStderr).toHaveLength(1);
+            errSpy.mockRestore();
+        });
     });
 
     it('returns exit 0 on a bare HOME and never prompts with --yes (cache stubbed)', async () => {

--- a/cli/tests/core/provider-version.test.ts
+++ b/cli/tests/core/provider-version.test.ts
@@ -10,6 +10,34 @@ describe('assertProviderSupported', () => {
         expect(exec).toHaveBeenCalledWith('codex', ['--version'], expect.any(Object));
     });
 
+    // Regression: npm installs `codex` as `codex.cmd` on Windows, and
+    // execFileSync can't CreateProcess a `.cmd` shim without a shell — it threw
+    // ENOENT here even on a machine where `codex --version` worked fine typed
+    // directly. `provider.versionCommand` is hardcoded first-party config
+    // (providers/index.ts), never attacker-controlled, so `shell: true` here
+    // carries none of the injection risk core/paths.ts's resolveOnPath was
+    // built to avoid for sensors.json's user/registry-supplied `cmd`.
+    describe('on native Windows', () => {
+        const realPlatform = process.platform;
+        afterEach(() => {
+            Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+        });
+
+        it('runs the version probe through a shell so the .cmd shim resolves', () => {
+            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+            const exec = jest.fn(() => Buffer.from('codex-cli 0.145.0\n'));
+            assertProviderSupported('codex', exec);
+            expect(exec).toHaveBeenCalledWith('codex', ['--version'], expect.objectContaining({ shell: true }));
+        });
+
+        it('does not use a shell on non-Windows platforms', () => {
+            Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+            const exec = jest.fn(() => Buffer.from('codex-cli 0.145.0\n'));
+            assertProviderSupported('codex', exec);
+            expect(exec).toHaveBeenCalledWith('codex', ['--version'], expect.objectContaining({ shell: false }));
+        });
+    });
+
     it.each(['0.145.1', '0.146.0', '1.0.0'])(
         'accepts stable Codex version %s above the minimum',
         (version) => {

--- a/cli/tests/core/provider-version.test.ts
+++ b/cli/tests/core/provider-version.test.ts
@@ -36,6 +36,23 @@ describe('assertProviderSupported', () => {
             assertProviderSupported('codex', exec);
             expect(exec).toHaveBeenCalledWith('codex', ['--version'], expect.objectContaining({ shell: false }));
         });
+
+        // Regression from the fix above: shipping shell:true changed how a
+        // GENUINELY missing binary fails. Without a shell it's a spawn-level
+        // ENOENT; through cmd.exe the shell itself starts fine and the missing
+        // command surfaces as a non-zero exit with this exact stderr text — no
+        // ENOENT anywhere. windows-latest CI (no codex installed) caught this:
+        // it started reporting "version probe failed" instead of "not
+        // installed" the first time shell:true shipped without this branch.
+        it('still reports "not installed" when the shell itself says the command is unknown', () => {
+            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+            const shellNotFound = Object.assign(new Error('Command failed: codex --version'), {
+                status: 1,
+                stderr: Buffer.from("'codex' is not recognized as an internal or external command,\r\noperable program or batch file.\r\n"),
+            });
+            expect(() => assertProviderSupported('codex', () => { throw shellNotFound; }))
+                .toThrow('Codex is not installed or not available on PATH');
+        });
     });
 
     it.each(['0.145.1', '0.146.0', '1.0.0'])(

--- a/cli/tests/utils/config.test.ts
+++ b/cli/tests/utils/config.test.ts
@@ -1,6 +1,30 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { resolveScopeOption } from '../../src/utils/config';
+
+// Regression for the `awm remove <bundle> --yes` gap found running the issue #55
+// Windows playbook (CORE-17): `--yes` skipped the agent prompt but not the scope
+// one, so a supposedly non-interactive removal still hung waiting on a picker.
+// D-006's own stated rule is "`--yes` implica cero prompts" — this closes the one
+// call site that had drifted from it.
+describe('resolveScopeOption', () => {
+    it('falls back to the default when nothing explicit was passed (the --yes path)', () => {
+        expect(resolveScopeOption(undefined, 'local')).toEqual({ ok: true, scope: 'local' });
+        expect(resolveScopeOption(undefined, 'global')).toEqual({ ok: true, scope: 'global' });
+    });
+
+    it('an explicit valid value wins over the default', () => {
+        expect(resolveScopeOption('global', 'local')).toEqual({ ok: true, scope: 'global' });
+    });
+
+    it('rejects a value that is neither local nor global', () => {
+        expect(resolveScopeOption('bogus', 'local')).toEqual({
+            ok: false,
+            error: 'Invalid scope "bogus". Use: local or global.',
+        });
+    });
+});
 
 describe('Preferences Manager', () => {
     let tmpHome: string;


### PR DESCRIPTION
## Summary

Found and fixed 4 real bugs running `core-acceptance.md` + `os-matrix.md` (issue #55) against a disposable Windows Server 2022 EC2, plus live evidence that Claude Code and OpenCode correctly read AWM-installed content on native Windows (issue #54).

- **`awm init --json` leaked a banner onto stdout on native Windows** (CORE-03): `noteWindowsCaveat` fired via `console.log` before checking `opts.json`, so `awm init --yes --json > init.json` — the exact flow the doc documents — produced a file that wasn't valid JSON. Now goes to stderr in `--json` mode.
- **`awm remove <bundle> --yes` still opened an interactive scope picker** (CORE-17): `--yes` skipped the agent prompt but not the sibling scope prompt, so a script with no TTY would hang. D-006 says plainly "`--yes` implica cero prompts" — this closes the one call site that had drifted from it.
- **`awm add <bundle> --method copy` was silently ignored** (WIN-02): `runAddBundleCore` hardcoded `method: 'symlink'` regardless of the CLI flag. Invisible on POSIX (wrong symlink instead of copy looks similar), concrete on Windows: reported success but installed a Junction, not a real directory. Reproduced in two independently fresh `AWM_HOME`/project setups to rule out state bleed.
- **`awm init -a codex` reported Codex as not installed when it plainly was**: `execFileSync('codex', ...)` can't `CreateProcess` a `.cmd` shim on Windows without a shell. Same root cause as the sensors `.cmd`/`.ps1` bug from v3.9.0, but this call site never got the fix. `shell: true` is safe here since `provider.versionCommand` is hardcoded first-party config, not the untrusted `sensors.json` content `core/paths.ts`'s `resolveOnPath` was built to avoid a shell for.

Each fix has a real, unmocked-where-possible regression test (see individual commits).

## Test plan

- [x] `npx jest` — 206/207 suites pass (the 1 failure, `codex-provider-isolated.test.ts`, is pre-existing and environment-specific: this dev machine has a real `codex` on PATH, unrelated to these changes)
- [x] `npx tsc --noEmit` clean
- [x] Live-verified on a disposable Windows Server 2022 EC2 (RDP + SSH): OpenCode and Claude Code both installed via npm, logged in with real accounts, and Claude Code correctly quoted specific internal content (line numbers, HTML gate markers, rule IDs) from the `development-process` skill AWM installed — real evidence, not something it could have known otherwise.
- [ ] Live redeploy of the codex fix to the EC2 wasn't done this session (would need temporary S3 access for the instance) — covered by the unit test instead.