### PR TITLE
fix(sensors): restrict dotfile coverage evidence

### DIFF
--- a/cli/src/commands/sensors/coverage/contract.ts
+++ b/cli/src/commands/sensors/coverage/contract.ts
@@ -2,6 +2,7 @@ import type { SensorConfig } from '../types';
 
 export const COVERAGE_SCHEMA_VERSION = 1;
 export const MAX_COVERAGE_FILE_BYTES = 1024 * 1024;
+const SAFE_EVIDENCE_DOTFILES: readonly string[] = Object.freeze(['.semgrep.awm.yml', '.dep-cruiser.awm.js']);
 
 export type CoverageFileRequirement = {
     path: string;
@@ -67,8 +68,16 @@ function nonEmptyString(value: unknown, source: unknown, location: string): stri
 
 function safeName(value: unknown, source: unknown, location: string): string {
     const name = nonEmptyString(value, source, location);
-    if (name === '.' || name === '..' || name.includes('..') || /[/\\]/.test(name) || !/^[A-Za-z0-9._-]+$/.test(name)) {
+    if (name === '.' || name === '..' || name.includes('..') || /[/\\]/.test(name) || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name)) {
         invalid(source, `${location} must be a safe filename component`);
+    }
+    return name;
+}
+
+function safeEvidenceFilename(value: unknown, source: unknown, location: string): string {
+    const name = nonEmptyString(value, source, location);
+    if (name === '.' || name === '..' || name.includes('..') || /[/\\]/.test(name) || !/^[A-Za-z0-9._-]+$/.test(name) || (name.startsWith('.') && !SAFE_EVIDENCE_DOTFILES.includes(name))) {
+        invalid(source, `${location} must be a safe evidence filename component`);
     }
     return name;
 }
@@ -83,7 +92,7 @@ function stringArray(value: unknown, source: unknown, location: string, allowEmp
 function parseFileRequirement(input: unknown, source: unknown, location: string): CoverageFileRequirement {
     const value = record(input, source, location);
     fields(value, ['path', 'containsAll'], source, location);
-    const path = safeName(value.path, source, `${location}.path`);
+    const path = safeEvidenceFilename(value.path, source, `${location}.path`);
     const containsAll = stringArray(value.containsAll, source, `${location}.containsAll`, true);
     return { path, containsAll };
 }

--- a/cli/src/commands/sensors/coverage/contract.ts
+++ b/cli/src/commands/sensors/coverage/contract.ts
@@ -67,7 +67,7 @@ function nonEmptyString(value: unknown, source: unknown, location: string): stri
 
 function safeName(value: unknown, source: unknown, location: string): string {
     const name = nonEmptyString(value, source, location);
-    if (name === '.' || name === '..' || name.includes('..') || /[/\\]/.test(name) || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name)) {
+    if (name === '.' || name === '..' || name.includes('..') || /[/\\]/.test(name) || !/^[A-Za-z0-9._-]+$/.test(name)) {
         invalid(source, `${location} must be a safe filename component`);
     }
     return name;

--- a/cli/tests/commands/sensors/coverage/contract.test.ts
+++ b/cli/tests/commands/sensors/coverage/contract.test.ts
@@ -34,7 +34,7 @@ describe('coverage contract v1', () => {
         expect(() => parseCoverageContract(input, 'coverage.json')).toThrow(message);
     });
 
-    test.each(['', '.', '..', '../secret', 'a/../../secret', '/etc/passwd', 'C:\\secret', 'a\\..\\secret', ' report.txt', 'report!.txt'])('rejects hostile evidence path %p', (path) => {
+    test.each(['', '.', '..', 'a..b', '../secret', 'a/../../secret', '/etc/passwd', 'C:\\secret', 'a\\..\\secret', ' report.txt', 'report!.txt', 'ñ.txt'])('rejects hostile evidence path %p', (path) => {
         const input = {
             schemaVersion: 1,
             classes: {

--- a/cli/tests/commands/sensors/coverage/contract.test.ts
+++ b/cli/tests/commands/sensors/coverage/contract.test.ts
@@ -48,6 +48,20 @@ describe('coverage contract v1', () => {
         expect(() => parseCoverageContract(input, 'coverage.json')).toThrow('path');
     });
 
+    test.each(['.semgrep.awm.yml', '.dep-cruiser.awm.js'])('accepts safe dotfile evidence path %p', (path) => {
+        const input = {
+            schemaVersion: 1,
+            classes: {
+                valid: {
+                    description: 'x',
+                    detectors: [{ sensor: 'test', evidence: { files: [{ path, containsAll: [] }] } }],
+                    remedy: { summary: 'x', command: 'x' },
+                },
+            },
+        };
+        expect(parseCoverageContract(input, 'coverage.json')).toEqual(input);
+    });
+
     it('rejects whitespace-only evidence text', () => {
         const input = {
             schemaVersion: 1,

--- a/cli/tests/commands/sensors/coverage/contract.test.ts
+++ b/cli/tests/commands/sensors/coverage/contract.test.ts
@@ -34,7 +34,7 @@ describe('coverage contract v1', () => {
         expect(() => parseCoverageContract(input, 'coverage.json')).toThrow(message);
     });
 
-    test.each(['', '.', '..', 'a..b', '../secret', 'a/../../secret', '/etc/passwd', 'C:\\secret', 'a\\..\\secret', ' report.txt', 'report!.txt', 'ñ.txt'])('rejects hostile evidence path %p', (path) => {
+    test.each(['', '.', '..', 'a..b', '../secret', 'a/../../secret', '/etc/passwd', 'C:\\secret', 'a\\..\\secret', ' report.txt', 'report!.txt', 'ñ.txt', '.env', '.gitignore'])('rejects hostile evidence path %p', (path) => {
         const input = {
             schemaVersion: 1,
             classes: {


### PR DESCRIPTION
## Resumen

Corrige la incompatibilidad descubierta durante la aceptación R2: los contratos del registry requieren `.semgrep.awm.yml` y `.dep-cruiser.awm.js`, pero el parser del CLI los rechazaba.

La corrección permite únicamente esos dos dotfiles de evidencia. Mantiene fail-closed el resto: `.env`, `.gitignore`, traversal, separadores, Unicode y puntuación no permitida siguen rechazados.

## Causa raíz

El parser exigía que todo filename comenzara con un carácter alfanumérico, una restricción más estrecha que el contrato R2 y que los artefactos de configuración legítimos.

## Verificación

- Tests focales de contrato: 36/36
- Mutaciones rojo/verde de dotfiles, traversal y boundary ASCII
- `npm run build`
- `awm sensors run` con overall pass
- Aceptación CLI compilada contra el registry R2 candidato: sensors run pass, coverage read-only

Refs #20