### PR TITLE
fix(sensors): allowlist coverage evidence paths

### DIFF
--- a/cli/src/commands/sensors/coverage/contract.ts
+++ b/cli/src/commands/sensors/coverage/contract.ts
@@ -2,7 +2,17 @@ import type { SensorConfig } from '../types';
 
 export const COVERAGE_SCHEMA_VERSION = 1;
 export const MAX_COVERAGE_FILE_BYTES = 1024 * 1024;
-const SAFE_EVIDENCE_DOTFILES: readonly string[] = Object.freeze(['.semgrep.awm.yml', '.dep-cruiser.awm.js']);
+const COVERAGE_EVIDENCE_PATHS: ReadonlySet<string> = new Set([
+    'eslint.config.awm.mjs',
+    'eslint.config.js',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    'eslint.config.ts',
+    'eslint.config.mts',
+    'eslint.config.cts',
+    '.semgrep.awm.yml',
+    '.dep-cruiser.awm.js',
+]);
 
 export type CoverageFileRequirement = {
     path: string;
@@ -76,8 +86,8 @@ function safeName(value: unknown, source: unknown, location: string): string {
 
 function safeEvidenceFilename(value: unknown, source: unknown, location: string): string {
     const name = nonEmptyString(value, source, location);
-    if (name === '.' || name === '..' || name.includes('..') || /[/\\]/.test(name) || !/^[A-Za-z0-9._-]+$/.test(name) || (name.startsWith('.') && !SAFE_EVIDENCE_DOTFILES.includes(name))) {
-        invalid(source, `${location} must be a safe evidence filename component`);
+    if (!COVERAGE_EVIDENCE_PATHS.has(name)) {
+        invalid(source, `${location} must be a supported coverage evidence path`);
     }
     return name;
 }

--- a/cli/tests/commands/sensors/coverage/contract.test.ts
+++ b/cli/tests/commands/sensors/coverage/contract.test.ts
@@ -11,7 +11,7 @@ describe('coverage contract v1', () => {
                         sensor: 'contract-test',
                         evidence: {
                             commandIncludes: ['coverage'],
-                            files: [{ path: 'contract.ts', containsAll: ['parseCoverageContract'] }],
+                            files: [{ path: 'eslint.config.awm.mjs', containsAll: ['parseCoverageContract'] }],
                         },
                     }],
                     remedy: { summary: 'Add a parser.', command: 'npm test -- contract.test.ts' },
@@ -34,7 +34,7 @@ describe('coverage contract v1', () => {
         expect(() => parseCoverageContract(input, 'coverage.json')).toThrow(message);
     });
 
-    test.each(['', '.', '..', 'a..b', '../secret', 'a/../../secret', '/etc/passwd', 'C:\\secret', 'a\\..\\secret', ' report.txt', 'report!.txt', 'ñ.txt', '.env', '.gitignore'])('rejects hostile evidence path %p', (path) => {
+    test.each(['', '.', '..', 'a..b', '../secret', 'a/../../secret', '/etc/passwd', 'C:\\secret', 'a\\..\\secret', ' report.txt', 'report!.txt', 'ñ.txt', '.env', '.gitignore', 'secrets.txt', 'id_rsa'])('rejects hostile evidence path %p', (path) => {
         const input = {
             schemaVersion: 1,
             classes: {
@@ -48,7 +48,17 @@ describe('coverage contract v1', () => {
         expect(() => parseCoverageContract(input, 'coverage.json')).toThrow('path');
     });
 
-    test.each(['.semgrep.awm.yml', '.dep-cruiser.awm.js'])('accepts safe dotfile evidence path %p', (path) => {
+    test.each([
+        'eslint.config.awm.mjs',
+        'eslint.config.js',
+        'eslint.config.mjs',
+        'eslint.config.cjs',
+        'eslint.config.ts',
+        'eslint.config.mts',
+        'eslint.config.cts',
+        '.semgrep.awm.yml',
+        '.dep-cruiser.awm.js',
+    ])('accepts contractual evidence path %p', (path) => {
         const input = {
             schemaVersion: 1,
             classes: {
@@ -68,7 +78,7 @@ describe('coverage contract v1', () => {
             classes: {
                 valid: {
                     description: 'x',
-                    detectors: [{ sensor: 'test', evidence: { files: [{ path: 'report.txt', containsAll: [' \n'] }] } }],
+                    detectors: [{ sensor: 'test', evidence: { files: [{ path: 'eslint.config.awm.mjs', containsAll: [' \n'] }] } }],
                     remedy: { summary: 'x', command: 'x' },
                 },
             },


### PR DESCRIPTION
## Summary
- restrict v1 coverage evidence to the nine declared contract paths
- reject arbitrary regular-file markers from a semitrusted registry
- retain fail-closed validation for dotfiles, traversal and Unicode

## Verification
- TDD RED then GREEN: 45 focused tests
- coverage test suite: 127 tests
- build and configured sensor gate pass

Closes QA ledger finding: r2-coverage-evidence-arbitrary-regular-file-oracle.