### PR TITLE
feat(sensors): harden pack v2 execution contract

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-workflow-manager",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-workflow-manager",
-      "version": "7.0.0",
+      "version": "8.0.0",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/cli/src/commands/sensors/compatibility/contract.ts
+++ b/cli/src/commands/sensors/compatibility/contract.ts
@@ -73,6 +73,11 @@ function stringArray(value: unknown, source: unknown, location: string): string[
     return value.map((item, index) => text(item, source, `${location}[${index}]`));
 }
 
+function assetArray(value: unknown, source: unknown, location: string, allowEmpty = false): string[] {
+    if (!Array.isArray(value) || (!allowEmpty && value.length === 0)) invalid(source, `${location} must be a ${allowEmpty ? '' : 'nonempty '}array`);
+    return value.map((item, index) => asset(item, source, `${location}[${index}]`));
+}
+
 export function parseStructuredCommand(input: unknown, source: unknown): StructuredCommand {
     const value = record(input, source, 'command');
     fields(value, ['executable', 'resolution', 'args', 'fileInput'], source, 'command');
@@ -123,11 +128,24 @@ function parseVariant(input: unknown, source: unknown, location: string): Sensor
         priority: value.priority,
         certifiedRange,
         requirements: { tool: text(requirements.tool, source, `${location}.requirements.tool`), toolRange, runtime: text(requirements.runtime, source, `${location}.requirements.runtime`), runtimeRange, ...('configFiles' in requirements ? { configFiles: stringArray(requirements.configFiles, source, `${location}.requirements.configFiles`).map((file, index) => asset(file, source, `${location}.requirements.configFiles[${index}]`)) } : {}) },
-        assets: stringArray(value.assets, source, `${location}.assets`).map((entry, index) => asset(entry, source, `${location}.assets[${index}]`)),
+        assets: assetArray(value.assets, source, `${location}.assets`, true),
         formatter: text(value.formatter, source, `${location}.formatter`),
         probe: { kind: probe.kind as CompatibilityProbe },
         command: parseStructuredCommand(value.command, source),
     };
+}
+
+function parseHardening(input: unknown, source: unknown): SensorPackV2['hardening'] {
+    const value = record(input, source, 'hardening');
+    const names = Object.keys(value);
+    if (names.length === 0) invalid(source, 'hardening must be nonempty when declared');
+    const hardening: NonNullable<SensorPackV2['hardening']> = {};
+    for (const name of names) {
+        const entry = record(value[name], source, `hardening.${name}`);
+        fields(entry, ['assets'], source, `hardening.${name}`);
+        hardening[id(name, source, 'hardening id')] = { assets: assetArray(entry.assets, source, `hardening.${name}.assets`) };
+    }
+    return hardening;
 }
 
 export function assertNoEqualPriorityOverlap(variants: unknown): void {
@@ -215,7 +233,7 @@ function parseLegacyPack(value: UnknownRecord, source: unknown): LegacySensorPac
 export function parseSensorPack(input: unknown, source: unknown): ParsedSensorPack {
     const value = record(input, source, 'root');
     if (!('schemaVersion' in value)) return { kind: 'legacy', pack: parseLegacyPack(value, source) };
-    fields(value, ['schemaVersion', 'name', 'description', 'detects', 'sensors', 'coverage'], source, 'root');
+    fields(value, ['schemaVersion', 'name', 'description', 'detects', 'sensors', 'coverage', 'hardening'], source, 'root');
     if (value.schemaVersion !== PACK_SCHEMA_VERSION) invalid(source, `unsupported pack schemaVersion ${String(value.schemaVersion)}; supported: legacy, 2; upgrade or migrate the pack`);
     const sensorsInput = record(value.sensors, source, 'sensors');
     const sensorNames = Object.keys(sensorsInput);
@@ -229,10 +247,11 @@ export function parseSensorPack(input: unknown, source: unknown): ParsedSensorPa
     } catch (error) {
         invalid(source, `coverage.${error instanceof Error ? error.message.replace(/^.*?: /, '') : 'is invalid'}`);
     }
+    const hardening = 'hardening' in value ? parseHardening(value.hardening, source) : undefined;
     return { kind: 'v2', pack: {
         schemaVersion: PACK_SCHEMA_VERSION,
         name: id(value.name, source, 'name'), description: text(value.description, source, 'description'), detects: stringArray(value.detects, source, 'detects'),
-        sensors,
+        sensors, ...(hardening ? { hardening } : {}),
         coverage,
     } };
 }

--- a/cli/src/commands/sensors/compatibility/contract.ts
+++ b/cli/src/commands/sensors/compatibility/contract.ts
@@ -128,7 +128,7 @@ export function resolveSemgrepPolicy(policyRef: unknown, source: unknown, locati
 
 export function parseStructuredCommand(input: unknown, source: unknown): StructuredCommand {
     const value = record(input, source, 'command');
-    fields(value, ['executable', 'resolution', 'args', 'packageManager', 'environment', 'fileInput'], source, 'command');
+    fields(value, ['executable', 'resolution', 'args', 'packageManager', 'environment', 'fileInput', 'pythonEnvironmentRoot'], source, 'command');
     const executable = text(value.executable, source, 'command.executable');
     if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(executable) || SHELL_EXECUTABLES.has(executable.toLowerCase().replace(/\.exe$/, ''))) {
         invalid(source, 'command.executable must not be a shell or path');
@@ -141,6 +141,10 @@ export function parseStructuredCommand(input: unknown, source: unknown): Structu
         if (arg.includes('{files}') && arg !== '{files}') invalid(source, `command.args[${index}] must not embed {files}`);
     }
     const command: StructuredCommand = { executable, resolution: value.resolution, args };
+    if ('pythonEnvironmentRoot' in value) {
+        if (value.resolution !== 'python-environment' || (value.pythonEnvironmentRoot !== '.venv' && value.pythonEnvironmentRoot !== 'venv')) invalid(source, 'command.pythonEnvironmentRoot must name the selected .venv or venv Python environment');
+        command.pythonEnvironmentRoot = value.pythonEnvironmentRoot;
+    }
     const executablePackageManager = normalizedPackageManager(executable);
     if (PACKAGE_MANAGERS.has(executablePackageManager) && !('packageManager' in value)) invalid(source, 'command.packageManager is required for a package-manager executable');
     if ('packageManager' in value) {

--- a/cli/src/commands/sensors/compatibility/contract.ts
+++ b/cli/src/commands/sensors/compatibility/contract.ts
@@ -13,6 +13,7 @@ import type {
 
 const PACK_SCHEMA_VERSION = 2;
 const SHELL_EXECUTABLES = new Set(['sh', 'bash', 'cmd', 'powershell']);
+const PACKAGE_MANAGERS = new Set(['npm', 'pnpm', 'yarn', 'bun']);
 const ALLOWED_PROBES = new Set<CompatibilityProbe>([
     'version',
     'eslint-print-config',
@@ -80,7 +81,7 @@ function assetArray(value: unknown, source: unknown, location: string, allowEmpt
 
 export function parseStructuredCommand(input: unknown, source: unknown): StructuredCommand {
     const value = record(input, source, 'command');
-    fields(value, ['executable', 'resolution', 'args', 'fileInput'], source, 'command');
+    fields(value, ['executable', 'resolution', 'args', 'packageManager', 'environment', 'fileInput'], source, 'command');
     const executable = text(value.executable, source, 'command.executable');
     if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(executable) || SHELL_EXECUTABLES.has(executable.toLowerCase().replace(/\.exe$/, ''))) {
         invalid(source, 'command.executable must not be a shell or path');
@@ -93,6 +94,18 @@ export function parseStructuredCommand(input: unknown, source: unknown): Structu
         if (arg.includes('{files}') && arg !== '{files}') invalid(source, `command.args[${index}] must not embed {files}`);
     }
     const command: StructuredCommand = { executable, resolution: value.resolution, args };
+    if (PACKAGE_MANAGERS.has(executable) && !('packageManager' in value)) invalid(source, 'command.packageManager is required for a package-manager executable');
+    if ('packageManager' in value) {
+        if (typeof value.packageManager !== 'string' || !PACKAGE_MANAGERS.has(value.packageManager)) invalid(source, 'command.packageManager must be npm, pnpm, yarn, or bun');
+        if (value.packageManager !== executable) invalid(source, 'command.packageManager must match executable');
+        command.packageManager = value.packageManager as StructuredCommand['packageManager'];
+    }
+    if ('environment' in value) {
+        const environment = record(value.environment, source, 'command.environment');
+        fields(environment, ['ESLINT_USE_FLAT_CONFIG'], source, 'command.environment');
+        if (environment.ESLINT_USE_FLAT_CONFIG !== 'false' || Object.keys(environment).length !== 1) invalid(source, 'command.environment must be the allowlisted ESLINT_USE_FLAT_CONFIG=false mapping');
+        command.environment = { ESLINT_USE_FLAT_CONFIG: 'false' };
+    }
     if ('fileInput' in value) {
         const fileInput = record(value.fileInput, source, 'command.fileInput');
         fields(fileInput, ['placeholder', 'extensions'], source, 'command.fileInput');

--- a/cli/src/commands/sensors/compatibility/contract.ts
+++ b/cli/src/commands/sensors/compatibility/contract.ts
@@ -1,4 +1,6 @@
 import semver from 'semver';
+import fs from 'fs';
+import path from 'path';
 import { parseCoverageContract } from '../coverage/contract';
 import type {
     CompatibilityProbe,
@@ -8,6 +10,7 @@ import type {
     SensorPackSensor,
     SensorPackV2,
     SensorVariant,
+    SemgrepPolicy,
     StructuredCommand,
 } from './types';
 
@@ -83,6 +86,46 @@ function assetArray(value: unknown, source: unknown, location: string, allowEmpt
     return value.map((item, index) => asset(item, source, `${location}[${index}]`));
 }
 
+const SEMGREP_POLICY_REF = 'shared/semgrep-policy.json' as const;
+const MAX_POLICY_BYTES = 64 * 1024;
+
+function contained(root: string, candidate: string): boolean {
+    const prefix = root.endsWith(path.sep) ? root : root + path.sep;
+    return candidate.startsWith(prefix);
+}
+
+export function parseSemgrepPolicy(input: unknown, source: unknown): SemgrepPolicy {
+    const value = record(input, source, 'Semgrep policy');
+    fields(value, ['tool', 'toolRange', 'runtime', 'runtimeRange', 'probe'], source, 'Semgrep policy');
+    if (value.tool !== 'semgrep' || value.runtime !== 'python' || value.probe !== 'semgrep-validate') {
+        invalid(source, 'Semgrep policy must declare semgrep, python, and semgrep-validate');
+    }
+    const toolRange = text(value.toolRange, source, 'Semgrep policy.toolRange');
+    const runtimeRange = text(value.runtimeRange, source, 'Semgrep policy.runtimeRange');
+    if (semver.validRange(toolRange) === null || semver.validRange(runtimeRange) === null) invalid(source, 'Semgrep policy ranges must be valid semver ranges');
+    return { tool: 'semgrep', toolRange, runtime: 'python', runtimeRange, probe: 'semgrep-validate' };
+}
+
+export function resolveSemgrepPolicy(policyRef: unknown, source: unknown, location = 'policy'): SemgrepPolicy {
+    if (policyRef !== SEMGREP_POLICY_REF) invalid(source, `${location}.policyRef must be the contained AWM-owned ${SEMGREP_POLICY_REF}`);
+    if (typeof source !== 'string' || !path.isAbsolute(source) || path.normalize(source) !== source || path.basename(source) !== 'pack.json') {
+        invalid(source, `${location}.policyRef requires an absolute pack.json source`);
+    }
+    const packRoot = path.dirname(source);
+    const sensorPacksRoot = path.dirname(packRoot);
+    const candidate = path.join(sensorPacksRoot, ...SEMGREP_POLICY_REF.split('/'));
+    if (!contained(sensorPacksRoot, candidate)) invalid(source, `${location}.policyRef escapes sensor-packs root`);
+    let stat: fs.Stats;
+    try { stat = fs.lstatSync(candidate); } catch { invalid(source, `${location}.policyRef does not resolve to a regular policy file`); }
+    if (!stat.isFile() || stat.isSymbolicLink() || stat.size > MAX_POLICY_BYTES) invalid(source, `${location}.policyRef must resolve to a bounded regular policy file`);
+    let realRoot: string; let realPolicy: string;
+    try { realRoot = fs.realpathSync(sensorPacksRoot); realPolicy = fs.realpathSync(candidate); } catch { invalid(source, `${location}.policyRef cannot be canonicalized`); }
+    if (!contained(realRoot, realPolicy)) invalid(source, `${location}.policyRef escapes sensor-packs root`);
+    let parsed: unknown;
+    try { parsed = JSON.parse(fs.readFileSync(realPolicy, 'utf8')); } catch { invalid(source, `${location}.policyRef must contain valid JSON`); }
+    return parseSemgrepPolicy(parsed, realPolicy);
+}
+
 export function parseStructuredCommand(input: unknown, source: unknown): StructuredCommand {
     const value = record(input, source, 'command');
     fields(value, ['executable', 'resolution', 'args', 'packageManager', 'environment', 'fileInput'], source, 'command');
@@ -130,26 +173,34 @@ export function parseStructuredCommand(input: unknown, source: unknown): Structu
 
 function parseVariant(input: unknown, source: unknown, location: string): SensorVariant {
     const value = record(input, source, location);
-    fields(value, ['id', 'priority', 'requirements', 'certifiedRange', 'command', 'assets', 'formatter', 'probe'], source, location);
+    fields(value, ['id', 'priority', 'requirements', 'certifiedRange', 'command', 'assets', 'formatter', 'probe', 'policyRef'], source, location);
     const certifiedRange = text(value.certifiedRange, source, `${location}.certifiedRange`);
     if (semver.validRange(certifiedRange) === null) invalid(source, `${location}.certifiedRange must be a valid semver range`);
     if (typeof value.priority !== 'number' || !Number.isSafeInteger(value.priority)) invalid(source, `${location}.priority must be a safe integer`);
-    const requirements = record(value.requirements, source, `${location}.requirements`);
-    fields(requirements, ['tool', 'toolRange', 'runtime', 'runtimeRange', 'configFiles'], source, `${location}.requirements`);
-    const toolRange = text(requirements.toolRange, source, `${location}.requirements.toolRange`);
-    const runtimeRange = text(requirements.runtimeRange, source, `${location}.requirements.runtimeRange`);
+    const policy = 'policyRef' in value ? resolveSemgrepPolicy(value.policyRef, source, location) : undefined;
+    if (policy && ('requirements' in value || 'probe' in value)) invalid(source, `${location}.policyRef is authoritative; requirements and probe must not duplicate it`);
+    if (!policy && (!('requirements' in value) || !('probe' in value))) invalid(source, `${location} requires requirements and probe when policyRef is absent`);
+    const requirements = policy ? undefined : record(value.requirements, source, `${location}.requirements`);
+    if (requirements) fields(requirements, ['tool', 'toolRange', 'runtime', 'runtimeRange', 'configFiles'], source, `${location}.requirements`);
+    const toolRange = policy?.toolRange ?? text(requirements!.toolRange, source, `${location}.requirements.toolRange`);
+    const runtimeRange = policy?.runtimeRange ?? text(requirements!.runtimeRange, source, `${location}.requirements.runtimeRange`);
     if (semver.validRange(toolRange) === null || semver.validRange(runtimeRange) === null) invalid(source, `${location}.requirements ranges must be valid semver ranges`);
-    const probe = record(value.probe, source, `${location}.probe`);
-    fields(probe, ['kind'], source, `${location}.probe`);
-    if (typeof probe.kind !== 'string' || !ALLOWED_PROBES.has(probe.kind as CompatibilityProbe)) invalid(source, `${location}.probe.kind must be an allowed probe`);
+    const probe = policy ? undefined : record(value.probe, source, `${location}.probe`);
+    if (probe) {
+        fields(probe, ['kind'], source, `${location}.probe`);
+        if (typeof probe.kind !== 'string' || !ALLOWED_PROBES.has(probe.kind as CompatibilityProbe)) invalid(source, `${location}.probe.kind must be an allowed probe`);
+    }
     return {
         id: id(value.id, source, `${location}.id`),
         priority: value.priority,
         certifiedRange,
-        requirements: { tool: text(requirements.tool, source, `${location}.requirements.tool`), toolRange, runtime: text(requirements.runtime, source, `${location}.requirements.runtime`), runtimeRange, ...('configFiles' in requirements ? { configFiles: stringArray(requirements.configFiles, source, `${location}.requirements.configFiles`).map((file, index) => asset(file, source, `${location}.requirements.configFiles[${index}]`)) } : {}) },
+        requirements: policy
+            ? { tool: policy.tool, toolRange, runtime: policy.runtime, runtimeRange }
+            : { tool: text(requirements!.tool, source, `${location}.requirements.tool`), toolRange, runtime: text(requirements!.runtime, source, `${location}.requirements.runtime`), runtimeRange, ...('configFiles' in requirements! ? { configFiles: stringArray(requirements!.configFiles, source, `${location}.requirements.configFiles`).map((file, index) => asset(file, source, `${location}.requirements.configFiles[${index}]`)) } : {}) },
         assets: assetArray(value.assets, source, `${location}.assets`, true),
         formatter: text(value.formatter, source, `${location}.formatter`),
-        probe: { kind: probe.kind as CompatibilityProbe },
+        probe: { kind: policy?.probe ?? probe!.kind as CompatibilityProbe },
+        ...(policy ? { policyRef: SEMGREP_POLICY_REF } : {}),
         command: parseStructuredCommand(value.command, source),
     };
 }
@@ -167,12 +218,10 @@ function parseHardening(input: unknown, source: unknown): SensorPackV2['hardenin
     return hardening;
 }
 
-export function assertNoEqualPriorityOverlap(variants: unknown): void {
-    if (!Array.isArray(variants) || variants.length === 0) throw new Error('variants must be a nonempty array');
-    const parsed = variants.map((variant, index) => parseVariant(variant, 'public overlap validator', `variants[${index}]`));
+function assertNoEqualPriorityOverlapParsed(parsed: SensorVariant[]): void {
     for (let left = 0; left < parsed.length; left++) {
         const first = parsed[left];
-        for (let right = left + 1; right < variants.length; right++) {
+        for (let right = left + 1; right < parsed.length; right++) {
             const second = parsed[right];
             const toolRangesIntersect = semver.intersects(first.requirements.toolRange, second.requirements.toolRange);
             const runtimeRangesIntersect = semver.intersects(first.requirements.runtimeRange, second.requirements.runtimeRange);
@@ -181,6 +230,11 @@ export function assertNoEqualPriorityOverlap(variants: unknown): void {
             }
         }
     }
+}
+
+export function assertNoEqualPriorityOverlap(variants: unknown): void {
+    if (!Array.isArray(variants) || variants.length === 0) throw new Error('variants must be a nonempty array');
+    assertNoEqualPriorityOverlapParsed(variants.map((variant, index) => parseVariant(variant, 'public overlap validator', `variants[${index}]`)));
 }
 
 function parseSensor(input: unknown, source: unknown, location: string, variantIds: Set<string>): SensorPackSensor {
@@ -193,7 +247,7 @@ function parseSensor(input: unknown, source: unknown, location: string, variantI
         variantIds.add(variant.id);
     }
     try {
-        assertNoEqualPriorityOverlap(variants);
+        assertNoEqualPriorityOverlapParsed(variants);
     } catch (error) {
         invalid(source, `${location}.variants ${error instanceof Error ? error.message : 'overlap validation failed'}`);
     }

--- a/cli/src/commands/sensors/compatibility/contract.ts
+++ b/cli/src/commands/sensors/compatibility/contract.ts
@@ -25,6 +25,10 @@ const ALLOWED_PROBES = new Set<CompatibilityProbe>([
 
 type UnknownRecord = Record<string, unknown>;
 
+function normalizedPackageManager(value: string): string {
+    return value.toLowerCase().replace(/\.exe$/, '');
+}
+
 function isRecord(value: unknown): value is UnknownRecord {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -94,11 +98,13 @@ export function parseStructuredCommand(input: unknown, source: unknown): Structu
         if (arg.includes('{files}') && arg !== '{files}') invalid(source, `command.args[${index}] must not embed {files}`);
     }
     const command: StructuredCommand = { executable, resolution: value.resolution, args };
-    if (PACKAGE_MANAGERS.has(executable) && !('packageManager' in value)) invalid(source, 'command.packageManager is required for a package-manager executable');
+    const executablePackageManager = normalizedPackageManager(executable);
+    if (PACKAGE_MANAGERS.has(executablePackageManager) && !('packageManager' in value)) invalid(source, 'command.packageManager is required for a package-manager executable');
     if ('packageManager' in value) {
-        if (typeof value.packageManager !== 'string' || !PACKAGE_MANAGERS.has(value.packageManager)) invalid(source, 'command.packageManager must be npm, pnpm, yarn, or bun');
-        if (value.packageManager !== executable) invalid(source, 'command.packageManager must match executable');
-        command.packageManager = value.packageManager as StructuredCommand['packageManager'];
+        if (typeof value.packageManager !== 'string' || !PACKAGE_MANAGERS.has(normalizedPackageManager(value.packageManager))) invalid(source, 'command.packageManager must be npm, pnpm, yarn, or bun');
+        const packageManager = normalizedPackageManager(value.packageManager);
+        if (packageManager !== executablePackageManager) invalid(source, 'command.packageManager must match executable');
+        command.packageManager = packageManager as StructuredCommand['packageManager'];
     }
     if ('environment' in value) {
         const environment = record(value.environment, source, 'command.environment');

--- a/cli/src/commands/sensors/compatibility/contract.ts
+++ b/cli/src/commands/sensors/compatibility/contract.ts
@@ -109,8 +109,8 @@ export function parseStructuredCommand(input: unknown, source: unknown): Structu
     if ('environment' in value) {
         const environment = record(value.environment, source, 'command.environment');
         fields(environment, ['ESLINT_USE_FLAT_CONFIG'], source, 'command.environment');
-        if (environment.ESLINT_USE_FLAT_CONFIG !== 'false' || Object.keys(environment).length !== 1) invalid(source, 'command.environment must be the allowlisted ESLINT_USE_FLAT_CONFIG=false mapping');
-        command.environment = { ESLINT_USE_FLAT_CONFIG: 'false' };
+        if ((environment.ESLINT_USE_FLAT_CONFIG !== 'true' && environment.ESLINT_USE_FLAT_CONFIG !== 'false') || Object.keys(environment).length !== 1) invalid(source, 'command.environment must be the exact allowlisted ESLINT_USE_FLAT_CONFIG=true or false mapping');
+        command.environment = { ESLINT_USE_FLAT_CONFIG: environment.ESLINT_USE_FLAT_CONFIG };
     }
     if ('fileInput' in value) {
         const fileInput = record(value.fileInput, source, 'command.fileInput');

--- a/cli/src/commands/sensors/compatibility/discovery.ts
+++ b/cli/src/commands/sensors/compatibility/discovery.ts
@@ -9,6 +9,8 @@ export type ProjectEvidence = {
     cwd: string;
     os: NodeJS.Platform;
     runtimeVersions: Record<string, string | null>;
+    /** The exact contained environment from which Python metadata was read. */
+    pythonEnvironmentRoot: '.venv' | 'venv' | null;
     /** Declared package ranges are context only, never evidence that a tool is installed. */
     declaredToolRanges: Record<string, string>;
     /** Exact versions inspected from contained local node_modules package metadata. */
@@ -60,8 +62,8 @@ function exactVersion(value: unknown): string | null {
     return typeof value === 'string' && semver.valid(value.trim()) !== null ? semver.clean(value.trim()) : null;
 }
 
-function pythonEnvironment(root: string): { rootParts: string[]; runtimeVersion: string | null } | null {
-    for (const name of ['.venv', 'venv']) {
+function pythonEnvironment(root: string): { rootParts: ['.venv' | 'venv']; runtimeVersion: string | null } | null {
+    for (const name of ['.venv', 'venv'] as const) {
         if (!containedEntry(root, [name], 'directory')) continue;
         const config = readBoundedLocalFile(root, [name, 'pyvenv.cfg']);
         const version = config?.match(/^version\s*=\s*([^\r\n#]+)\s*$/mi)?.[1] ?? null;
@@ -160,7 +162,7 @@ export function discoverProjectEvidence(cwd: unknown, pack: SensorPack, dependen
     const sitePackages = environment ? pythonSitePackages(root, environment.rootParts, targetPlatform) : [];
     const toolVersions = Object.fromEntries([...tools].sort().map(tool => [tool, pythonToolVersion(root, sitePackages, tool) ?? installedPackageVersion(root, tool)]));
     return {
-        cwd: root, os: targetPlatform, runtimeVersions: { node: process.versions.node ?? null, ...(environment ? { python: environment.runtimeVersion } : {}) }, declaredToolRanges, toolVersions,
+        cwd: root, os: targetPlatform, runtimeVersions: { node: process.versions.node ?? null, ...(environment ? { python: environment.runtimeVersion } : {}) }, pythonEnvironmentRoot: environment?.rootParts[0] ?? null, declaredToolRanges, toolVersions,
         packageManager: declaredManager ?? (lockManagers.size === 1 ? [...lockManagers][0] : null), packageManagerConflict: lockManagers.size > 1,
         scripts, configFiles, paths: [...new Set([...(safeFile(root, 'package.json') ? ['package.json'] : []), ...locks, ...configFiles])].sort(),
     };

--- a/cli/src/commands/sensors/compatibility/live.ts
+++ b/cli/src/commands/sensors/compatibility/live.ts
@@ -20,17 +20,24 @@ export type LiveCompatibilityOptions = { packSelection?: 'explicit' };
  * Keep this at the live pack boundary so the command used by probing, init's
  * materialized manifest, and `sensors run` is one identical structured command.
  */
-function containedRuntimeCommand(variant: SensorVariant): SensorVariant {
+function containedRuntimeCommand(variant: SensorVariant, pythonEnvironmentRoot: '.venv' | 'venv' | null): SensorVariant {
     if (variant.requirements.runtime !== 'python') return variant;
-    return { ...variant, command: { ...variant.command, resolution: 'python-environment' } };
+    return {
+        ...variant,
+        command: {
+            ...variant.command,
+            resolution: 'python-environment',
+            ...(pythonEnvironmentRoot ? { pythonEnvironmentRoot } : {}),
+        },
+    };
 }
 
-function bindContainedRuntimeCommands(pack: SensorPackV2): SensorPackV2 {
+function bindContainedRuntimeCommands(pack: SensorPackV2, pythonEnvironmentRoot: '.venv' | 'venv' | null): SensorPackV2 {
     return {
         ...pack,
         sensors: Object.fromEntries(Object.entries(pack.sensors).map(([name, sensor]) => [
             name,
-            { ...sensor, variants: sensor.variants.map(containedRuntimeCommand) },
+            { ...sensor, variants: sensor.variants.map(variant => containedRuntimeCommand(variant, pythonEnvironmentRoot)) },
         ])),
     };
 }
@@ -59,8 +66,8 @@ export async function resolveLiveCompatibility(cwd: string, packName: string, re
 export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPackV2, options: LiveCompatibilityOptions = {}): Promise<LiveCompatibility> {
     if (typeof cwd !== 'string' || cwd.trim() === '') throw new Error('cwd must be a non-empty path');
     if (!pack || typeof pack !== 'object' || pack.schemaVersion !== 2) throw new Error('pack must be a parsed v2 sensor pack');
-    const executionPack = bindContainedRuntimeCommands(pack);
-    const evidence = discoverProjectEvidence(cwd, executionPack);
+    const evidence = discoverProjectEvidence(cwd, pack);
+    const executionPack = bindContainedRuntimeCommands(pack, evidence.pythonEnvironmentRoot);
     const resolutionEvidence = { ...evidence, ...(options.packSelection === 'explicit' ? { packSelection: 'explicit' as const } : {}) };
     const initial = resolveProjectCompatibility(executionPack, resolutionEvidence).sensors;
     const sensors: Record<string, CompatibilityEvidence> = {};
@@ -72,6 +79,7 @@ export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPa
                 cwd,
                 toolExecutable: variant.command.executable,
                 toolResolution: variant.command.resolution,
+                pythonEnvironmentRoot: variant.command.pythonEnvironmentRoot,
                 configFiles: evidence.configFiles,
                 scripts: evidence.scripts,
             })

--- a/cli/src/commands/sensors/compatibility/live.ts
+++ b/cli/src/commands/sensors/compatibility/live.ts
@@ -10,6 +10,7 @@ export type LiveCompatibility = {
     pack: SensorPackV2;
     sensors: Record<string, CompatibilityEvidence>;
 };
+export type LiveCompatibilityOptions = { explicitPackSelection?: boolean };
 
 /**
  * Re-resolve a v2 pack from the configured registry and current project evidence.
@@ -17,7 +18,7 @@ export type LiveCompatibility = {
  * live certification source. Probes are bounded and structured through the shared
  * compatibility probe runner.
  */
-export async function resolveLiveCompatibility(cwd: string, packName: string, registryRoot?: string): Promise<LiveCompatibility> {
+export async function resolveLiveCompatibility(cwd: string, packName: string, registryRoot?: string, options: LiveCompatibilityOptions = {}): Promise<LiveCompatibility> {
     if (typeof cwd !== 'string' || cwd.trim() === '') throw new Error('cwd must be a non-empty path');
     if (typeof packName !== 'string' || !/^[a-z][a-z0-9-]*$/.test(packName)) throw new Error('pack name must be a stable lowercase id');
     if (registryRoot !== undefined && (typeof registryRoot !== 'string' || !path.isAbsolute(registryRoot) || path.normalize(registryRoot) !== registryRoot || /[\0\r\n]/.test(registryRoot))) {
@@ -28,15 +29,16 @@ export async function resolveLiveCompatibility(cwd: string, packName: string, re
         : resolvePackSource(packName, { registries: [{ name: 'manifest-provenance', remote: 'local', contentRoot: registryRoot }] });
     const parsed = parseSensorPack(JSON.parse(source.content), source.path);
     if (parsed.kind !== 'v2') throw new Error(`sensor pack "${packName}" does not provide a v2 compatibility contract`);
-    return resolveParsedPackCompatibility(cwd, parsed.pack);
+    return resolveParsedPackCompatibility(cwd, parsed.pack, options);
 }
 
 /** Resolve a pre-parsed v2 pack. Init uses this when given an explicit registry root. */
-export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPackV2): Promise<LiveCompatibility> {
+export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPackV2, options: LiveCompatibilityOptions = {}): Promise<LiveCompatibility> {
     if (typeof cwd !== 'string' || cwd.trim() === '') throw new Error('cwd must be a non-empty path');
     if (!pack || typeof pack !== 'object' || pack.schemaVersion !== 2) throw new Error('pack must be a parsed v2 sensor pack');
     const evidence = discoverProjectEvidence(cwd, pack);
-    const initial = resolveProjectCompatibility(pack, evidence).sensors;
+    const resolutionEvidence = { ...evidence, explicitPackSelection: options.explicitPackSelection === true };
+    const initial = resolveProjectCompatibility(pack, resolutionEvidence).sensors;
     const sensors: Record<string, CompatibilityEvidence> = {};
     for (const [name, sensor] of Object.entries(pack.sensors)) {
         const base = initial[name];
@@ -51,7 +53,7 @@ export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPa
             : null;
         sensors[name] = resolveProjectCompatibility(
             { ...pack, sensors: { [name]: sensor } },
-            { ...evidence, probe: probe ?? undefined },
+            { ...resolutionEvidence, probe: probe ?? undefined },
         ).sensors[name];
     }
     return { pack, sensors };

--- a/cli/src/commands/sensors/compatibility/live.ts
+++ b/cli/src/commands/sensors/compatibility/live.ts
@@ -10,7 +10,7 @@ export type LiveCompatibility = {
     pack: SensorPackV2;
     sensors: Record<string, CompatibilityEvidence>;
 };
-export type LiveCompatibilityOptions = { explicitPackSelection?: boolean };
+export type LiveCompatibilityOptions = { packSelection?: 'explicit' };
 
 /**
  * Re-resolve a v2 pack from the configured registry and current project evidence.
@@ -37,7 +37,7 @@ export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPa
     if (typeof cwd !== 'string' || cwd.trim() === '') throw new Error('cwd must be a non-empty path');
     if (!pack || typeof pack !== 'object' || pack.schemaVersion !== 2) throw new Error('pack must be a parsed v2 sensor pack');
     const evidence = discoverProjectEvidence(cwd, pack);
-    const resolutionEvidence = { ...evidence, explicitPackSelection: options.explicitPackSelection === true };
+    const resolutionEvidence = { ...evidence, ...(options.packSelection === 'explicit' ? { packSelection: 'explicit' as const } : {}) };
     const initial = resolveProjectCompatibility(pack, resolutionEvidence).sensors;
     const sensors: Record<string, CompatibilityEvidence> = {};
     for (const [name, sensor] of Object.entries(pack.sensors)) {
@@ -47,6 +47,7 @@ export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPa
             ? await runCompatibilityProbe(variant.probe, {
                 cwd,
                 toolExecutable: variant.command.executable,
+                toolResolution: variant.command.resolution,
                 configFiles: evidence.configFiles,
                 scripts: evidence.scripts,
             })

--- a/cli/src/commands/sensors/compatibility/live.ts
+++ b/cli/src/commands/sensors/compatibility/live.ts
@@ -3,7 +3,7 @@ import { parseSensorPack } from './contract';
 import { discoverProjectEvidence } from './discovery';
 import { resolveProjectCompatibility } from './resolve';
 import { runCompatibilityProbe } from './probe';
-import type { CompatibilityEvidence, SensorPackV2 } from './types';
+import type { CompatibilityEvidence, SensorPackV2, SensorVariant } from './types';
 import path from 'path';
 
 export type LiveCompatibility = {
@@ -11,6 +11,29 @@ export type LiveCompatibility = {
     sensors: Record<string, CompatibilityEvidence>;
 };
 export type LiveCompatibilityOptions = { packSelection?: 'explicit' };
+
+/**
+ * Python package metadata is evidence only for a contained virtual environment.
+ * A v2 command that names a Python-runtime tool must therefore resolve through
+ * that same environment — never a same-named executable inherited from PATH.
+ *
+ * Keep this at the live pack boundary so the command used by probing, init's
+ * materialized manifest, and `sensors run` is one identical structured command.
+ */
+function containedRuntimeCommand(variant: SensorVariant): SensorVariant {
+    if (variant.requirements.runtime !== 'python') return variant;
+    return { ...variant, command: { ...variant.command, resolution: 'python-environment' } };
+}
+
+function bindContainedRuntimeCommands(pack: SensorPackV2): SensorPackV2 {
+    return {
+        ...pack,
+        sensors: Object.fromEntries(Object.entries(pack.sensors).map(([name, sensor]) => [
+            name,
+            { ...sensor, variants: sensor.variants.map(containedRuntimeCommand) },
+        ])),
+    };
+}
 
 /**
  * Re-resolve a v2 pack from the configured registry and current project evidence.
@@ -36,11 +59,12 @@ export async function resolveLiveCompatibility(cwd: string, packName: string, re
 export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPackV2, options: LiveCompatibilityOptions = {}): Promise<LiveCompatibility> {
     if (typeof cwd !== 'string' || cwd.trim() === '') throw new Error('cwd must be a non-empty path');
     if (!pack || typeof pack !== 'object' || pack.schemaVersion !== 2) throw new Error('pack must be a parsed v2 sensor pack');
-    const evidence = discoverProjectEvidence(cwd, pack);
+    const executionPack = bindContainedRuntimeCommands(pack);
+    const evidence = discoverProjectEvidence(cwd, executionPack);
     const resolutionEvidence = { ...evidence, ...(options.packSelection === 'explicit' ? { packSelection: 'explicit' as const } : {}) };
-    const initial = resolveProjectCompatibility(pack, resolutionEvidence).sensors;
+    const initial = resolveProjectCompatibility(executionPack, resolutionEvidence).sensors;
     const sensors: Record<string, CompatibilityEvidence> = {};
-    for (const [name, sensor] of Object.entries(pack.sensors)) {
+    for (const [name, sensor] of Object.entries(executionPack.sensors)) {
         const base = initial[name];
         const variant = base.variantId === null ? null : sensor.variants.find(candidate => candidate.id === base.variantId) ?? null;
         const probe = variant
@@ -53,9 +77,9 @@ export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPa
             })
             : null;
         sensors[name] = resolveProjectCompatibility(
-            { ...pack, sensors: { [name]: sensor } },
+            { ...executionPack, sensors: { [name]: sensor } },
             { ...resolutionEvidence, probe: probe ?? undefined },
         ).sensors[name];
     }
-    return { pack, sensors };
+    return { pack: executionPack, sensors };
 }

--- a/cli/src/commands/sensors/compatibility/manifest.ts
+++ b/cli/src/commands/sensors/compatibility/manifest.ts
@@ -9,6 +9,8 @@ type UnknownRecord = Record<string, unknown>;
 export type SensorManifestV2 = {
     schemaVersion: 2;
     pack: string;
+    /** Durable operator intent. Absent means detected/fallback, never explicit. */
+    packSelection?: 'explicit';
     registryRoot?: string;
     sensors: Record<string, { enabled: boolean; fast?: boolean; variantId: string; command: StructuredCommand; assets?: string[]; policyRef?: 'shared/semgrep-policy.json'; initializedCompatibility: CompatibilityEvidence }>;
     concurrency?: number;
@@ -169,13 +171,17 @@ function provenanceRoot(value: unknown, source: unknown): string {
 }
 
 function parseV2Manifest(value: UnknownRecord, source: unknown): SensorManifestV2 {
-    fields(value, ['schemaVersion', 'pack', 'registryRoot', 'sensors', 'concurrency'], source, 'root');
+    fields(value, ['schemaVersion', 'pack', 'packSelection', 'registryRoot', 'sensors', 'concurrency'], source, 'root');
     if (value.schemaVersion !== 2) invalid(source, `unsupported manifest schemaVersion ${String(value.schemaVersion)}; supported: legacy, 2; upgrade or migrate the manifest`);
     const pack = id(value.pack, source, 'pack');
     const sensorsInput = record(value.sensors, source, 'sensors');
     const sensors: SensorManifestV2['sensors'] = {};
     for (const name of Object.keys(sensorsInput)) sensors[id(name, source, 'sensor id')] = parseV2Sensor(sensorsInput[name], source, `sensors.${name}`);
     const manifest: SensorManifestV2 = { schemaVersion: 2, pack, sensors };
+    if ('packSelection' in value) {
+        if (value.packSelection !== 'explicit') invalid(source, 'packSelection must be "explicit" when present');
+        manifest.packSelection = 'explicit';
+    }
     if ('registryRoot' in value) manifest.registryRoot = provenanceRoot(value.registryRoot, source);
     if ('concurrency' in value) {
         if (typeof value.concurrency !== 'number' || !Number.isSafeInteger(value.concurrency) || value.concurrency <= 0) invalid(source, 'concurrency must be a positive safe integer');

--- a/cli/src/commands/sensors/compatibility/manifest.ts
+++ b/cli/src/commands/sensors/compatibility/manifest.ts
@@ -10,7 +10,7 @@ export type SensorManifestV2 = {
     schemaVersion: 2;
     pack: string;
     registryRoot?: string;
-    sensors: Record<string, { enabled: boolean; fast?: boolean; variantId: string; command: StructuredCommand; assets?: string[]; initializedCompatibility: CompatibilityEvidence }>;
+    sensors: Record<string, { enabled: boolean; fast?: boolean; variantId: string; command: StructuredCommand; assets?: string[]; policyRef?: 'shared/semgrep-policy.json'; initializedCompatibility: CompatibilityEvidence }>;
     concurrency?: number;
 };
 
@@ -139,7 +139,7 @@ function parseLegacyManifest(value: UnknownRecord, source: unknown): LegacySenso
 
 function parseV2Sensor(input: unknown, source: unknown, location: string): SensorManifestV2['sensors'][string] {
     const value = record(input, source, location);
-    fields(value, ['enabled', 'fast', 'variantId', 'command', 'assets', 'initializedCompatibility'], source, location);
+    fields(value, ['enabled', 'fast', 'variantId', 'command', 'assets', 'policyRef', 'initializedCompatibility'], source, location);
     if (typeof value.enabled !== 'boolean') invalid(source, `${location}.enabled must be a boolean`);
     const sensor: SensorManifestV2['sensors'][string] = {
         enabled: value.enabled, variantId: id(value.variantId, source, `${location}.variantId`),
@@ -151,6 +151,10 @@ function parseV2Sensor(input: unknown, source: unknown, location: string): Senso
     if (sensor.initializedCompatibility.state === 'certified' && (sensor.initializedCompatibility.toolVersion === null || sensor.initializedCompatibility.runtimeVersion === null || sensor.initializedCompatibility.certifiedRange === null)) invalid(source, `${location}.initializedCompatibility certified evidence is incomplete`);
     if (sensor.initializedCompatibility.state === 'certified' && !semver.satisfies(sensor.initializedCompatibility.toolVersion!, sensor.initializedCompatibility.certifiedRange!)) invalid(source, `${location}.initializedCompatibility.toolVersion must satisfy certifiedRange`);
     if ('assets' in value) sensor.assets = stringArray(value.assets, source, `${location}.assets`, true).map((entry, index) => asset(entry, source, `${location}.assets[${index}]`));
+    if ('policyRef' in value) {
+        if (value.policyRef !== 'shared/semgrep-policy.json') invalid(source, `${location}.policyRef must be the contained AWM-owned shared/semgrep-policy.json`);
+        sensor.policyRef = value.policyRef;
+    }
     if ('fast' in value) {
         if (typeof value.fast !== 'boolean') invalid(source, `${location}.fast must be a boolean`);
         sensor.fast = value.fast;

--- a/cli/src/commands/sensors/compatibility/manifest.ts
+++ b/cli/src/commands/sensors/compatibility/manifest.ts
@@ -150,7 +150,7 @@ function parseV2Sensor(input: unknown, source: unknown, location: string): Senso
     if (['certified', 'compatible-unverified', 'incompatible'].includes(sensor.initializedCompatibility.state) && sensor.initializedCompatibility.variantId === null) invalid(source, `${location}.initializedCompatibility.variantId is required for ${sensor.initializedCompatibility.state}`);
     if (sensor.initializedCompatibility.state === 'certified' && (sensor.initializedCompatibility.toolVersion === null || sensor.initializedCompatibility.runtimeVersion === null || sensor.initializedCompatibility.certifiedRange === null)) invalid(source, `${location}.initializedCompatibility certified evidence is incomplete`);
     if (sensor.initializedCompatibility.state === 'certified' && !semver.satisfies(sensor.initializedCompatibility.toolVersion!, sensor.initializedCompatibility.certifiedRange!)) invalid(source, `${location}.initializedCompatibility.toolVersion must satisfy certifiedRange`);
-    if ('assets' in value) sensor.assets = stringArray(value.assets, source, `${location}.assets`, false).map((entry, index) => asset(entry, source, `${location}.assets[${index}]`));
+    if ('assets' in value) sensor.assets = stringArray(value.assets, source, `${location}.assets`, true).map((entry, index) => asset(entry, source, `${location}.assets[${index}]`));
     if ('fast' in value) {
         if (typeof value.fast !== 'boolean') invalid(source, `${location}.fast must be a boolean`);
         sensor.fast = value.fast;

--- a/cli/src/commands/sensors/compatibility/materialize.ts
+++ b/cli/src/commands/sensors/compatibility/materialize.ts
@@ -8,6 +8,7 @@ export type MaterializeInput = {
     projectRoot: string;
     packRoot: string;
     pack: string;
+    packSelection?: 'explicit';
     registryRoot?: string;
     sensors: Record<string, V2Sensor>;
     configure?: boolean;
@@ -76,7 +77,7 @@ export function materializeResolvedSensors(input: MaterializeInput): Materialize
         if (parsed.kind !== 'v2') throw new Error('materialized sensor must be v2');
         sensors[name] = parsed.pack.sensors[name];
     }
-    const manifest: SensorManifestV2 = { schemaVersion: 2, pack, sensors, ...(input.registryRoot ? { registryRoot: input.registryRoot } : {}) };
+    const manifest: SensorManifestV2 = { schemaVersion: 2, pack, sensors, ...(input.packSelection === 'explicit' ? { packSelection: 'explicit' } : {}), ...(input.registryRoot ? { registryRoot: input.registryRoot } : {}) };
     // A policy reference is deliberately not a materialized asset. Resolve it here
     // from the registry-owned sibling only, so a manifest cannot turn arbitrary
     // registry content into a project write through a cosmetic policy field.

--- a/cli/src/commands/sensors/compatibility/materialize.ts
+++ b/cli/src/commands/sensors/compatibility/materialize.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { parseSensorManifest, serializeManifestV2, type SensorManifestV2 } from './manifest';
+import { resolveSemgrepPolicy } from './contract';
 
 type V2Sensor = SensorManifestV2['sensors'][string];
 export type MaterializeInput = {
@@ -76,6 +77,12 @@ export function materializeResolvedSensors(input: MaterializeInput): Materialize
         sensors[name] = parsed.pack.sensors[name];
     }
     const manifest: SensorManifestV2 = { schemaVersion: 2, pack, sensors, ...(input.registryRoot ? { registryRoot: input.registryRoot } : {}) };
+    // A policy reference is deliberately not a materialized asset. Resolve it here
+    // from the registry-owned sibling only, so a manifest cannot turn arbitrary
+    // registry content into a project write through a cosmetic policy field.
+    for (const [name, sensor] of Object.entries(sensors)) {
+        if (sensor.policyRef) resolveSemgrepPolicy(sensor.policyRef, path.join(packRoot, 'pack.json'), `sensors.${name}`);
+    }
     const selected = [...new Set(Object.values(sensors).flatMap(sensor => sensor.assets ?? []))].map((asset, index) => containedAsset(asset, `assets[${index}]`)).sort();
     const prior = priorAssets(projectRoot);
     const configured: string[] = [];

--- a/cli/src/commands/sensors/compatibility/probe.ts
+++ b/cli/src/commands/sensors/compatibility/probe.ts
@@ -3,20 +3,19 @@ import type { CompatibilityProbe, StructuredCommand } from './types';
 
 export type ProbeStatus = 'matched' | 'not-matched' | 'unverifiable';
 export type ProbeResult = { status: ProbeStatus; reason: string };
-export type ProbeEvidence = { cwd: string; toolExecutable?: string; configFiles?: string[]; scripts?: string[] };
+export type ProbeEvidence = { cwd: string; toolExecutable?: string; toolResolution?: StructuredCommand['resolution']; configFiles?: string[]; scripts?: string[] };
 export type ProbeExecutor = (command: StructuredCommand, options: ExecOptions) => Promise<ExecResult>;
 const KINDS = new Set<CompatibilityProbe>(['version', 'eslint-print-config', 'typescript-show-config', 'semgrep-validate', 'package-script-present', 'config-present']);
 
 function commandFor(kind: CompatibilityProbe, evidence: ProbeEvidence): StructuredCommand | null {
     const executable = evidence.toolExecutable ?? (kind.startsWith('typescript') ? 'tsc' : kind.startsWith('eslint') ? 'eslint' : kind.startsWith('semgrep') ? 'semgrep' : 'node');
-    // A tool version certified from local package metadata must be probed through
-    // the same project installation. Only the Node runtime is intentionally PATH
-    // resolved: it is runtime evidence, not a package-local tool assertion.
+    // Probe an executable through the same bounded resolver as its variant's
+    // eventual execution. Falling back preserves legacy probe-only kinds.
     const resolution = executable === 'node'
         ? 'path'
-        : kind === 'semgrep-validate'
+        : evidence.toolResolution ?? (kind === 'semgrep-validate'
             ? 'python-environment'
-            : 'node-modules-bin' as const;
+            : 'node-modules-bin');
     if (kind === 'package-script-present') return null;
     if (kind === 'config-present') return null;
     if (kind === 'version') return { executable, resolution, args: ['--version'] };

--- a/cli/src/commands/sensors/compatibility/probe.ts
+++ b/cli/src/commands/sensors/compatibility/probe.ts
@@ -3,7 +3,7 @@ import type { CompatibilityProbe, StructuredCommand } from './types';
 
 export type ProbeStatus = 'matched' | 'not-matched' | 'unverifiable';
 export type ProbeResult = { status: ProbeStatus; reason: string };
-export type ProbeEvidence = { cwd: string; toolExecutable?: string; toolResolution?: StructuredCommand['resolution']; configFiles?: string[]; scripts?: string[] };
+export type ProbeEvidence = { cwd: string; toolExecutable?: string; toolResolution?: StructuredCommand['resolution']; pythonEnvironmentRoot?: StructuredCommand['pythonEnvironmentRoot']; configFiles?: string[]; scripts?: string[] };
 export type ProbeExecutor = (command: StructuredCommand, options: ExecOptions) => Promise<ExecResult>;
 const KINDS = new Set<CompatibilityProbe>(['version', 'eslint-print-config', 'typescript-show-config', 'semgrep-validate', 'package-script-present', 'config-present']);
 
@@ -18,10 +18,11 @@ function commandFor(kind: CompatibilityProbe, evidence: ProbeEvidence): Structur
             : 'node-modules-bin');
     if (kind === 'package-script-present') return null;
     if (kind === 'config-present') return null;
-    if (kind === 'version') return { executable, resolution, args: ['--version'] };
-    if (kind === 'eslint-print-config') return { executable, resolution, args: ['--print-config', evidence.configFiles?.[0] ?? 'package.json'] };
-    if (kind === 'typescript-show-config') return { executable, resolution, args: ['--showConfig'] };
-    return { executable, resolution, args: ['--validate'] };
+    const command = { executable, resolution, ...(resolution === 'python-environment' && evidence.pythonEnvironmentRoot ? { pythonEnvironmentRoot: evidence.pythonEnvironmentRoot } : {}) };
+    if (kind === 'version') return { ...command, args: ['--version'] };
+    if (kind === 'eslint-print-config') return { ...command, args: ['--print-config', evidence.configFiles?.[0] ?? 'package.json'] };
+    if (kind === 'typescript-show-config') return { ...command, args: ['--showConfig'] };
+    return { ...command, args: ['--validate'] };
 }
 
 /** Executes only the closed probe enum. Raw output is intentionally discarded. */

--- a/cli/src/commands/sensors/compatibility/resolve.ts
+++ b/cli/src/commands/sensors/compatibility/resolve.ts
@@ -3,7 +3,7 @@ import { legacyCompatibility } from './manifest';
 import type { CompatibilityEvidence, SensorPack, SensorPackSensor, SensorVariant } from './types';
 import type { ProjectEvidence } from './discovery';
 
-export type ResolveEvidence = { paths?: string[]; applicable?: boolean; packageManagerConflict?: boolean; toolVersion?: string | null; runtimeVersion?: string | null; toolVersions?: Record<string, string | null>; runtimeVersions?: Record<string, string | null>; os?: NodeJS.Platform; probe?: { status?: string } };
+export type ResolveEvidence = { paths?: string[]; applicable?: boolean; explicitPackSelection?: boolean; packageManagerConflict?: boolean; toolVersion?: string | null; runtimeVersion?: string | null; toolVersions?: Record<string, string | null>; runtimeVersions?: Record<string, string | null>; os?: NodeJS.Platform; probe?: { status?: string } };
 export type ResolveContext = { pack: string; sensor: string };
 
 function result(state: CompatibilityEvidence['state'], reason: string, variant: SensorVariant | null, evidence: ResolveEvidence): CompatibilityEvidence {
@@ -21,7 +21,7 @@ function result(state: CompatibilityEvidence['state'], reason: string, variant: 
 }
 function applies(sensor: SensorPackSensor, evidence: ResolveEvidence): boolean {
     if (sensor.applicability.kind === 'explicit-or-supported-language') {
-        if (evidence.applicable === true) return true;
+        if (evidence.applicable === true || evidence.explicitPackSelection === true) return true;
         const supportedMarkers = new Set(['package.json', 'pyproject.toml', 'requirements.txt', 'setup.py', 'setup.cfg', 'Pipfile']);
         return (evidence.paths ?? []).some(path => supportedMarkers.has(path));
     }

--- a/cli/src/commands/sensors/compatibility/resolve.ts
+++ b/cli/src/commands/sensors/compatibility/resolve.ts
@@ -20,7 +20,11 @@ function result(state: CompatibilityEvidence['state'], reason: string, variant: 
     return { state, reason, variantId: variant?.id ?? null, toolVersion, runtimeVersion, certifiedRange: variant?.certifiedRange ?? null, evidence: refs.slice(0, 32) };
 }
 function applies(sensor: SensorPackSensor, evidence: ResolveEvidence): boolean {
-    if (sensor.applicability.kind === 'explicit-or-supported-language') return evidence.applicable === true;
+    if (sensor.applicability.kind === 'explicit-or-supported-language') {
+        if (evidence.applicable === true) return true;
+        const supportedMarkers = new Set(['package.json', 'pyproject.toml', 'requirements.txt', 'setup.py', 'setup.cfg', 'Pipfile']);
+        return (evidence.paths ?? []).some(path => supportedMarkers.has(path));
+    }
     if (evidence.applicable === false) return false;
     const paths = new Set(evidence.paths ?? []);
     const rule = sensor.applicability;
@@ -74,10 +78,7 @@ export function resolveProjectCompatibility(pack: SensorPack, evidence: ProjectE
         return { sensors };
     }
     for (const [name, sensor] of Object.entries(pack.sensors)) {
-        // Generic is selected explicitly by the caller; never infer that broad
-        // capability merely from arbitrary project files.
-        const resolvedEvidence = pack.name === 'generic' ? { ...evidence, applicable: true } : evidence;
-        sensors[name] = resolveSensorCompatibility(sensor, resolvedEvidence, { pack: pack.name, sensor: name });
+        sensors[name] = resolveSensorCompatibility(sensor, evidence, { pack: pack.name, sensor: name });
     }
     return { sensors };
 }

--- a/cli/src/commands/sensors/compatibility/resolve.ts
+++ b/cli/src/commands/sensors/compatibility/resolve.ts
@@ -3,7 +3,7 @@ import { legacyCompatibility } from './manifest';
 import type { CompatibilityEvidence, SensorPack, SensorPackSensor, SensorVariant } from './types';
 import type { ProjectEvidence } from './discovery';
 
-export type ResolveEvidence = { paths?: string[]; applicable?: boolean; explicitPackSelection?: boolean; packageManagerConflict?: boolean; toolVersion?: string | null; runtimeVersion?: string | null; toolVersions?: Record<string, string | null>; runtimeVersions?: Record<string, string | null>; os?: NodeJS.Platform; probe?: { status?: string } };
+export type ResolveEvidence = { paths?: string[]; applicable?: boolean; packSelection?: 'explicit'; packageManagerConflict?: boolean; toolVersion?: string | null; runtimeVersion?: string | null; toolVersions?: Record<string, string | null>; runtimeVersions?: Record<string, string | null>; os?: NodeJS.Platform; probe?: { status?: string } };
 export type ResolveContext = { pack: string; sensor: string };
 
 function result(state: CompatibilityEvidence['state'], reason: string, variant: SensorVariant | null, evidence: ResolveEvidence): CompatibilityEvidence {
@@ -21,9 +21,7 @@ function result(state: CompatibilityEvidence['state'], reason: string, variant: 
 }
 function applies(sensor: SensorPackSensor, evidence: ResolveEvidence): boolean {
     if (sensor.applicability.kind === 'explicit-or-supported-language') {
-        if (evidence.applicable === true || evidence.explicitPackSelection === true) return true;
-        const supportedMarkers = new Set(['package.json', 'pyproject.toml', 'requirements.txt', 'setup.py', 'setup.cfg', 'Pipfile']);
-        return (evidence.paths ?? []).some(path => supportedMarkers.has(path));
+        return evidence.applicable === true || evidence.packSelection === 'explicit';
     }
     if (evidence.applicable === false) return false;
     const paths = new Set(evidence.paths ?? []);

--- a/cli/src/commands/sensors/compatibility/resolve.ts
+++ b/cli/src/commands/sensors/compatibility/resolve.ts
@@ -20,6 +20,7 @@ function result(state: CompatibilityEvidence['state'], reason: string, variant: 
     return { state, reason, variantId: variant?.id ?? null, toolVersion, runtimeVersion, certifiedRange: variant?.certifiedRange ?? null, evidence: refs.slice(0, 32) };
 }
 function applies(sensor: SensorPackSensor, evidence: ResolveEvidence): boolean {
+    if (sensor.applicability.kind === 'explicit-or-supported-language') return evidence.applicable === true;
     if (evidence.applicable === false) return false;
     const paths = new Set(evidence.paths ?? []);
     const rule = sensor.applicability;

--- a/cli/src/commands/sensors/compatibility/resolve.ts
+++ b/cli/src/commands/sensors/compatibility/resolve.ts
@@ -74,7 +74,10 @@ export function resolveProjectCompatibility(pack: SensorPack, evidence: ProjectE
         return { sensors };
     }
     for (const [name, sensor] of Object.entries(pack.sensors)) {
-        sensors[name] = resolveSensorCompatibility(sensor, evidence, { pack: pack.name, sensor: name });
+        // Generic is selected explicitly by the caller; never infer that broad
+        // capability merely from arbitrary project files.
+        const resolvedEvidence = pack.name === 'generic' ? { ...evidence, applicable: true } : evidence;
+        sensors[name] = resolveSensorCompatibility(sensor, resolvedEvidence, { pack: pack.name, sensor: name });
     }
     return { sensors };
 }

--- a/cli/src/commands/sensors/compatibility/types.ts
+++ b/cli/src/commands/sensors/compatibility/types.ts
@@ -9,6 +9,8 @@ export type CompatibilityState =
 export type StructuredCommand = {
     executable: string;
     resolution: 'node-modules-bin' | 'python-environment' | 'path';
+    /** Discovery-bound virtual environment identity for Python commands. */
+    pythonEnvironmentRoot?: '.venv' | 'venv';
     args: string[];
     /** A script runner is explicit: v2 never guesses npm/pnpm/yarn/bun. */
     packageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun';

--- a/cli/src/commands/sensors/compatibility/types.ts
+++ b/cli/src/commands/sensors/compatibility/types.ts
@@ -12,8 +12,8 @@ export type StructuredCommand = {
     args: string[];
     /** A script runner is explicit: v2 never guesses npm/pnpm/yarn/bun. */
     packageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun';
-    /** Closed execution environment; only contract-approved keys may be set. */
-    environment?: { ESLINT_USE_FLAT_CONFIG: 'false' };
+    /** Closed execution environment; choose ESLint flat config or legacy eslintrc mode explicitly. */
+    environment?: { ESLINT_USE_FLAT_CONFIG: 'true' | 'false' };
     fileInput?: { placeholder: '{files}'; extensions: string[] };
 };
 

--- a/cli/src/commands/sensors/compatibility/types.ts
+++ b/cli/src/commands/sensors/compatibility/types.ts
@@ -42,6 +42,13 @@ export type SensorVariant = {
     command: StructuredCommand;
 };
 
+/**
+ * Stricter pack configuration that is deliberately inert until an explicit opt-in
+ * surface selects it. That future surface must require a named hardening choice and
+ * package-manager/environment resolution before it can materialize any asset.
+ */
+export type SensorPackHardening = Record<string, { assets: string[] }>;
+
 export type SensorPackSensor = {
     applicability: { allFiles?: string[]; anyFiles?: string[]; kind?: string };
     variants: SensorVariant[];
@@ -55,6 +62,7 @@ export type SensorPackV2 = {
     detects: string[];
     sensors: Record<string, SensorPackSensor>;
     coverage: unknown;
+    hardening?: SensorPackHardening;
 };
 
 export type LegacySensorPack = {

--- a/cli/src/commands/sensors/compatibility/types.ts
+++ b/cli/src/commands/sensors/compatibility/types.ts
@@ -43,7 +43,17 @@ export type SensorVariant = {
     assets: string[];
     formatter: string;
     probe: { kind: CompatibilityProbe };
+    /** A registry-owned policy whose compatibility requirements are authoritative. */
+    policyRef?: 'shared/semgrep-policy.json';
     command: StructuredCommand;
+};
+
+export type SemgrepPolicy = {
+    tool: 'semgrep';
+    toolRange: string;
+    runtime: 'python';
+    runtimeRange: string;
+    probe: 'semgrep-validate';
 };
 
 /**

--- a/cli/src/commands/sensors/compatibility/types.ts
+++ b/cli/src/commands/sensors/compatibility/types.ts
@@ -10,6 +10,10 @@ export type StructuredCommand = {
     executable: string;
     resolution: 'node-modules-bin' | 'python-environment' | 'path';
     args: string[];
+    /** A script runner is explicit: v2 never guesses npm/pnpm/yarn/bun. */
+    packageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun';
+    /** Closed execution environment; only contract-approved keys may be set. */
+    environment?: { ESLINT_USE_FLAT_CONFIG: 'false' };
     fileInput?: { placeholder: '{files}'; extensions: string[] };
 };
 

--- a/cli/src/commands/sensors/exec.ts
+++ b/cli/src/commands/sensors/exec.ts
@@ -163,16 +163,22 @@ function collectSpawn(input: SpawnInput, opts: ExecOptions): Promise<ExecResult>
 }
 
 function validateStructuredCommand(command: StructuredCommand): void {
-    if (!command || typeof command !== 'object' || typeof command.executable !== 'string' || (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(command.executable) && !path.isAbsolute(command.executable))) {
+    if (!command || typeof command !== 'object' || typeof command.executable !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(command.executable)) {
         throw new Error('structured command executable must be a safe executable name');
+    }
+    const normalizedExecutable = command.executable.toLowerCase().replace(/\.exe$/, '');
+    if (new Set(['sh', 'bash', 'cmd', 'powershell']).has(normalizedExecutable)) {
+        throw new Error('structured command executable must not be a shell');
     }
     if (!Array.isArray(command.args) || command.args.some(arg => typeof arg !== 'string' || /[\0\r\n]/.test(arg))) {
         throw new Error('structured command args must be an array of single-line strings without NUL');
     }
     if (!['node-modules-bin', 'python-environment', 'path'].includes(command.resolution)) throw new Error('structured command resolution is unsupported');
     const packageManagers = new Set(['npm', 'pnpm', 'yarn', 'bun']);
-    if (packageManagers.has(command.executable) && command.packageManager !== command.executable) throw new Error('structured command packageManager must explicitly match its executable');
-    if (command.packageManager !== undefined && !packageManagers.has(command.packageManager)) throw new Error('structured command packageManager is unsupported');
+    const normalizedPackageManager = typeof command.packageManager === 'string' ? command.packageManager.toLowerCase().replace(/\.exe$/, '') : undefined;
+    if (packageManagers.has(normalizedExecutable) && normalizedPackageManager !== normalizedExecutable) throw new Error('structured command packageManager must explicitly match its executable');
+    if (normalizedPackageManager !== undefined && !packageManagers.has(normalizedPackageManager)) throw new Error('structured command packageManager is unsupported');
+    if (normalizedPackageManager !== undefined && normalizedPackageManager !== normalizedExecutable) throw new Error('structured command packageManager must explicitly match its executable');
     if (command.environment !== undefined && (Object.keys(command.environment).length !== 1 || command.environment.ESLINT_USE_FLAT_CONFIG !== 'false')) throw new Error('structured command environment is not allowlisted');
 }
 

--- a/cli/src/commands/sensors/exec.ts
+++ b/cli/src/commands/sensors/exec.ts
@@ -182,6 +182,10 @@ function validateStructuredCommand(command: StructuredCommand): void {
         }
     }
     if (!['node-modules-bin', 'python-environment', 'path'].includes(command.resolution)) throw new Error('structured command resolution is unsupported');
+    if (command.pythonEnvironmentRoot !== undefined && (command.resolution !== 'python-environment' || (command.pythonEnvironmentRoot !== '.venv' && command.pythonEnvironmentRoot !== 'venv'))) {
+        throw new Error('structured command pythonEnvironmentRoot must name the selected .venv or venv Python environment');
+    }
+    if (command.resolution === 'python-environment' && command.pythonEnvironmentRoot === undefined) throw new Error('python environment command requires a discovery-bound contained local environment root');
     const packageManagers = new Set(['npm', 'pnpm', 'yarn', 'bun']);
     const normalizedPackageManager = typeof command.packageManager === 'string' ? command.packageManager.toLowerCase().replace(/\.exe$/, '') : undefined;
     if (packageManagers.has(normalizedExecutable) && normalizedPackageManager !== normalizedExecutable) throw new Error('structured command packageManager must explicitly match its executable');
@@ -273,8 +277,7 @@ function resolveStructuredExecutable(command: StructuredCommand, cwd: string): s
     const candidates: string[] = [];
     if (command.resolution === 'python-environment') {
         if (path.isAbsolute(command.executable)) throw new Error('python environment executable must be a contained local name');
-        candidates.push(path.join(cwd, '.venv', isWindowsNative() ? 'Scripts' : 'bin', command.executable));
-        candidates.push(path.join(cwd, 'venv', isWindowsNative() ? 'Scripts' : 'bin', command.executable));
+        candidates.push(path.join(cwd, command.pythonEnvironmentRoot!, isWindowsNative() ? 'Scripts' : 'bin', command.executable));
     } else if (path.isAbsolute(command.executable)) candidates.push(command.executable);
     else {
         for (const entry of (process.env.PATH ?? '').split(path.delimiter).filter(Boolean)) candidates.push(path.join(entry, command.executable));

--- a/cli/src/commands/sensors/exec.ts
+++ b/cli/src/commands/sensors/exec.ts
@@ -230,6 +230,22 @@ function regularFile(candidate: string): boolean {
     } catch { return false; }
 }
 
+/** Resolve a Python environment executable only when every selected path
+ * component is a non-symbolic-link local entry. A leaf-only lstat follows a
+ * linked .venv/venv ancestor and can otherwise execute outside the project. */
+function localPythonEnvironmentExecutable(cwd: string, environmentRoot: '.venv' | 'venv', executable: string): string | null {
+    const parts = [environmentRoot, isWindowsNative() ? 'Scripts' : 'bin', executable];
+    let candidate = cwd;
+    try {
+        for (const part of parts) {
+            candidate = path.join(candidate, part);
+            const stat = fs.lstatSync(candidate);
+            if (stat.isSymbolicLink()) return null;
+        }
+        return fs.lstatSync(candidate).isFile() ? candidate : null;
+    } catch { return null; }
+}
+
 function containedPath(root: string, candidate: string): boolean {
     const relative = path.relative(root, candidate);
     return relative !== '' && !relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative);
@@ -277,7 +293,20 @@ function resolveStructuredExecutable(command: StructuredCommand, cwd: string): s
     const candidates: string[] = [];
     if (command.resolution === 'python-environment') {
         if (path.isAbsolute(command.executable)) throw new Error('python environment executable must be a contained local name');
-        candidates.push(path.join(cwd, command.pythonEnvironmentRoot!, isWindowsNative() ? 'Scripts' : 'bin', command.executable));
+        if (!isWindowsNative()) {
+            const local = localPythonEnvironmentExecutable(cwd, command.pythonEnvironmentRoot!, command.executable);
+            if (local) return local;
+            throw new Error('python environment executable is not a contained local regular file');
+        }
+        const extensions = safeWindowsExecutableExtensions();
+        if (extensions.length === 0) throw new Error('PATHEXT contains no safe Windows executable extension for structured commands');
+        for (const executable of [command.executable, ...extensions.map(extension => command.executable + extension)]) {
+            const lower = executable.toLowerCase();
+            if (lower.endsWith('.cmd') || lower.endsWith('.bat')) throw new Error('structured commands cannot execute Windows command wrappers');
+            const local = localPythonEnvironmentExecutable(cwd, command.pythonEnvironmentRoot!, executable);
+            if (local && extensions.some(extension => lower.endsWith(extension))) return local;
+        }
+        throw new Error('python environment executable is not a contained local regular file');
     } else if (path.isAbsolute(command.executable)) candidates.push(command.executable);
     else {
         for (const entry of (process.env.PATH ?? '').split(path.delimiter).filter(Boolean)) candidates.push(path.join(entry, command.executable));
@@ -285,7 +314,6 @@ function resolveStructuredExecutable(command: StructuredCommand, cwd: string): s
     if (!isWindowsNative()) {
         const found = candidates.find(regularFile);
         if (found) return found;
-        if (command.resolution === 'python-environment') throw new Error('python environment executable is not a contained local regular file');
         return command.executable;
     }
     const extensions = safeWindowsExecutableExtensions();
@@ -296,7 +324,6 @@ function resolveStructuredExecutable(command: StructuredCommand, cwd: string): s
         if (regularFile(candidate) && extensions.some(ext => lower.endsWith(ext))) return candidate;
         for (const extension of extensions) if (regularFile(candidate + extension)) return candidate + extension;
     }
-    if (command.resolution === 'python-environment') throw new Error('python environment executable is not a contained local regular file');
     return command.executable;
 }
 

--- a/cli/src/commands/sensors/exec.ts
+++ b/cli/src/commands/sensors/exec.ts
@@ -27,7 +27,7 @@ export type ExecOptions = {
     killGraceMs?: number;
 };
 
-type SpawnInput = { executable: string; args: string[]; shell: boolean; environment?: { ESLINT_USE_FLAT_CONFIG: 'false' } };
+type SpawnInput = { executable: string; args: string[]; shell: boolean; environment?: { ESLINT_USE_FLAT_CONFIG: 'true' | 'false' } };
 
 const DEFAULT_MAX_BUFFER = 64 * 1024 * 1024;
 const DEFAULT_KILL_GRACE_MS = 2_000;
@@ -187,7 +187,14 @@ function validateStructuredCommand(command: StructuredCommand): void {
     if (packageManagers.has(normalizedExecutable) && normalizedPackageManager !== normalizedExecutable) throw new Error('structured command packageManager must explicitly match its executable');
     if (normalizedPackageManager !== undefined && !packageManagers.has(normalizedPackageManager)) throw new Error('structured command packageManager is unsupported');
     if (normalizedPackageManager !== undefined && normalizedPackageManager !== normalizedExecutable) throw new Error('structured command packageManager must explicitly match its executable');
-    if (command.environment !== undefined && (Object.keys(command.environment).length !== 1 || command.environment.ESLINT_USE_FLAT_CONFIG !== 'false')) throw new Error('structured command environment is not allowlisted');
+    if (command.environment !== undefined) {
+        const environment = command.environment as unknown;
+        if (!environment || typeof environment !== 'object' || Array.isArray(environment) || Object.keys(environment).length !== 1 || !Object.prototype.hasOwnProperty.call(environment, 'ESLINT_USE_FLAT_CONFIG')) {
+            throw new Error('structured command environment must be the exact allowlisted ESLINT_USE_FLAT_CONFIG=true or false mapping');
+        }
+        const flatConfig = (environment as { ESLINT_USE_FLAT_CONFIG?: unknown }).ESLINT_USE_FLAT_CONFIG;
+        if (flatConfig !== 'true' && flatConfig !== 'false') throw new Error('structured command environment must be the exact allowlisted ESLINT_USE_FLAT_CONFIG=true or false mapping');
+    }
     const fileArguments = command.args.filter(arg => arg === '{files}').length;
     if (command.fileInput === undefined) {
         if (fileArguments !== 0) throw new Error('structured command {files} argument requires fileInput');

--- a/cli/src/commands/sensors/exec.ts
+++ b/cli/src/commands/sensors/exec.ts
@@ -27,7 +27,7 @@ export type ExecOptions = {
     killGraceMs?: number;
 };
 
-type SpawnInput = { executable: string; args: string[]; shell: boolean };
+type SpawnInput = { executable: string; args: string[]; shell: boolean; environment?: { ESLINT_USE_FLAT_CONFIG: 'false' } };
 
 const DEFAULT_MAX_BUFFER = 64 * 1024 * 1024;
 const DEFAULT_KILL_GRACE_MS = 2_000;
@@ -104,8 +104,9 @@ function collectSpawn(input: SpawnInput, opts: ExecOptions): Promise<ExecResult>
             })
             : spawn(input.executable, input.args, {
                 shell: false,
-            cwd: opts.cwd,
-            detached: !isWindowsNative(),
+                cwd: opts.cwd,
+                detached: !isWindowsNative(),
+                ...(input.environment ? { env: { ...process.env, ...input.environment } } : {}),
             // stdin closed: a sensor must never block waiting for input, and the
             // EOF also tells watch-mode-capable tools (vitest, jest) to run once.
             stdio: ['ignore', 'pipe', 'pipe'],
@@ -169,6 +170,10 @@ function validateStructuredCommand(command: StructuredCommand): void {
         throw new Error('structured command args must be an array of single-line strings without NUL');
     }
     if (!['node-modules-bin', 'python-environment', 'path'].includes(command.resolution)) throw new Error('structured command resolution is unsupported');
+    const packageManagers = new Set(['npm', 'pnpm', 'yarn', 'bun']);
+    if (packageManagers.has(command.executable) && command.packageManager !== command.executable) throw new Error('structured command packageManager must explicitly match its executable');
+    if (command.packageManager !== undefined && !packageManagers.has(command.packageManager)) throw new Error('structured command packageManager is unsupported');
+    if (command.environment !== undefined && (Object.keys(command.environment).length !== 1 || command.environment.ESLINT_USE_FLAT_CONFIG !== 'false')) throw new Error('structured command environment is not allowlisted');
 }
 
 function regularFile(candidate: string): boolean {
@@ -250,7 +255,7 @@ function resolveStructuredExecutable(command: StructuredCommand, cwd: string): s
 /** Execute a v2 command as an executable plus literal argv; it never starts a shell. */
 export function runStructuredCommand(command: StructuredCommand, opts: ExecOptions): Promise<ExecResult> {
     validateStructuredCommand(command);
-    return collectSpawn({ executable: resolveStructuredExecutable(command, opts.cwd), args: command.args, shell: false }, opts);
+    return collectSpawn({ executable: resolveStructuredExecutable(command, opts.cwd), args: command.args, shell: false, environment: command.environment }, opts);
 }
 
 /** Legacy sensor strings intentionally retain their documented shell semantics. */

--- a/cli/src/commands/sensors/exec.ts
+++ b/cli/src/commands/sensors/exec.ts
@@ -170,8 +170,16 @@ function validateStructuredCommand(command: StructuredCommand): void {
     if (new Set(['sh', 'bash', 'cmd', 'powershell']).has(normalizedExecutable)) {
         throw new Error('structured command executable must not be a shell');
     }
-    if (!Array.isArray(command.args) || command.args.some(arg => typeof arg !== 'string' || /[\0\r\n]/.test(arg))) {
-        throw new Error('structured command args must be an array of single-line strings without NUL');
+    if (!Array.isArray(command.args) || command.args.length === 0) {
+        throw new Error('structured command args must be a nonempty array');
+    }
+    for (const [index, arg] of command.args.entries()) {
+        if (typeof arg !== 'string' || arg.trim() === '' || /[\0\r\n]/.test(arg)) {
+            throw new Error(`structured command args[${index}] must be a nonempty single-line string without NUL`);
+        }
+        if (arg.includes('{files}') && arg !== '{files}') {
+            throw new Error(`structured command args[${index}] must not embed {files}`);
+        }
     }
     if (!['node-modules-bin', 'python-environment', 'path'].includes(command.resolution)) throw new Error('structured command resolution is unsupported');
     const packageManagers = new Set(['npm', 'pnpm', 'yarn', 'bun']);
@@ -180,6 +188,28 @@ function validateStructuredCommand(command: StructuredCommand): void {
     if (normalizedPackageManager !== undefined && !packageManagers.has(normalizedPackageManager)) throw new Error('structured command packageManager is unsupported');
     if (normalizedPackageManager !== undefined && normalizedPackageManager !== normalizedExecutable) throw new Error('structured command packageManager must explicitly match its executable');
     if (command.environment !== undefined && (Object.keys(command.environment).length !== 1 || command.environment.ESLINT_USE_FLAT_CONFIG !== 'false')) throw new Error('structured command environment is not allowlisted');
+    const fileArguments = command.args.filter(arg => arg === '{files}').length;
+    if (command.fileInput === undefined) {
+        if (fileArguments !== 0) throw new Error('structured command {files} argument requires fileInput');
+        return;
+    }
+    const fileInput = command.fileInput as unknown;
+    if (!fileInput || typeof fileInput !== 'object' || Array.isArray(fileInput) || Object.keys(fileInput).length !== 2 || !Object.prototype.hasOwnProperty.call(fileInput, 'placeholder') || !Object.prototype.hasOwnProperty.call(fileInput, 'extensions')) {
+        throw new Error('structured command fileInput must contain only placeholder and extensions');
+    }
+    const { placeholder, extensions } = fileInput as { placeholder?: unknown; extensions?: unknown };
+    if (placeholder !== '{files}') throw new Error('structured command fileInput.placeholder must be {files}');
+    if (!Array.isArray(extensions) || extensions.length === 0 || extensions.some(extension => typeof extension !== 'string' || extension.trim() === '' || /[\0\r\n]/.test(extension) || !/^\.[A-Za-z0-9]+$/.test(extension))) {
+        throw new Error('structured command fileInput.extensions must be a nonempty array of extensions');
+    }
+    if (fileArguments !== 1) throw new Error('structured command fileInput requires exactly one {files} argument');
+}
+
+function safeWindowsExecutableExtensions(): string[] {
+    return (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD')
+        .split(';')
+        .map(ext => ext.toLowerCase())
+        .filter(ext => ext === '.exe' || ext === '.com');
 }
 
 function regularFile(candidate: string): boolean {
@@ -222,7 +252,8 @@ function resolveStructuredExecutable(command: StructuredCommand, cwd: string): s
             if (local) return local;
             throw new Error('node_modules executable is not a contained local file');
         }
-        const extensions = (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD').split(';').map(ext => ext.toLowerCase()).filter(ext => ext === '.exe' || ext === '.com');
+        const extensions = safeWindowsExecutableExtensions();
+        if (extensions.length === 0) throw new Error('PATHEXT contains no safe Windows executable extension for structured commands');
         const candidates = [path.join(bin, command.executable), ...extensions.map(extension => path.join(bin, command.executable + extension))];
         for (const candidate of candidates) {
             const lower = candidate.toLowerCase();
@@ -247,7 +278,8 @@ function resolveStructuredExecutable(command: StructuredCommand, cwd: string): s
         if (command.resolution === 'python-environment') throw new Error('python environment executable is not a contained local regular file');
         return command.executable;
     }
-    const extensions = (process.env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD').split(';').map(ext => ext.toLowerCase()).filter(ext => ext === '.exe' || ext === '.com');
+    const extensions = safeWindowsExecutableExtensions();
+    if (extensions.length === 0) throw new Error('PATHEXT contains no safe Windows executable extension for structured commands');
     for (const candidate of candidates) {
         const lower = candidate.toLowerCase();
         if (lower.endsWith('.cmd') || lower.endsWith('.bat')) throw new Error('structured commands cannot execute Windows command wrappers');

--- a/cli/src/commands/sensors/init.ts
+++ b/cli/src/commands/sensors/init.ts
@@ -280,7 +280,7 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
         const resolvedV2 = readV2Pack(resolvedPack, opts.registryRoot);
         if (resolvedV2) {
             const packSelection = opts.pack ? 'explicit' as const : undefined;
-            const compatibility = (await resolveParsedPackCompatibility(cwd, resolvedV2.pack, { explicitPackSelection: packSelection === 'explicit' })).sensors;
+            const compatibility = (await resolveParsedPackCompatibility(cwd, resolvedV2.pack, { packSelection })).sensors;
             const sensors: Record<string, any> = {};
             for (const [name, sensor] of Object.entries(resolvedV2.pack.sensors)) {
                 const resolved = compatibility[name];

--- a/cli/src/commands/sensors/init.ts
+++ b/cli/src/commands/sensors/init.ts
@@ -279,7 +279,8 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
     if (opts.registryRoot) {
         const resolvedV2 = readV2Pack(resolvedPack, opts.registryRoot);
         if (resolvedV2) {
-            const compatibility = (await resolveParsedPackCompatibility(cwd, resolvedV2.pack)).sensors;
+            const packSelection = opts.pack ? 'explicit' as const : undefined;
+            const compatibility = (await resolveParsedPackCompatibility(cwd, resolvedV2.pack, { explicitPackSelection: packSelection === 'explicit' })).sensors;
             const sensors: Record<string, any> = {};
             for (const [name, sensor] of Object.entries(resolvedV2.pack.sensors)) {
                 const resolved = compatibility[name];
@@ -308,7 +309,7 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
             }
             const materialized = materializeResolvedSensors({
                 projectRoot: cwd, packRoot: resolvedV2.packRoot,
-                pack: resolvedPack, registryRoot: opts.registryRoot, sensors, configure,
+                pack: resolvedPack, ...(packSelection ? { packSelection } : {}), registryRoot: opts.registryRoot, sensors, configure,
             });
             return { detection, ...materialized,
                 compatibility, ...(unavailablePack ? { unavailablePack } : {}) };

--- a/cli/src/commands/sensors/init.ts
+++ b/cli/src/commands/sensors/init.ts
@@ -299,6 +299,7 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
                         variantId: variant.id,
                         command: variant.command,
                         assets: variant.assets,
+                        ...(variant.policyRef ? { policyRef: variant.policyRef } : {}),
                         initializedCompatibility: migratedOverride
                             ? { ...resolved, state: 'compatible-unverified', reason: 'legacy custom command requires explicit v2 migration' }
                             : resolved,

--- a/cli/src/commands/sensors/init.ts
+++ b/cli/src/commands/sensors/init.ts
@@ -280,9 +280,10 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
         const resolvedV2 = readV2Pack(resolvedPack, opts.registryRoot);
         if (resolvedV2) {
             const packSelection = opts.pack ? 'explicit' as const : undefined;
-            const compatibility = (await resolveParsedPackCompatibility(cwd, resolvedV2.pack, { packSelection })).sensors;
+            const live = await resolveParsedPackCompatibility(cwd, resolvedV2.pack, { packSelection });
+            const compatibility = live.sensors;
             const sensors: Record<string, any> = {};
-            for (const [name, sensor] of Object.entries(resolvedV2.pack.sensors)) {
+            for (const [name, sensor] of Object.entries(live.pack.sensors)) {
                 const resolved = compatibility[name];
                 const variant = resolved.variantId === null ? null : sensor.variants.find(candidate => candidate.id === resolved.variantId) ?? null;
                 // Unresolved states do not receive an arbitrary command. They remain

--- a/cli/src/commands/sensors/run.ts
+++ b/cli/src/commands/sensors/run.ts
@@ -75,7 +75,7 @@ function readManifest(cwd: string): SensorManifest | null {
 async function resolveLiveV2(cwd: string, manifest: ReturnType<typeof parseSensorManifest>): Promise<Awaited<ReturnType<typeof resolveLiveCompatibility>> | null> {
     if (manifest.kind !== 'v2') return null;
     try {
-        return await resolveLiveCompatibility(cwd, manifest.pack.pack, manifest.pack.registryRoot, { explicitPackSelection: manifest.pack.packSelection === 'explicit' });
+        return await resolveLiveCompatibility(cwd, manifest.pack.pack, manifest.pack.registryRoot, { packSelection: manifest.pack.packSelection });
     } catch { return null; }
 }
 

--- a/cli/src/commands/sensors/run.ts
+++ b/cli/src/commands/sensors/run.ts
@@ -75,7 +75,7 @@ function readManifest(cwd: string): SensorManifest | null {
 async function resolveLiveV2(cwd: string, manifest: ReturnType<typeof parseSensorManifest>): Promise<Awaited<ReturnType<typeof resolveLiveCompatibility>> | null> {
     if (manifest.kind !== 'v2') return null;
     try {
-        return await resolveLiveCompatibility(cwd, manifest.pack.pack, manifest.pack.registryRoot);
+        return await resolveLiveCompatibility(cwd, manifest.pack.pack, manifest.pack.registryRoot, { explicitPackSelection: manifest.pack.packSelection === 'explicit' });
     } catch { return null; }
 }
 

--- a/cli/src/commands/sensors/status.ts
+++ b/cli/src/commands/sensors/status.ts
@@ -68,7 +68,7 @@ export async function computeSensorStatus(cwd: string = process.cwd()): Promise<
             const checks: Record<string, SensorCheck> = {};
             let live: Awaited<ReturnType<typeof resolveLiveCompatibility>>;
             try {
-                live = await resolveLiveCompatibility(cwd, parsed.pack.pack, parsed.pack.registryRoot, { explicitPackSelection: parsed.pack.packSelection === 'explicit' });
+                live = await resolveLiveCompatibility(cwd, parsed.pack.pack, parsed.pack.registryRoot, { packSelection: parsed.pack.packSelection });
             } catch (error) {
                 const detail = `compatibility revalidation failed: ${error instanceof Error ? error.message : String(error)}`;
                 for (const [name, sensor] of Object.entries(parsed.pack.sensors)) {

--- a/cli/src/commands/sensors/status.ts
+++ b/cli/src/commands/sensors/status.ts
@@ -68,7 +68,7 @@ export async function computeSensorStatus(cwd: string = process.cwd()): Promise<
             const checks: Record<string, SensorCheck> = {};
             let live: Awaited<ReturnType<typeof resolveLiveCompatibility>>;
             try {
-                live = await resolveLiveCompatibility(cwd, parsed.pack.pack, parsed.pack.registryRoot);
+                live = await resolveLiveCompatibility(cwd, parsed.pack.pack, parsed.pack.registryRoot, { explicitPackSelection: parsed.pack.packSelection === 'explicit' });
             } catch (error) {
                 const detail = `compatibility revalidation failed: ${error instanceof Error ? error.message : String(error)}`;
                 for (const [name, sensor] of Object.entries(parsed.pack.sensors)) {

--- a/cli/tests/commands/sensors/compatibility/contract.test.ts
+++ b/cli/tests/commands/sensors/compatibility/contract.test.ts
@@ -59,6 +59,18 @@ describe('sensor pack v2 contract', () => {
         });
     });
 
+    it('accepts only the explicit ESLint v8 environment and package-manager selection', () => {
+        const command = {
+            executable: 'npm',
+            resolution: 'path',
+            args: ['run', 'lint'],
+            packageManager: 'npm',
+            environment: { ESLINT_USE_FLAT_CONFIG: 'false' },
+        };
+        expect(parseSensorPack({ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command }] } } }, 'pack.json'))
+            .toMatchObject({ kind: 'v2', pack: { sensors: { lint: { variants: [{ command }] } } } });
+    });
+
     it('keeps an unversioned pack on the legacy compatibility path', () => {
         const legacy = { name: 'legacy', sensors: {} };
         expect(parseSensorPack(legacy, 'pack.json')).toMatchObject({ kind: 'legacy', pack: { ...legacy, compatibility: { state: 'compatible-unverified' } } });
@@ -116,6 +128,9 @@ describe('sensor pack v2 contract', () => {
         [{ ...validPack(), sensors: { lint: { variants: [validPack().sensors.lint.variants[0], { ...validPack().sensors.lint.variants[0], id: 'eslint-9-next', certifiedRange: '>=9.1.0 <10.0.0' }] } } }, 'overlap'],
         [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], assets: ['C:/secret'] }] } } }, 'asset'],
         [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command: { executable: 'cmd.exe', resolution: 'path', args: ['x'] } }] } } }, 'executable'],
+        [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command: { executable: 'npm', resolution: 'path', args: ['run', 'lint'] } }] } } }, 'packageManager'],
+        [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command: { executable: 'npm', resolution: 'path', args: ['run', 'lint'], packageManager: 'pnpm' } }] } } }, 'match executable'],
+        [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command: { ...validPack().sensors.lint.variants[0].command, environment: { NODE_OPTIONS: '--require unsafe' } } }] } } }, 'environment'],
         [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command: { ...validPack().sensors.lint.variants[0].command, args: ['prefix{files}'] } }] } } }, 'embed'],
         [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], formatter: 'bad\nformat' }] } } }, 'formatter'],
         [{ ...validPack(), hardening: { 'typescript-strict': { assets: ['../tsconfig.awm.json'] } } }, 'asset'],

--- a/cli/tests/commands/sensors/compatibility/contract.test.ts
+++ b/cli/tests/commands/sensors/compatibility/contract.test.ts
@@ -71,6 +71,23 @@ describe('sensor pack v2 contract', () => {
             .toMatchObject({ kind: 'v2', pack: { sensors: { lint: { variants: [{ command }] } } } });
     });
 
+    it('normalizes package-manager executable spelling before enforcing its explicit selection', () => {
+        const variant = validPack().sensors.lint.variants[0];
+        const withExecutable = (executable: string, packageManager?: string) => ({
+            ...validPack(),
+            sensors: { lint: { ...validPack().sensors.lint, variants: [{
+                ...variant,
+                command: { executable, resolution: 'path', args: ['run', 'lint'], ...(packageManager === undefined ? {} : { packageManager }) },
+            }] } },
+        });
+
+        expect(() => parseSensorPack(withExecutable('NPM'), 'pack.json')).toThrow('packageManager');
+        expect(parseSensorPack(withExecutable('npm.exe', 'NPM'), 'pack.json')).toMatchObject({
+            kind: 'v2', pack: { sensors: { lint: { variants: [{ command: { executable: 'npm.exe', packageManager: 'npm' } }] } } },
+        });
+        expect(() => parseSensorPack(withExecutable('NPM', 'pnpm'), 'pack.json')).toThrow('match executable');
+    });
+
     it('keeps an unversioned pack on the legacy compatibility path', () => {
         const legacy = { name: 'legacy', sensors: {} };
         expect(parseSensorPack(legacy, 'pack.json')).toMatchObject({ kind: 'legacy', pack: { ...legacy, compatibility: { state: 'compatible-unverified' } } });

--- a/cli/tests/commands/sensors/compatibility/contract.test.ts
+++ b/cli/tests/commands/sensors/compatibility/contract.test.ts
@@ -59,16 +59,25 @@ describe('sensor pack v2 contract', () => {
         });
     });
 
-    it('accepts only the explicit ESLint v8 environment and package-manager selection', () => {
+    it.each(['true', 'false'] as const)('accepts the exact ESLINT_USE_FLAT_CONFIG=%s environment mapping', flatConfig => {
         const command = {
             executable: 'npm',
             resolution: 'path',
             args: ['run', 'lint'],
             packageManager: 'npm',
-            environment: { ESLINT_USE_FLAT_CONFIG: 'false' },
+            environment: { ESLINT_USE_FLAT_CONFIG: flatConfig },
         };
         expect(parseSensorPack({ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command }] } } }, 'pack.json'))
             .toMatchObject({ kind: 'v2', pack: { sensors: { lint: { variants: [{ command }] } } } });
+    });
+
+    it.each([
+        { ESLINT_USE_FLAT_CONFIG: 'yes' },
+        { ESLINT_USE_FLAT_CONFIG: 'true', OTHER: 'value' },
+    ])('rejects an unknown or expanded ESLint environment mapping', environment => {
+        const command = { executable: 'npm', resolution: 'path', args: ['run', 'lint'], packageManager: 'npm', environment };
+        expect(() => parseSensorPack({ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command }] } } }, 'pack.json'))
+            .toThrow('command.environment');
     });
 
     it('normalizes package-manager executable spelling before enforcing its explicit selection', () => {

--- a/cli/tests/commands/sensors/compatibility/contract.test.ts
+++ b/cli/tests/commands/sensors/compatibility/contract.test.ts
@@ -1,4 +1,7 @@
 import { assertNoEqualPriorityOverlap, parseSensorPack } from '../../../../src/commands/sensors/compatibility/contract';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 const coverage = {
     schemaVersion: 1,
@@ -38,6 +41,40 @@ function validPack() {
 }
 
 describe('sensor pack v2 contract', () => {
+    it('derives Semgrep compatibility from a contained shared policy reference', () => {
+        const sensorPacks = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-policy-'));
+        const packDir = path.join(sensorPacks, 'python');
+        try {
+            fs.mkdirSync(path.join(sensorPacks, 'shared'), { recursive: true });
+            fs.mkdirSync(packDir);
+            fs.writeFileSync(path.join(sensorPacks, 'shared', 'semgrep-policy.json'), JSON.stringify({
+                tool: 'semgrep', toolRange: '>=1.0.0', runtime: 'python', runtimeRange: '>=3.9.0', probe: 'semgrep-validate',
+            }));
+            const pack = validPack();
+            pack.sensors.lint.variants[0] = {
+                id: 'semgrep-python', priority: 10, certifiedRange: '>=1.0.0', policyRef: 'shared/semgrep-policy.json',
+                command: { executable: 'semgrep', resolution: 'path', args: ['--config', '.semgrep.awm.yml', '--json', '.'] },
+                assets: ['.semgrep.awm.yml'], formatter: 'semgrep',
+            } as any;
+            const parsed = parseSensorPack(pack, path.join(packDir, 'pack.json'));
+            expect(parsed).toMatchObject({ kind: 'v2', pack: { sensors: { lint: { variants: [{
+                policyRef: 'shared/semgrep-policy.json', requirements: { tool: 'semgrep', runtime: 'python' }, probe: { kind: 'semgrep-validate' },
+            }] } } } });
+        } finally {
+            fs.rmSync(sensorPacks, { recursive: true, force: true });
+        }
+    });
+
+    it('fails closed when a policy reference is not the AWM-owned shared Semgrep policy', () => {
+        const pack = validPack();
+        pack.sensors.lint.variants[0] = {
+            id: 'semgrep-python', priority: 10, certifiedRange: '>=1.0.0', policyRef: '../secret.json',
+            command: { executable: 'semgrep', resolution: 'path', args: ['--config', '.semgrep.awm.yml', '--json', '.'] },
+            assets: ['.semgrep.awm.yml'], formatter: 'semgrep',
+        } as any;
+        expect(() => parseSensorPack(pack, '/tmp/sensor-packs/python/pack.json')).toThrow('policyRef');
+    });
+
     it('parses a valid versioned pack', () => {
         expect(parseSensorPack(validPack(), 'pack.json')).toMatchObject({ kind: 'v2', pack: validPack() });
     });

--- a/cli/tests/commands/sensors/compatibility/contract.test.ts
+++ b/cli/tests/commands/sensors/compatibility/contract.test.ts
@@ -42,6 +42,23 @@ describe('sensor pack v2 contract', () => {
         expect(parseSensorPack(validPack(), 'pack.json')).toMatchObject({ kind: 'v2', pack: validPack() });
     });
 
+    it('accepts an opt-in hardening asset while variants may require no assets', () => {
+        const pack = {
+            ...validPack(),
+            hardening: { 'typescript-strict': { assets: ['tsconfig.awm.json'] } },
+            sensors: {
+                lint: {
+                    ...validPack().sensors.lint,
+                    variants: [{ ...validPack().sensors.lint.variants[0], assets: [] }],
+                },
+            },
+        };
+        expect(parseSensorPack(pack, 'pack.json')).toMatchObject({
+            kind: 'v2',
+            pack: { hardening: { 'typescript-strict': { assets: ['tsconfig.awm.json'] } }, sensors: { lint: { variants: [{ assets: [] }] } } },
+        });
+    });
+
     it('keeps an unversioned pack on the legacy compatibility path', () => {
         const legacy = { name: 'legacy', sensors: {} };
         expect(parseSensorPack(legacy, 'pack.json')).toMatchObject({ kind: 'legacy', pack: { ...legacy, compatibility: { state: 'compatible-unverified' } } });
@@ -101,6 +118,9 @@ describe('sensor pack v2 contract', () => {
         [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command: { executable: 'cmd.exe', resolution: 'path', args: ['x'] } }] } } }, 'executable'],
         [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], command: { ...validPack().sensors.lint.variants[0].command, args: ['prefix{files}'] } }] } } }, 'embed'],
         [{ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...validPack().sensors.lint.variants[0], formatter: 'bad\nformat' }] } } }, 'formatter'],
+        [{ ...validPack(), hardening: { 'typescript-strict': { assets: ['../tsconfig.awm.json'] } } }, 'asset'],
+        [{ ...validPack(), hardening: { 'typescript-strict': { assets: [] } } }, 'hardening'],
+        [{ ...validPack(), hardening: { 'typescript-strict': { assets: ['tsconfig.awm.json'], command: {} } } }, 'unknown field'],
     ])('rejects malformed pack %j', (input, message) => {
         expect(() => parseSensorPack(input, 'pack.json')).toThrow(message);
     });

--- a/cli/tests/commands/sensors/compatibility/live.test.ts
+++ b/cli/tests/commands/sensors/compatibility/live.test.ts
@@ -51,4 +51,34 @@ describe('resolveParsedPackCompatibility — contained Python commands', () => {
             fs.rmSync(global, { recursive: true, force: true });
         }
     });
+
+    it('never falls back from the discovered .venv to a sibling venv executable', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-environment-identity-'));
+        try {
+            const discoveredSitePackages = path.join(root, '.venv', 'lib', 'python3.12', 'site-packages');
+            const siblingBin = path.join(root, 'venv', 'bin');
+            fs.mkdirSync(path.join(discoveredSitePackages, 'semgrep-1.91.0.dist-info'), { recursive: true });
+            fs.mkdirSync(siblingBin, { recursive: true });
+            fs.writeFileSync(path.join(root, '.venv', 'pyvenv.cfg'), 'version = 3.12.4\n');
+            fs.writeFileSync(path.join(discoveredSitePackages, 'semgrep-1.91.0.dist-info', 'METADATA'), 'Name: semgrep\nVersion: 1.91.0\n');
+            fs.writeFileSync(path.join(siblingBin, 'semgrep'), '#!/bin/sh\necho sibling-semgrep\n', { mode: 0o755 });
+            fs.writeFileSync(path.join(root, 'pyproject.toml'), '[project]\nname = "sample"\n');
+
+            const pack = {
+                schemaVersion: 2, name: 'python', description: 'test', detects: ['pyproject.toml'], coverage: {},
+                sensors: { security: { applicability: { allFiles: ['pyproject.toml'] }, variants: [{
+                    id: 'semgrep-1', priority: 1, certifiedRange: '>=1 <2',
+                    requirements: { tool: 'semgrep', toolRange: '>=1 <2', runtime: 'python', runtimeRange: '>=3.12 <4' },
+                    assets: [], formatter: 'semgrep', probe: { kind: 'semgrep-validate' },
+                    command: { executable: 'semgrep', resolution: 'path', args: ['--validate'] },
+                }] } },
+            } as any;
+
+            const live = await resolveParsedPackCompatibility(root, pack);
+
+            expect(live.sensors.security).toMatchObject({ state: 'unverifiable', reason: 'probe-inconclusive', toolVersion: '1.91.0' });
+            expect(() => runStructuredCommand(live.pack.sensors.security.variants[0].command, { cwd: root, timeout: 5_000 }))
+                .toThrow('python environment executable is not a contained local regular file');
+        } finally { fs.rmSync(root, { recursive: true, force: true }); }
+    });
 });

--- a/cli/tests/commands/sensors/compatibility/live.test.ts
+++ b/cli/tests/commands/sensors/compatibility/live.test.ts
@@ -3,20 +3,26 @@ import os from 'os';
 import path from 'path';
 import { resolveParsedPackCompatibility } from '../../../../src/commands/sensors/compatibility/live';
 import { runStructuredCommand } from '../../../../src/commands/sensors/exec';
+import { createSemgrepVenvFixture } from './python-venv-fixture';
 
 describe('resolveParsedPackCompatibility — contained Python commands', () => {
+    test.each([
+        ['linux', ['.venv', 'bin', 'semgrep']],
+        ['win32', ['.venv', 'Scripts', 'semgrep.exe']],
+    ] as const)('creates a local Semgrep executable in the %s virtual-environment layout', (targetPlatform, executableParts) => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-venv-layout-'));
+        try {
+            createSemgrepVenvFixture(root, targetPlatform);
+            expect(fs.lstatSync(path.join(root, ...executableParts)).isFile()).toBe(true);
+        } finally { fs.rmSync(root, { recursive: true, force: true }); }
+    });
+
     it('binds Semgrep discovery, probe, and execution to the same local virtual-environment executable', async () => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-contained-'));
         const global = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-global-'));
         const savedPath = process.env.PATH;
         try {
-            const localBin = path.join(root, '.venv', 'bin');
-            const sitePackages = path.join(root, '.venv', 'lib', 'python3.12', 'site-packages');
-            fs.mkdirSync(localBin, { recursive: true });
-            fs.mkdirSync(path.join(sitePackages, 'semgrep-1.91.0.dist-info'), { recursive: true });
-            fs.writeFileSync(path.join(root, '.venv', 'pyvenv.cfg'), 'version = 3.12.4\n');
-            fs.writeFileSync(path.join(sitePackages, 'semgrep-1.91.0.dist-info', 'METADATA'), 'Name: semgrep\nVersion: 1.91.0\n');
-            fs.writeFileSync(path.join(localBin, 'semgrep'), '#!/bin/sh\necho local-semgrep\n', { mode: 0o755 });
+            createSemgrepVenvFixture(root);
             fs.writeFileSync(path.join(global, 'semgrep'), '#!/bin/sh\necho global-semgrep\n', { mode: 0o755 });
             process.env.PATH = global;
 
@@ -32,8 +38,8 @@ describe('resolveParsedPackCompatibility — contained Python commands', () => {
                         variants: [{
                             id: 'semgrep-1', priority: 1, certifiedRange: '>=1 <2',
                             requirements: { tool: 'semgrep', toolRange: '>=1 <2', runtime: 'python', runtimeRange: '>=3.12 <4' },
-                            assets: [], formatter: 'semgrep', probe: { kind: 'semgrep-validate' },
-                            command: { executable: 'semgrep', resolution: 'path', args: ['--validate'] },
+                            assets: [], formatter: 'semgrep', probe: { kind: 'version' },
+                            command: { executable: 'semgrep', resolution: 'path', args: ['--version'] },
                         }],
                     },
                 },
@@ -44,7 +50,10 @@ describe('resolveParsedPackCompatibility — contained Python commands', () => {
             const command = live.pack.sensors.security.variants[0].command;
             expect(live.sensors.security).toMatchObject({ state: 'certified', toolVersion: '1.91.0' });
             expect(command).toMatchObject({ executable: 'semgrep', resolution: 'python-environment' });
-            await expect(runStructuredCommand(command, { cwd: root, timeout: 5_000 })).resolves.toMatchObject({ code: 0, stdout: 'local-semgrep\n' });
+            await expect(runStructuredCommand(command, { cwd: root, timeout: 5_000 })).resolves.toMatchObject({
+                code: 0,
+                stdout: process.platform === 'win32' ? `${process.version}\n` : 'local-semgrep\n',
+            });
         } finally {
             process.env.PATH = savedPath;
             fs.rmSync(root, { recursive: true, force: true });
@@ -55,13 +64,8 @@ describe('resolveParsedPackCompatibility — contained Python commands', () => {
     it('never falls back from the discovered .venv to a sibling venv executable', async () => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-environment-identity-'));
         try {
-            const discoveredSitePackages = path.join(root, '.venv', 'lib', 'python3.12', 'site-packages');
-            const siblingBin = path.join(root, 'venv', 'bin');
-            fs.mkdirSync(path.join(discoveredSitePackages, 'semgrep-1.91.0.dist-info'), { recursive: true });
-            fs.mkdirSync(siblingBin, { recursive: true });
-            fs.writeFileSync(path.join(root, '.venv', 'pyvenv.cfg'), 'version = 3.12.4\n');
-            fs.writeFileSync(path.join(discoveredSitePackages, 'semgrep-1.91.0.dist-info', 'METADATA'), 'Name: semgrep\nVersion: 1.91.0\n');
-            fs.writeFileSync(path.join(siblingBin, 'semgrep'), '#!/bin/sh\necho sibling-semgrep\n', { mode: 0o755 });
+            createSemgrepVenvFixture(root, process.platform, '.venv', { executable: false });
+            createSemgrepVenvFixture(root, process.platform, 'venv');
             fs.writeFileSync(path.join(root, 'pyproject.toml'), '[project]\nname = "sample"\n');
 
             const pack = {

--- a/cli/tests/commands/sensors/compatibility/live.test.ts
+++ b/cli/tests/commands/sensors/compatibility/live.test.ts
@@ -1,0 +1,54 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { resolveParsedPackCompatibility } from '../../../../src/commands/sensors/compatibility/live';
+import { runStructuredCommand } from '../../../../src/commands/sensors/exec';
+
+describe('resolveParsedPackCompatibility — contained Python commands', () => {
+    it('binds Semgrep discovery, probe, and execution to the same local virtual-environment executable', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-contained-'));
+        const global = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-global-'));
+        const savedPath = process.env.PATH;
+        try {
+            const localBin = path.join(root, '.venv', 'bin');
+            const sitePackages = path.join(root, '.venv', 'lib', 'python3.12', 'site-packages');
+            fs.mkdirSync(localBin, { recursive: true });
+            fs.mkdirSync(path.join(sitePackages, 'semgrep-1.91.0.dist-info'), { recursive: true });
+            fs.writeFileSync(path.join(root, '.venv', 'pyvenv.cfg'), 'version = 3.12.4\n');
+            fs.writeFileSync(path.join(sitePackages, 'semgrep-1.91.0.dist-info', 'METADATA'), 'Name: semgrep\nVersion: 1.91.0\n');
+            fs.writeFileSync(path.join(localBin, 'semgrep'), '#!/bin/sh\necho local-semgrep\n', { mode: 0o755 });
+            fs.writeFileSync(path.join(global, 'semgrep'), '#!/bin/sh\necho global-semgrep\n', { mode: 0o755 });
+            process.env.PATH = global;
+
+            const pack = {
+                schemaVersion: 2,
+                name: 'python',
+                description: 'test',
+                detects: ['pyproject.toml'],
+                coverage: {},
+                sensors: {
+                    security: {
+                        applicability: { allFiles: ['pyproject.toml'] },
+                        variants: [{
+                            id: 'semgrep-1', priority: 1, certifiedRange: '>=1 <2',
+                            requirements: { tool: 'semgrep', toolRange: '>=1 <2', runtime: 'python', runtimeRange: '>=3.12 <4' },
+                            assets: [], formatter: 'semgrep', probe: { kind: 'semgrep-validate' },
+                            command: { executable: 'semgrep', resolution: 'path', args: ['--validate'] },
+                        }],
+                    },
+                },
+            } as any;
+            fs.writeFileSync(path.join(root, 'pyproject.toml'), '[project]\nname = "sample"\n');
+
+            const live = await resolveParsedPackCompatibility(root, pack);
+            const command = live.pack.sensors.security.variants[0].command;
+            expect(live.sensors.security).toMatchObject({ state: 'certified', toolVersion: '1.91.0' });
+            expect(command).toMatchObject({ executable: 'semgrep', resolution: 'python-environment' });
+            await expect(runStructuredCommand(command, { cwd: root, timeout: 5_000 })).resolves.toMatchObject({ code: 0, stdout: 'local-semgrep\n' });
+        } finally {
+            process.env.PATH = savedPath;
+            fs.rmSync(root, { recursive: true, force: true });
+            fs.rmSync(global, { recursive: true, force: true });
+        }
+    });
+});

--- a/cli/tests/commands/sensors/compatibility/live.test.ts
+++ b/cli/tests/commands/sensors/compatibility/live.test.ts
@@ -5,6 +5,8 @@ import { resolveParsedPackCompatibility } from '../../../../src/commands/sensors
 import { runStructuredCommand } from '../../../../src/commands/sensors/exec';
 import { createSemgrepVenvFixture } from './python-venv-fixture';
 
+const itPosix = process.platform !== 'win32' ? it : it.skip;
+
 describe('resolveParsedPackCompatibility — contained Python commands', () => {
     test.each([
         ['linux', ['.venv', 'bin', 'semgrep']],
@@ -17,12 +19,43 @@ describe('resolveParsedPackCompatibility — contained Python commands', () => {
         } finally { fs.rmSync(root, { recursive: true, force: true }); }
     });
 
-    it('binds Semgrep discovery, probe, and execution to the same local virtual-environment executable', async () => {
+    it('resolves the Windows virtual-environment executable from Scripts instead of PATH', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-windows-resolution-'));
+        const global = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-windows-global-'));
+        const originalPlatform = process.platform;
+        const savedPath = process.env.PATH;
+        const savedPathExt = process.env.PATHEXT;
+        try {
+            Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+            process.env.PATH = global;
+            process.env.PATHEXT = '.EXE';
+            createSemgrepVenvFixture(root, 'win32');
+            fs.writeFileSync(path.join(global, 'semgrep.exe'), 'must-not-run');
+
+            await expect(runStructuredCommand({
+                executable: 'semgrep', resolution: 'python-environment', pythonEnvironmentRoot: '.venv', args: ['--version'],
+            }, { cwd: root, timeout: 5_000 })).resolves.toMatchObject({
+                code: 0,
+                stdout: expect.stringContaining(process.version),
+            });
+        } finally {
+            Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+            if (savedPath === undefined) delete process.env.PATH;
+            else process.env.PATH = savedPath;
+            if (savedPathExt === undefined) delete process.env.PATHEXT;
+            else process.env.PATHEXT = savedPathExt;
+            fs.rmSync(root, { recursive: true, force: true });
+            fs.rmSync(global, { recursive: true, force: true });
+        }
+    });
+
+    itPosix('binds Semgrep discovery, validation probe, and execution to the same local virtual-environment executable', async () => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-contained-'));
         const global = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-global-'));
         const savedPath = process.env.PATH;
         try {
             createSemgrepVenvFixture(root);
+            fs.writeFileSync(path.join(root, '.venv', 'bin', 'semgrep'), '#!/bin/sh\nif [ "$1" = "--validate" ]; then echo local-semgrep; exit 0; fi\nexit 1\n', { mode: 0o755 });
             fs.writeFileSync(path.join(global, 'semgrep'), '#!/bin/sh\necho global-semgrep\n', { mode: 0o755 });
             process.env.PATH = global;
 
@@ -38,8 +71,8 @@ describe('resolveParsedPackCompatibility — contained Python commands', () => {
                         variants: [{
                             id: 'semgrep-1', priority: 1, certifiedRange: '>=1 <2',
                             requirements: { tool: 'semgrep', toolRange: '>=1 <2', runtime: 'python', runtimeRange: '>=3.12 <4' },
-                            assets: [], formatter: 'semgrep', probe: { kind: 'version' },
-                            command: { executable: 'semgrep', resolution: 'path', args: ['--version'] },
+                            assets: [], formatter: 'semgrep', probe: { kind: 'semgrep-validate' },
+                            command: { executable: 'semgrep', resolution: 'path', args: ['--validate'] },
                         }],
                     },
                 },
@@ -50,10 +83,7 @@ describe('resolveParsedPackCompatibility — contained Python commands', () => {
             const command = live.pack.sensors.security.variants[0].command;
             expect(live.sensors.security).toMatchObject({ state: 'certified', toolVersion: '1.91.0' });
             expect(command).toMatchObject({ executable: 'semgrep', resolution: 'python-environment' });
-            await expect(runStructuredCommand(command, { cwd: root, timeout: 5_000 })).resolves.toMatchObject({
-                code: 0,
-                stdout: process.platform === 'win32' ? `${process.version}\n` : 'local-semgrep\n',
-            });
+            await expect(runStructuredCommand(command, { cwd: root, timeout: 5_000 })).resolves.toMatchObject({ code: 0, stdout: 'local-semgrep\n' });
         } finally {
             process.env.PATH = savedPath;
             fs.rmSync(root, { recursive: true, force: true });

--- a/cli/tests/commands/sensors/compatibility/manifest.test.ts
+++ b/cli/tests/commands/sensors/compatibility/manifest.test.ts
@@ -34,6 +34,16 @@ describe('sensor manifest contract', () => {
         expect(JSON.parse(serializeManifestV2(manifest))).toEqual(manifest);
     });
 
+    it('persists only an explicit v2 pack selection as applicability provenance', () => {
+        const manifest = {
+            schemaVersion: 2, pack: 'generic', packSelection: 'explicit',
+            sensors: {},
+        };
+        expect(parseSensorManifest(manifest, 'sensors.json')).toMatchObject({ kind: 'v2', pack: { packSelection: 'explicit' } });
+        expect(JSON.parse(serializeManifestV2(manifest))).toEqual(manifest);
+        expect(() => parseSensorManifest({ ...manifest, packSelection: 'detected' }, 'sensors.json')).toThrow('packSelection');
+    });
+
     it('accepts optional contained assets and rejects traversal', () => {
         const sensor = { enabled: true, variantId: 'eslint-9', assets: ['eslint.config.awm.mjs'], command: { executable: 'eslint', resolution: 'node-modules-bin', args: ['.'] }, initializedCompatibility: { state: 'certified', reason: 'ok', variantId: 'eslint-9', toolVersion: '9.0.0', runtimeVersion: '24.0.0', certifiedRange: '>=9 <10', evidence: [] } };
         expect(parseSensorManifest({ schemaVersion: 2, pack: 'js-ts', sensors: { lint: sensor } }, 'sensors.json')).toMatchObject({ kind: 'v2' });

--- a/cli/tests/commands/sensors/compatibility/materialize.test.ts
+++ b/cli/tests/commands/sensors/compatibility/materialize.test.ts
@@ -38,6 +38,25 @@ describe('materializeResolvedSensors', () => {
         expect(fs.readFileSync(path.join(projectRoot, 'eslint.config.awm.mjs'), 'utf8')).toBe('owner content');
     });
 
+    it('revalidates a shared Semgrep policy reference without materializing the policy itself', () => {
+        const sensorPacks = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-materialize-policy-'));
+        const semgrepPack = path.join(sensorPacks, 'python');
+        try {
+            fs.mkdirSync(path.join(sensorPacks, 'shared'), { recursive: true });
+            fs.mkdirSync(semgrepPack);
+            fs.writeFileSync(path.join(semgrepPack, 'pack.json'), '{}');
+            fs.writeFileSync(path.join(semgrepPack, '.semgrep.awm.yml'), 'rules: []\n');
+            fs.writeFileSync(path.join(sensorPacks, 'shared', 'semgrep-policy.json'), JSON.stringify({ tool: 'semgrep', toolRange: '>=1.0.0', runtime: 'python', runtimeRange: '>=3.9.0', probe: 'semgrep-validate' }));
+            const result = materializeResolvedSensors({ projectRoot, packRoot: semgrepPack, pack: 'python', sensors: {
+                security: { enabled: true, variantId: 'semgrep-python', command: { executable: 'semgrep', resolution: 'path', args: ['--config', '.semgrep.awm.yml', '--json', '.'] }, assets: ['.semgrep.awm.yml'], policyRef: 'shared/semgrep-policy.json', initializedCompatibility: { ...evidence, variantId: 'semgrep-python' } },
+            } });
+            expect(result.configured).toEqual(['.semgrep.awm.yml']);
+            expect(fs.existsSync(path.join(projectRoot, 'shared', 'semgrep-policy.json'))).toBe(false);
+        } finally {
+            fs.rmSync(sensorPacks, { recursive: true, force: true });
+        }
+    });
+
     it('reports previous AWM assets as orphaned and never deletes them', () => {
         fs.mkdirSync(path.join(projectRoot, '.awm'));
         fs.writeFileSync(path.join(projectRoot, '.awm', 'sensors.json'), JSON.stringify({ schemaVersion: 2, pack: 'js-ts', sensors: {

--- a/cli/tests/commands/sensors/compatibility/probe.test.ts
+++ b/cli/tests/commands/sensors/compatibility/probe.test.ts
@@ -38,6 +38,17 @@ describe('runCompatibilityProbe', () => {
         );
     });
 
+    it('keeps Windows Semgrep validation on the discovered .venv executable', async () => {
+        await runCompatibilityProbe({ kind: 'semgrep-validate' }, {
+            cwd: process.cwd(), toolExecutable: 'semgrep', toolResolution: 'python-environment', pythonEnvironmentRoot: '.venv',
+        }, fakeExecutor);
+
+        expect(fakeExecutor).toHaveBeenCalledWith(
+            { executable: 'semgrep', resolution: 'python-environment', pythonEnvironmentRoot: '.venv', args: ['--validate'] },
+            expect.objectContaining({ cwd: process.cwd() }),
+        );
+    });
+
     it.each(['mypy', 'ruff', 'pytest'])('probes a %s variant through the contained Python environment', async (toolExecutable) => {
         await runCompatibilityProbe({ kind: 'version' }, { ...evidence, toolExecutable, toolResolution: 'python-environment' }, fakeExecutor);
 

--- a/cli/tests/commands/sensors/compatibility/probe.test.ts
+++ b/cli/tests/commands/sensors/compatibility/probe.test.ts
@@ -37,4 +37,13 @@ describe('runCompatibilityProbe', () => {
             expect.any(Object),
         );
     });
+
+    it.each(['mypy', 'ruff', 'pytest'])('probes a %s variant through the contained Python environment', async (toolExecutable) => {
+        await runCompatibilityProbe({ kind: 'version' }, { ...evidence, toolExecutable, toolResolution: 'python-environment' }, fakeExecutor);
+
+        expect(fakeExecutor).toHaveBeenCalledWith(
+            expect.objectContaining({ executable: toolExecutable, resolution: 'python-environment', args: ['--version'] }),
+            expect.any(Object),
+        );
+    });
 });

--- a/cli/tests/commands/sensors/compatibility/python-venv-fixture.ts
+++ b/cli/tests/commands/sensors/compatibility/python-venv-fixture.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import path from 'path';
+
+type EnvironmentRoot = '.venv' | 'venv';
+type Options = { executable?: boolean };
+
+/** Creates contained Semgrep metadata and the host-appropriate virtualenv executable. */
+export function createSemgrepVenvFixture(root: string, targetPlatform: NodeJS.Platform = process.platform, environmentRoot: EnvironmentRoot = '.venv', options: Options = {}): void {
+    if (typeof root !== 'string' || root.trim() === '') throw new Error('fixture root must be a non-empty path');
+    const windows = targetPlatform === 'win32';
+    const sitePackages = windows
+        ? [environmentRoot, 'Lib', 'site-packages']
+        : [environmentRoot, 'lib', 'python3.12', 'site-packages'];
+    const metadata = path.join(root, ...sitePackages, 'semgrep-1.91.0.dist-info');
+    fs.mkdirSync(metadata, { recursive: true });
+    fs.writeFileSync(path.join(root, environmentRoot, 'pyvenv.cfg'), 'version = 3.12.4\n');
+    fs.writeFileSync(path.join(metadata, 'METADATA'), 'Name: semgrep\nVersion: 1.91.0\n');
+    if (options.executable === false) return;
+
+    const executable = path.join(root, environmentRoot, windows ? 'Scripts' : 'bin', windows ? 'semgrep.exe' : 'semgrep');
+    fs.mkdirSync(path.dirname(executable), { recursive: true });
+    if (windows) fs.copyFileSync(process.execPath, executable);
+    else fs.writeFileSync(executable, '#!/bin/sh\necho local-semgrep\n', { mode: 0o755 });
+}

--- a/cli/tests/commands/sensors/compatibility/resolve.test.ts
+++ b/cli/tests/commands/sensors/compatibility/resolve.test.ts
@@ -18,7 +18,8 @@ describe('resolveSensorCompatibility', () => {
         expect(resolved).toMatchObject({ state: 'not-applicable', reason: 'applicability-not-met' });
     });
     it('treats explicit generic pack selection as positive capability in project resolution', () => {
-        const resolved = resolveProjectCompatibility({ schemaVersion: 2, name: 'generic', sensors: { security: { applicability: { kind: 'explicit-or-supported-language' }, variants: [variant('semgrep')] } } } as any, evidence());
+        const resolved = resolveProjectCompatibility({ schemaVersion: 2, name: 'generic', sensors: { security: { applicability: { kind: 'explicit-or-supported-language' }, variants: [variant('semgrep')] } } } as any,
+            evidence({ applicable: undefined, paths: [], explicitPackSelection: true }));
         expect(resolved.sensors.security.state).not.toBe('not-applicable');
     });
     test.each([

--- a/cli/tests/commands/sensors/compatibility/resolve.test.ts
+++ b/cli/tests/commands/sensors/compatibility/resolve.test.ts
@@ -12,6 +12,11 @@ const evidence = (input: any = {}) => ({ paths: ['package.json'], applicable: tr
 const context = { pack: 'js-ts', sensor: 'lint' };
 
 describe('resolveSensorCompatibility', () => {
+    it('keeps explicit-or-supported-language sensors not-applicable without positive capability evidence', () => {
+        const resolved = resolveSensorCompatibility({ applicability: { kind: 'explicit-or-supported-language' }, variants: [variant('semgrep')] } as any,
+            evidence({ applicable: undefined, paths: [], toolVersion: '1.0.0', runtimeVersion: '3.12.0', probe: { status: 'matched' } }), { pack: 'generic', sensor: 'security' });
+        expect(resolved).toMatchObject({ state: 'not-applicable', reason: 'applicability-not-met' });
+    });
     test.each([
         ['certified', evidence(), 'eslint-main'],
         ['compatible-unverified', evidence({ toolVersion: '11.0.0' }), 'eslint-main'],

--- a/cli/tests/commands/sensors/compatibility/resolve.test.ts
+++ b/cli/tests/commands/sensors/compatibility/resolve.test.ts
@@ -17,6 +17,10 @@ describe('resolveSensorCompatibility', () => {
             evidence({ applicable: undefined, paths: [], toolVersion: '1.0.0', runtimeVersion: '3.12.0', probe: { status: 'matched' } }), { pack: 'generic', sensor: 'security' });
         expect(resolved).toMatchObject({ state: 'not-applicable', reason: 'applicability-not-met' });
     });
+    it('treats explicit generic pack selection as positive capability in project resolution', () => {
+        const resolved = resolveProjectCompatibility({ schemaVersion: 2, name: 'generic', sensors: { security: { applicability: { kind: 'explicit-or-supported-language' }, variants: [variant('semgrep')] } } } as any, evidence());
+        expect(resolved.sensors.security.state).not.toBe('not-applicable');
+    });
     test.each([
         ['certified', evidence(), 'eslint-main'],
         ['compatible-unverified', evidence({ toolVersion: '11.0.0' }), 'eslint-main'],

--- a/cli/tests/commands/sensors/compatibility/resolve.test.ts
+++ b/cli/tests/commands/sensors/compatibility/resolve.test.ts
@@ -12,14 +12,14 @@ const evidence = (input: any = {}) => ({ paths: ['package.json'], applicable: tr
 const context = { pack: 'js-ts', sensor: 'lint' };
 
 describe('resolveSensorCompatibility', () => {
-    it('keeps explicit-or-supported-language sensors not-applicable without positive capability evidence', () => {
+    it('keeps an automatically selected generic pack not-applicable despite language markers', () => {
         const resolved = resolveSensorCompatibility({ applicability: { kind: 'explicit-or-supported-language' }, variants: [variant('semgrep')] } as any,
-            evidence({ applicable: undefined, paths: [], toolVersion: '1.0.0', runtimeVersion: '3.12.0', probe: { status: 'matched' } }), { pack: 'generic', sensor: 'security' });
+            evidence({ applicable: undefined, paths: ['pyproject.toml'], toolVersion: '1.0.0', runtimeVersion: '3.12.0', probe: { status: 'matched' } }), { pack: 'generic', sensor: 'security' });
         expect(resolved).toMatchObject({ state: 'not-applicable', reason: 'applicability-not-met' });
     });
-    it('treats explicit generic pack selection as positive capability in project resolution', () => {
+    it('treats the persisted explicit generic pack selection as positive capability in project resolution', () => {
         const resolved = resolveProjectCompatibility({ schemaVersion: 2, name: 'generic', sensors: { security: { applicability: { kind: 'explicit-or-supported-language' }, variants: [variant('semgrep')] } } } as any,
-            evidence({ applicable: undefined, paths: [], explicitPackSelection: true }));
+            evidence({ applicable: undefined, paths: [], packSelection: 'explicit' }));
         expect(resolved.sensors.security.state).not.toBe('not-applicable');
     });
     test.each([

--- a/cli/tests/commands/sensors/exec-windows.test.ts
+++ b/cli/tests/commands/sensors/exec-windows.test.ts
@@ -23,6 +23,11 @@ function fakeChild(pid = 4242) {
     return child;
 }
 
+function restoreEnvironment(name: 'PATH' | 'PATHEXT', value: string | undefined): void {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+}
+
 describe('runCommand — win32', () => {
     const originalPlatform = process.platform;
 
@@ -64,10 +69,10 @@ describe('runCommand — win32', () => {
             expect(mockSpawn).toHaveBeenCalledWith(path.join(dir, 'tool.exe'), ['literal;&'], expect.objectContaining({ shell: false, detached: false }));
             child.emit('close', 0, null);
             await expect(pending).resolves.toMatchObject({ code: 0 });
-            expect(() => runStructuredCommand({ executable: 'tool.cmd', resolution: 'path', args: [] }, { timeout: 5000, cwd: dir })).toThrow(/wrappers/);
+            expect(() => runStructuredCommand({ executable: 'tool.cmd', resolution: 'path', args: ['--version'] }, { timeout: 5000, cwd: dir })).toThrow(/wrappers/);
         } finally {
-            process.env.PATH = savedPath;
-            process.env.PATHEXT = savedPathExt;
+            restoreEnvironment('PATH', savedPath);
+            restoreEnvironment('PATHEXT', savedPathExt);
             fs.rmSync(dir, { recursive: true, force: true });
         }
     });
@@ -86,13 +91,13 @@ describe('runCommand — win32', () => {
             process.env.PATHEXT = '.EXE';
             const child = fakeChild();
             mockSpawn.mockReturnValue(child);
-            const pending = runStructuredCommand({ executable: 'tool', resolution: 'node-modules-bin', args: [] }, { timeout: 5000, cwd: dir });
-            expect(mockSpawn).toHaveBeenCalledWith(path.join(localBin, 'tool.exe'), [], expect.objectContaining({ shell: false }));
+            const pending = runStructuredCommand({ executable: 'tool', resolution: 'node-modules-bin', args: ['--version'] }, { timeout: 5000, cwd: dir });
+            expect(mockSpawn).toHaveBeenCalledWith(path.join(localBin, 'tool.exe'), ['--version'], expect.objectContaining({ shell: false }));
             child.emit('close', 0, null);
             await expect(pending).resolves.toMatchObject({ code: 0 });
         } finally {
-            process.env.PATH = savedPath;
-            process.env.PATHEXT = savedPathExt;
+            restoreEnvironment('PATH', savedPath);
+            restoreEnvironment('PATHEXT', savedPathExt);
             fs.rmSync(dir, { recursive: true, force: true });
             fs.rmSync(global, { recursive: true, force: true });
         }
@@ -106,13 +111,32 @@ describe('runCommand — win32', () => {
             fs.writeFileSync(path.join(global, 'tool.exe'), 'global');
             process.env.PATH = global;
             mockSpawn.mockReturnValue(fakeChild());
-            expect(() => runStructuredCommand({ executable: 'tool', resolution: 'node-modules-bin', args: [] }, { timeout: 5000, cwd: dir }))
+            expect(() => runStructuredCommand({ executable: 'tool', resolution: 'node-modules-bin', args: ['--version'] }, { timeout: 5000, cwd: dir }))
                 .toThrow(/node_modules.*not found locally/i);
             expect(mockSpawn).not.toHaveBeenCalled();
         } finally {
-            process.env.PATH = savedPath;
+            restoreEnvironment('PATH', savedPath);
             fs.rmSync(dir, { recursive: true, force: true });
             fs.rmSync(global, { recursive: true, force: true });
+        }
+    });
+
+    it('fails closed when PATHEXT contains no safe executable extension', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-structured-win-pathext-'));
+        const savedPath = process.env.PATH;
+        const savedPathExt = process.env.PATHEXT;
+        try {
+            fs.writeFileSync(path.join(dir, 'tool.cmd'), 'wrapper');
+            process.env.PATH = dir;
+            process.env.PATHEXT = '.CMD';
+
+            expect(() => runStructuredCommand({ executable: 'tool', resolution: 'path', args: ['--version'] }, { timeout: 5000, cwd: dir }))
+                .toThrow(/safe Windows executable|PATHEXT/i);
+            expect(mockSpawn).not.toHaveBeenCalled();
+        } finally {
+            restoreEnvironment('PATH', savedPath);
+            restoreEnvironment('PATHEXT', savedPathExt);
+            fs.rmSync(dir, { recursive: true, force: true });
         }
     });
 
@@ -128,7 +152,7 @@ describe('runCommand — win32', () => {
                 .toThrow(/python.*environment.*local|contained/i);
             expect(mockSpawn).not.toHaveBeenCalled();
         } finally {
-            process.env.PATH = savedPath;
+            restoreEnvironment('PATH', savedPath);
             fs.rmSync(dir, { recursive: true, force: true });
             fs.rmSync(global, { recursive: true, force: true });
         }

--- a/cli/tests/commands/sensors/exec-windows.test.ts
+++ b/cli/tests/commands/sensors/exec-windows.test.ts
@@ -77,6 +77,31 @@ describe('runCommand — win32', () => {
         }
     });
 
+    it('spawns the allowlisted flat-config environment for ESLint 8', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-structured-win-env-'));
+        const savedPath = process.env.PATH;
+        const savedPathExt = process.env.PATHEXT;
+        try {
+            fs.writeFileSync(path.join(dir, 'tool.exe'), 'fixture');
+            process.env.PATH = dir;
+            process.env.PATHEXT = '.EXE';
+            const child = fakeChild();
+            mockSpawn.mockReturnValue(child);
+
+            const pending = runStructuredCommand({ executable: 'tool', resolution: 'path', args: ['--version'], environment: { ESLINT_USE_FLAT_CONFIG: 'true' } }, { timeout: 5000, cwd: dir });
+            expect(mockSpawn).toHaveBeenCalledWith(path.join(dir, 'tool.exe'), ['--version'], expect.objectContaining({
+                shell: false,
+                env: expect.objectContaining({ ESLINT_USE_FLAT_CONFIG: 'true' }),
+            }));
+            child.emit('close', 0, null);
+            await expect(pending).resolves.toMatchObject({ code: 0 });
+        } finally {
+            restoreEnvironment('PATH', savedPath);
+            restoreEnvironment('PATHEXT', savedPathExt);
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     it('uses the project node_modules executable instead of a same-named global command', async () => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-local-bin-win-'));
         const global = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-global-bin-win-'));

--- a/cli/tests/commands/sensors/exec.test.ts
+++ b/cli/tests/commands/sensors/exec.test.ts
@@ -24,7 +24,7 @@ describe('runCommand — exit codes and output', () => {
             const literal = `;touch ${marker}`;
             const received = path.join(dir, 'received');
             const result = await runStructuredCommand({
-                executable: process.execPath,
+                executable: 'node',
                 resolution: 'path',
                 args: ['-e', "require('fs').writeFileSync(process.argv[1], process.argv[2])", received, literal],
             }, { timeout: 5000, cwd: dir });
@@ -132,6 +132,20 @@ describe('runCommand — spawn failure', () => {
         const r = await runCommand('echo hi', { timeout: 5000, cwd: path.join(os.tmpdir(), 'awm-no-such-dir-xyz') });
         expect(r.spawnError).toBeDefined();
         expect(r.code).not.toBe(0);
+    });
+});
+
+describe('runStructuredCommand — public boundary validation', () => {
+    it.each(['sh', 'cmd.exe', '/usr/bin/node', 'nested/tool', 'nested\\tool'])('rejects unsafe executable %j before resolution', executable => {
+        expect(() => runStructuredCommand({ executable, resolution: 'path', args: [] }, { timeout: 5000, cwd: process.cwd() }))
+            .toThrow(/safe executable name|shell/i);
+    });
+
+    it('normalizes package-manager spellings while requiring an equivalent explicit selection', () => {
+        expect(() => runStructuredCommand({ executable: 'NPM.exe', resolution: 'path', args: [] }, { timeout: 5000, cwd: process.cwd() }))
+            .toThrow(/packageManager/);
+        expect(() => runStructuredCommand({ executable: 'NPM.exe', resolution: 'path', args: [], packageManager: 'pnpm' }, { timeout: 5000, cwd: process.cwd() }))
+            .toThrow(/packageManager/);
     });
 });
 

--- a/cli/tests/commands/sensors/exec.test.ts
+++ b/cli/tests/commands/sensors/exec.test.ts
@@ -149,6 +149,14 @@ describe('runStructuredCommand — public boundary validation', () => {
     });
 
     it.each([
+        { ESLINT_USE_FLAT_CONFIG: 'invalid' },
+        { ESLINT_USE_FLAT_CONFIG: 'true', OTHER: 'value' },
+    ])('rejects an unknown or expanded environment mapping at the public boundary', environment => {
+        expect(() => runStructuredCommand({ executable: 'node', resolution: 'path', args: ['--version'], environment } as any, { timeout: 5000, cwd: process.cwd() }))
+            .toThrow(/exact allowlisted/);
+    });
+
+    it.each([
         [{ executable: 'node', resolution: 'path', args: [] }, /nonempty array/],
         [{ executable: 'node', resolution: 'path', args: [''] }, /nonempty single-line/],
         [{ executable: 'node', resolution: 'path', args: ['one\ntwo'] }, /single-line/],

--- a/cli/tests/commands/sensors/exec.test.ts
+++ b/cli/tests/commands/sensors/exec.test.ts
@@ -197,6 +197,25 @@ onPosix('runStructuredCommand — local node_modules binaries', () => {
 });
 
 onPosix('runStructuredCommand — Python environments', () => {
+    it.each(['.venv', 'venv'] as const)('rejects a symlinked %s ancestor instead of executing outside the project', environment => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-python-env-ancestor-'));
+        const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-python-env-outside-'));
+        const marker = path.join(dir, 'must-not-exist');
+        try {
+            const executable = path.join(outside, 'bin', 'semgrep');
+            fs.mkdirSync(path.dirname(executable), { recursive: true });
+            fs.writeFileSync(executable, `#!/bin/sh\ntouch ${marker}\n`, { mode: 0o755 });
+            fs.symlinkSync(outside, path.join(dir, environment));
+
+            expect(() => runStructuredCommand({ executable: 'semgrep', resolution: 'python-environment', pythonEnvironmentRoot: environment, args: ['--validate'] }, { timeout: 5000, cwd: dir }))
+                .toThrow(/python.*environment.*local|contained/i);
+            expect(fs.existsSync(marker)).toBe(false);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+            fs.rmSync(outside, { recursive: true, force: true });
+        }
+    });
+
     it('rejects a missing project Python executable instead of falling back to PATH', () => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-python-env-missing-'));
         const global = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-python-env-global-'));

--- a/cli/tests/commands/sensors/exec.test.ts
+++ b/cli/tests/commands/sensors/exec.test.ts
@@ -137,15 +137,27 @@ describe('runCommand — spawn failure', () => {
 
 describe('runStructuredCommand — public boundary validation', () => {
     it.each(['sh', 'cmd.exe', '/usr/bin/node', 'nested/tool', 'nested\\tool'])('rejects unsafe executable %j before resolution', executable => {
-        expect(() => runStructuredCommand({ executable, resolution: 'path', args: [] }, { timeout: 5000, cwd: process.cwd() }))
+        expect(() => runStructuredCommand({ executable, resolution: 'path', args: ['--version'] }, { timeout: 5000, cwd: process.cwd() }))
             .toThrow(/safe executable name|shell/i);
     });
 
     it('normalizes package-manager spellings while requiring an equivalent explicit selection', () => {
-        expect(() => runStructuredCommand({ executable: 'NPM.exe', resolution: 'path', args: [] }, { timeout: 5000, cwd: process.cwd() }))
+        expect(() => runStructuredCommand({ executable: 'NPM.exe', resolution: 'path', args: ['--version'] }, { timeout: 5000, cwd: process.cwd() }))
             .toThrow(/packageManager/);
-        expect(() => runStructuredCommand({ executable: 'NPM.exe', resolution: 'path', args: [], packageManager: 'pnpm' }, { timeout: 5000, cwd: process.cwd() }))
+        expect(() => runStructuredCommand({ executable: 'NPM.exe', resolution: 'path', args: ['--version'], packageManager: 'pnpm' }, { timeout: 5000, cwd: process.cwd() }))
             .toThrow(/packageManager/);
+    });
+
+    it.each([
+        [{ executable: 'node', resolution: 'path', args: [] }, /nonempty array/],
+        [{ executable: 'node', resolution: 'path', args: [''] }, /nonempty single-line/],
+        [{ executable: 'node', resolution: 'path', args: ['one\ntwo'] }, /single-line/],
+        [{ executable: 'node', resolution: 'path', args: ['{files}'] }, /requires fileInput/],
+        [{ executable: 'node', resolution: 'path', args: ['prefix{files}'], fileInput: { placeholder: '{files}', extensions: ['.ts'] } }, /must not embed/],
+        [{ executable: 'node', resolution: 'path', args: ['{files}', '{files}'], fileInput: { placeholder: '{files}', extensions: ['.ts'] } }, /exactly one/],
+        [{ executable: 'node', resolution: 'path', args: ['--check'], fileInput: { placeholder: '{files}', extensions: ['.ts'] } }, /exactly one/],
+    ])('rejects malformed args or file input at the public boundary', (command, message) => {
+        expect(() => runStructuredCommand(command as any, { timeout: 5000, cwd: process.cwd() })).toThrow(message);
     });
 });
 
@@ -163,12 +175,12 @@ onPosix('runStructuredCommand — local node_modules binaries', () => {
             fs.mkdirSync(bin, { recursive: true });
             fs.symlinkSync('../tool/bin/tool', path.join(bin, 'tool'));
 
-            await expect(runStructuredCommand({ executable: 'tool', resolution: 'node-modules-bin', args: [] }, { timeout: 5000, cwd: dir }))
+            await expect(runStructuredCommand({ executable: 'tool', resolution: 'node-modules-bin', args: ['--version'] }, { timeout: 5000, cwd: dir }))
                 .resolves.toMatchObject({ code: 0, stdout: 'contained\n' });
 
             fs.unlinkSync(path.join(bin, 'tool'));
             fs.symlinkSync(outside, path.join(bin, 'tool'));
-            expect(() => runStructuredCommand({ executable: 'tool', resolution: 'node-modules-bin', args: [] }, { timeout: 5000, cwd: dir }))
+            expect(() => runStructuredCommand({ executable: 'tool', resolution: 'node-modules-bin', args: ['--version'] }, { timeout: 5000, cwd: dir }))
                 .toThrow(/node_modules.*contain|local/i);
         } finally {
             fs.rmSync(dir, { recursive: true, force: true });

--- a/cli/tests/commands/sensors/init.test.ts
+++ b/cli/tests/commands/sensors/init.test.ts
@@ -43,9 +43,11 @@ function makeV2Registry(): string {
     const packDir = path.join(registryRoot, 'sensor-packs', 'js-ts');
     fs.mkdirSync(packDir, { recursive: true });
     fs.writeFileSync(path.join(packDir, 'eslint.config.awm.mjs'), 'export default []\n');
+    fs.writeFileSync(path.join(packDir, 'tsconfig.awm.json'), '{ "compilerOptions": { "strict": true } }\n');
     fs.writeFileSync(path.join(packDir, 'pack.json'), JSON.stringify({
         schemaVersion: 2, name: 'js-ts', description: 'fixture', detects: ['package.json'],
         coverage: { schemaVersion: 1, classes: { lint: { description: 'lint', detectors: [{ sensor: 'lint' }], remedy: { summary: 'fix lint', command: 'awm sensors init --pack js-ts' } } } },
+        hardening: { 'typescript-strict': { assets: ['tsconfig.awm.json'] } },
         sensors: { lint: { applicability: { allFiles: ['package.json'] }, variants: [{
             id: 'eslint-10', priority: 10, certifiedRange: '>=10.0.0 <11.0.0',
             requirements: { tool: 'eslint', toolRange: '>=10.0.0 <11.0.0', runtime: 'node', runtimeRange: '>=0.0.0' },
@@ -298,6 +300,20 @@ describe('initSensors', () => {
             expect(written.sensors.lint.initializedCompatibility).toMatchObject({ variantId: 'eslint-10', state: 'certified', reason: 'range-and-probe' });
             expect(written.registryRoot).toBe(v2Registry);
             expect(fs.existsSync(path.join(tmpDir, 'eslint.config.awm.mjs'))).toBe(true);
+        } finally {
+            fs.rmSync(v2Registry, { recursive: true, force: true });
+        }
+    });
+
+    it('never materializes an opt-in hardening asset during ordinary v2 init', async () => {
+        const v2Registry = makeV2Registry();
+        try {
+            fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { eslint: '^10.0.0' } }));
+            fs.mkdirSync(path.join(tmpDir, 'node_modules', 'eslint'), { recursive: true });
+            fs.writeFileSync(path.join(tmpDir, 'node_modules', 'eslint', 'package.json'), JSON.stringify({ version: '10.0.0' }));
+            await initSensors({ cwd: tmpDir, registryRoot: v2Registry });
+            expect(fs.existsSync(path.join(tmpDir, 'eslint.config.awm.mjs'))).toBe(true);
+            expect(fs.existsSync(path.join(tmpDir, 'tsconfig.awm.json'))).toBe(false);
         } finally {
             fs.rmSync(v2Registry, { recursive: true, force: true });
         }

--- a/cli/tests/commands/sensors/init.test.ts
+++ b/cli/tests/commands/sensors/init.test.ts
@@ -319,6 +319,27 @@ describe('initSensors', () => {
         }
     });
 
+    it('initializes a selected v2 variant with an explicitly empty assets list', async () => {
+        const v2Registry = makeV2Registry();
+        try {
+            const packPath = path.join(v2Registry, 'sensor-packs', 'js-ts', 'pack.json');
+            const pack = JSON.parse(fs.readFileSync(packPath, 'utf8'));
+            pack.sensors.lint.variants[0].assets = [];
+            fs.writeFileSync(packPath, JSON.stringify(pack));
+            fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { eslint: '^10.0.0' } }));
+            fs.mkdirSync(path.join(tmpDir, 'node_modules', 'eslint'), { recursive: true });
+            fs.writeFileSync(path.join(tmpDir, 'node_modules', 'eslint', 'package.json'), JSON.stringify({ version: '10.0.0' }));
+
+            await expect(initSensors({ cwd: tmpDir, registryRoot: v2Registry })).resolves.toMatchObject({
+                manifest: { schemaVersion: 2, sensors: { lint: { assets: [] } } },
+                configured: [],
+            });
+            expect(fs.existsSync(path.join(tmpDir, 'eslint.config.awm.mjs'))).toBe(false);
+        } finally {
+            fs.rmSync(v2Registry, { recursive: true, force: true });
+        }
+    });
+
     it('preserves enabled and fast choices when a valid v2 manifest is re-initialized', async () => {
         const v2Registry = makeV2Registry();
         try {

--- a/cli/tests/commands/sensors/init.test.ts
+++ b/cli/tests/commands/sensors/init.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { detectStack, detectSourceDirs, buildManifest, initSensors } from '../../../src/commands/sensors/init';
+import { computeSensorStatus } from '../../../src/commands/sensors/status';
 
 // Build a throwaway registry with a js-ts pack.json (the single source of truth
 // init now reads from). `defaultCmd` uses the {{SOURCE_DIRS}} placeholder for depcheck.
@@ -52,6 +53,24 @@ function makeV2Registry(): string {
             id: 'eslint-10', priority: 10, certifiedRange: '>=10.0.0 <11.0.0',
             requirements: { tool: 'eslint', toolRange: '>=10.0.0 <11.0.0', runtime: 'node', runtimeRange: '>=0.0.0' },
             assets: ['eslint.config.awm.mjs'], formatter: 'eslint-llm', probe: { kind: 'config-present' },
+            command: { executable: 'eslint', resolution: 'node-modules-bin', args: ['.'] },
+        }] } },
+    }));
+    return registryRoot;
+}
+
+function makeGenericV2Registry(): string {
+    const registryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-reg-generic-v2-'));
+    const packDir = path.join(registryRoot, 'sensor-packs', 'generic');
+    fs.mkdirSync(packDir, { recursive: true });
+    fs.writeFileSync(path.join(packDir, 'generic.config'), 'fixture\n');
+    fs.writeFileSync(path.join(packDir, 'pack.json'), JSON.stringify({
+        schemaVersion: 2, name: 'generic', description: 'fixture', detects: ['README.md'],
+        coverage: { schemaVersion: 1, classes: { security: { description: 'security', detectors: [{ sensor: 'security' }], remedy: { summary: 'run security', command: 'awm sensors init --pack generic' } } } },
+        sensors: { security: { applicability: { kind: 'explicit-or-supported-language' }, variants: [{
+            id: 'eslint-10', priority: 10, certifiedRange: '>=10.0.0 <11.0.0',
+            requirements: { tool: 'eslint', toolRange: '>=10.0.0 <11.0.0', runtime: 'node', runtimeRange: '>=0.0.0', configFiles: ['generic.config'] },
+            assets: ['generic.config'], formatter: 'eslint-llm', probe: { kind: 'config-present' },
             command: { executable: 'eslint', resolution: 'node-modules-bin', args: ['.'] },
         }] } },
     }));
@@ -300,6 +319,26 @@ describe('initSensors', () => {
             expect(written.sensors.lint.initializedCompatibility).toMatchObject({ variantId: 'eslint-10', state: 'certified', reason: 'range-and-probe' });
             expect(written.registryRoot).toBe(v2Registry);
             expect(fs.existsSync(path.join(tmpDir, 'eslint.config.awm.mjs'))).toBe(true);
+        } finally {
+            fs.rmSync(v2Registry, { recursive: true, force: true });
+        }
+    });
+
+    it('persists an explicit generic selection for live revalidation without promoting automatic generic fallback', async () => {
+        const v2Registry = makeGenericV2Registry();
+        try {
+            fs.mkdirSync(path.join(tmpDir, 'node_modules', 'eslint'), { recursive: true });
+            fs.writeFileSync(path.join(tmpDir, 'node_modules', 'eslint', 'package.json'), JSON.stringify({ version: '10.0.0' }));
+
+            const automatic = await initSensors({ cwd: tmpDir, registryRoot: v2Registry, configure: false });
+            expect(automatic.manifest).toMatchObject({ schemaVersion: 2, pack: 'generic', sensors: {} });
+            expect((automatic.manifest as any).packSelection).toBeUndefined();
+
+            const explicit = await initSensors({ cwd: tmpDir, registryRoot: v2Registry, pack: 'generic' });
+            const written = JSON.parse(fs.readFileSync(path.join(tmpDir, '.awm', 'sensors.json'), 'utf8'));
+            expect(explicit.manifest).toMatchObject({ schemaVersion: 2, pack: 'generic', packSelection: 'explicit', sensors: { security: { variantId: 'eslint-10' } } });
+            expect(written.packSelection).toBe('explicit');
+            await expect(computeSensorStatus(tmpDir)).resolves.toMatchObject({ overall: 'HEALTHY', checks: { security: { ok: true } } });
         } finally {
             fs.rmSync(v2Registry, { recursive: true, force: true });
         }

--- a/cli/tests/structural/r3-cli-major-version.test.ts
+++ b/cli/tests/structural/r3-cli-major-version.test.ts
@@ -4,7 +4,7 @@ import { spawnSync } from 'child_process';
 
 const CLI_ROOT = path.resolve(__dirname, '../..');
 const DIST_ENTRYPOINT = path.join(CLI_ROOT, 'dist', 'src', 'index.js');
-const TARGET_VERSION = '7.0.0';
+const TARGET_VERSION = '8.0.0';
 
 function readJson(file: string): Record<string, unknown> {
     return JSON.parse(fs.readFileSync(path.join(CLI_ROOT, file), 'utf8')) as Record<string, unknown>;
@@ -21,7 +21,7 @@ function runCompiledCli(...args: string[]): string {
 }
 
 describe('R3 public major CLI release contract', () => {
-    it('declares 7.0.0 consistently in package metadata and the lockfile root', () => {
+    it('declares 8.0.0 consistently in package metadata and the lockfile root', () => {
         const pkg = readJson('package.json');
         const lock = readJson('package-lock.json');
         const root = (lock.packages as Record<string, Record<string, unknown>>)[''];
@@ -31,7 +31,7 @@ describe('R3 public major CLI release contract', () => {
         expect(root.version).toBe(TARGET_VERSION);
     });
 
-    it('exposes 7.0.0 from the compiled CLI while retaining its help banner', () => {
+    it('exposes 8.0.0 from the compiled CLI while retaining its help banner', () => {
         expect(runCompiledCli('--version').trim()).toBe(TARGET_VERSION);
         expect(runCompiledCli('--help')).toContain('Usage: awm');
     });

--- a/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
+++ b/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
@@ -967,7 +967,7 @@ _Requirements: R1.1, R1.6, R1.7, R4.10, R7.1, R9.4, R10.3_
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Crear rama limpia del registry después de CLI 7 publicado**
+- [x] **Step 1: Crear rama limpia del registry después de CLI 7 publicado**
 
 ```bash
 git -C ../awm-baseline-registry fetch origin
@@ -977,7 +977,7 @@ git -C ../awm-baseline-registry status --short --branch
 
 Expected: rama nueva limpia desde `origin/main`; si ya existe, verificar que su base coincide y reutilizar sin reescribir trabajo ajeno.
 
-- [ ] **Step 2: Escribir corpus rojo de pack v2**
+- [x] **Step 2: Escribir corpus rojo de pack v2**
 
 ```js
 test('valid fixture carries v2 variants and coverage v1', () => {
@@ -994,15 +994,15 @@ for (const [fixture, message] of [
 ]) test(`rejects ${fixture}`, () => assert.throws(() => validateFixture(fixture), message));
 ```
 
-- [ ] **Step 3: Implementar schema y validador cerrado**
+- [x] **Step 3: Implementar schema y validador cerrado**
 
 `pack.schema.json` refleja exactamente el contrato T1, con `additionalProperties:false`, IDs kebab, arrays nonempty, commands argv y probes enum. `sensor-pack-variants.test.mjs` agrega validaciones semánticas: overlap, referencias, assets reales/contenidos, coverage detector→sensor, comando→asset, y clases genéricas sin nombres de proyecto.
 
-- [ ] **Step 4: Escribir la referencia canónica de autores**
+- [x] **Step 4: Escribir la referencia canónica de autores**
 
 En inglés: v2 completo, legacy, custom registries, operational vs certified, future compatible-unverified, probes cerrados, assets, native/baseline/hardening, ejemplos válidos, migración y enlace al CLI configuration guide. No duplicar tablas de soporte.
 
-- [ ] **Step 5: Ejecutar el gate compatible con legacy y commit del contrato**
+- [x] **Step 5: Ejecutar el gate compatible con legacy y commit del contrato**
 
 Run:
 
@@ -1040,7 +1040,7 @@ _Requirements: R4.2, R4.3, R4.4, R4.5, R4.6, R9.2_
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Escribir tests rojos de las variantes obligatorias**
+- [x] **Step 1: Escribir tests rojos de las variantes obligatorias**
 
 ```js
 const expectedLint = ['eslint-8-eslintrc', 'eslint-8-flat', 'eslint-9-flat', 'eslint-10-flat'];
@@ -1064,7 +1064,7 @@ test('commands are local argv and test variants cover npm/pnpm/yarn/bun (R4.5, R
 });
 ```
 
-- [ ] **Step 2: Generar y congelar pins de certificación**
+- [x] **Step 2: Generar y congelar pins de certificación**
 
 `resolve-certification-pins.mjs` consulta registries oficiales una sola vez para las familias declaradas (`eslint@8/9/10`, TypeScript, Prettier, dependency-cruiser, Stryker), selecciona el patch más reciente de cada frontera, escribe JSON ordenado con `resolvedAt` y URL fuente, y falla si una versión no satisface el rango del manifest. Ejecutar:
 
@@ -1072,15 +1072,15 @@ test('commands are local argv and test variants cover npm/pnpm/yarn/bun (R4.5, R
 
 Expected: `tests/fixtures/certification-pins.json` reproducible y sin tags flotantes en CI posterior.
 
-- [ ] **Step 3: Implementar manifests y assets por nivel**
+- [x] **Step 3: Implementar manifests y assets por nivel**
 
 ESLint declara las cuatro variantes; flat v8 usa env estático allowlisted si hace falta, v9/v10 no dependen de eslintrc. TypeScript normal ejecuta `tsc --noEmit` contra config nativa sin asset; `tsconfig.awm.json` vive solo en `hardening`. Prettier/depcruise/Stryker/test script declaran probes/version ranges y argv. `formatter` queda en cada variante.
 
-- [ ] **Step 4: Certificar carga real de ESLint y configs nativas**
+- [x] **Step 4: Certificar carga real de ESLint y configs nativas**
 
 Extender `sensor-pack-eslint.test.mjs` para matriz de pins y cuatro formas de config. Cada fixture instala exact version pin en tmpdir, ejecuta el command resuelto y afirma config/código de salida. Casos native config dañada deben fallar; ausencia de config usa baseline compatible solo donde la variante lo declara.
 
-- [ ] **Step 5: Ejecutar gate completo js-ts y mutaciones**
+- [x] **Step 5: Ejecutar gate completo js-ts y mutaciones**
 
 Run:
 
@@ -1095,7 +1095,7 @@ node tests/sensor-pack-coverage.test.mjs
 
 Expected: todos los comandos salen 0; `js-ts` pasa como v2 y los otros tres packs siguen aceptados por la ruta legacy `compatible-unverified`. Mutaciones: mover `tsconfig.awm.json` a assets default y usar `npx`; ambos casos deben fallar.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add sensor-packs/js-ts tests/sensor-pack-eslint.test.mjs tests/sensor-pack-js-ts-variants.test.mjs tests/fixtures/certification-pins.json scripts/resolve-certification-pins.mjs
@@ -1121,7 +1121,7 @@ _Requirements: R4.1, R4.7, R4.8, R4.9, R9.2_
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Escribir tests rojos por capacidad**
+- [x] **Step 1: Escribir tests rojos por capacidad**
 
 ```js
 test('python variants cover native configured tools (R4.7)', () => {
@@ -1143,19 +1143,19 @@ test('generic declares only Semgrep capability (R4.9)', () => {
 });
 ```
 
-- [ ] **Step 2: Ampliar pins y declarar rangos operativos/certificados**
+- [x] **Step 2: Ampliar pins y declarar rangos operativos/certificados**
 
 Ejecutar el mismo resolver para Python 3.9/actual, mypy, Ruff, pytest, Semgrep y ShellCheck; persistir versiones exactas. Mutmut permanece opt-in. Rangos se validan contra pins, no se deducen del latest en CI.
 
-- [ ] **Step 3: Migrar los tres packs y compartir política Semgrep**
+- [x] **Step 3: Migrar los tres packs y compartir política Semgrep**
 
 Cada pack referencia `shared/semgrep-policy.json` para requisitos/probe, manteniendo reglas YAML específicas por lenguaje. ShellCheck usa `{files}` como argumento entero. Python resuelve environment local y configs nativas. Generic es N/A/inconclusive fuera de su capacidad explícita, nunca covered por vacío. `sensor-pack-variants.test.mjs` activa ahora la aserción productiva de que los cuatro packs oficiales usan `schemaVersion: 2`; desde este punto el gate ya no permite legacy oficial.
 
-- [ ] **Step 4: Convertir rules-fire en gate real sin skip**
+- [x] **Step 4: Convertir rules-fire en gate real sin skip**
 
 Eliminar el skip por Semgrep ausente dentro del job de certificación: el workflow instalará el pin. Los tests disparan una regla real por pack y fallan si salida no contiene el rule ID esperado.
 
-- [ ] **Step 5: Ejecutar todos los packs, mutaciones y commit**
+- [x] **Step 5: Ejecutar todos los packs, mutaciones y commit**
 
 Run:
 

--- a/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
+++ b/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
@@ -121,7 +121,7 @@ T1 contratos/parsers
  -> T5 ledger tipado y scan bounded
  -> T6 cobertura empírica y CLI
  -> T7 documentación y freshness CLI
- -> T8 aceptación + PR CLI + npm 7.0.0
+ -> T8 aceptación + PR CLI + npm 8.0.0
  -> T9 gate/schema/autores registry
  -> T10 pack js-ts
  -> T11 packs python/shell/generic
@@ -944,11 +944,11 @@ Invocar `requesting-code-review`; por cada hallazgo agregar un test discriminant
 git status --short --branch
 git diff origin/main...HEAD --check
 git push -u origin feat/issue-20-r3-empirical-coverage
-gh pr create --repo Kodria/agentic-workflow --base main --head feat/issue-20-r3-empirical-coverage --title "feat(sensors)!: add compatible empirical coverage" --body "Refs #20; resolves the CLI portion of #70; registry v2 remains ordered after npm 7.0.0."
+gh pr create --repo Kodria/agentic-workflow --base main --head feat/issue-20-r3-empirical-coverage --title "feat(sensors)!: add compatible empirical coverage" --body "Refs #20; resolves the CLI portion of #70; registry v2 remains ordered after npm 8.0.0."
 gh pr checks --watch
 ```
 
-Expected: PR URL real y CI verde en tres OS. Tras merge, esperar release workflow verde y verificar `npm view agentic-workflow-manager@7.0.0 version` devuelve `7.0.0` antes de T9. No elevar todavía el registry.
+Expected: PR URL real y CI verde en tres OS. Tras merge, esperar release workflow verde y verificar `npm view agentic-workflow-manager@8.0.0 version` devuelve `8.0.0` antes de T9. No elevar todavía el registry.
 
 ### Task 9: Contrato de autor pack v2 y gate estructural del registry
 
@@ -1311,7 +1311,7 @@ _Requirements: R7.7, R7.8, R9.1, R9.2, R9.3, R9.4, R10.11, R10.13_
 
 - [ ] **Step 1: Instalar consumidor publicado y pin exacto en homes temporales**
 
-Crear tmpdirs con `mktemp -d`; instalar `agentic-workflow-manager@7.0.0` allí y clonar/registrar exclusivamente `awm-baseline-registry@v2.0.0`. No tocar `~/.awm`. Guardar comandos y hashes, no rutas temporales absolutas.
+Crear tmpdirs con `mktemp -d`; instalar `agentic-workflow-manager@8.0.0` allí y clonar/registrar exclusivamente `awm-baseline-registry@v2.0.0`. No tocar `~/.awm`. Guardar comandos y hashes, no rutas temporales absolutas.
 
 - [ ] **Step 2: Ejecutar matriz end-to-end new/legacy/future**
 
@@ -1332,7 +1332,7 @@ npx jest tests/structural/support-matrix-is-current.test.ts --runInBand
 git diff --check ../docs/support-matrix.md
 ```
 
-Expected: tabla idéntica a manifests de `v2.0.0`. `published-acceptance.json` registra `cliVersion:7.0.0`, `registryTag:v2.0.0`, commit/tag hashes, resultado 3-OS y hashes de fixtures.
+Expected: tabla idéntica a manifests de `v2.0.0`. `published-acceptance.json` registra `cliVersion:8.0.0`, `registryTag:v2.0.0`, commit/tag hashes, resultado 3-OS y hashes de fixtures.
 
 - [ ] **Step 5: Ejecutar reconciliación completa de ambos repos**
 
@@ -1357,7 +1357,7 @@ REGISTRY_PR_URL=$(gh pr list --repo Kodria/awm-baseline-registry --head feat/iss
 test -n "$CLI_PR_URL" && test -n "$REGISTRY_PR_URL"
 ```
 
-Comentar issue #20 con PRs, npm 7.0.0, registry v2.0.0, comandos, schemas, matriz y retro. Cerrar #70 citando las variantes ESLint/TS y hardening opt-in. Cerrar #20 solo si sus demás releases están completas; si no, dejar baton exacto sin afirmar cierre global.
+Comentar issue #20 con PRs, npm 8.0.0, registry v2.0.0, comandos, schemas, matriz y retro. Cerrar #70 citando las variantes ESLint/TS y hardening opt-in. Cerrar #20 solo si sus demás releases están completas; si no, dejar baton exacto sin afirmar cierre global.
 
 - [ ] **Step 7: Persistir aceptación, solicitar review final y transferir a QA/retro/finishing**
 
@@ -1428,7 +1428,7 @@ Invocar `requesting-code-review`, corregir todo hallazgo, marcar únicamente che
 | R7.3 | T4 | renderer tests exigen envelope público `schemaVersion: 2` |
 | R7.4 | T1, T4, T9 | contratos prueban `coverage.schemaVersion: 1` anidado |
 | R7.5 | T1 | corpus future-schema rechaza versiones desconocidas con mensaje accionable |
-| R7.6 | T8 | suite/release verifica versión CLI major `7.0.0` |
+| R7.6 | T8 | suite/release verifica versión CLI major `8.0.0` |
 | R7.7 | T13 | aceptación exige dos URLs reales y registra ambos artefactos publicados |
 | R7.8 | T8, T13 | E2E legacy y aceptación publicada prueban orden CLI-antes-registry |
 | R8.1 | T5 | `scan.test.ts` cubre archivos, bytes, líneas, refs y profundidad acotados |
@@ -1452,7 +1452,7 @@ Invocar `requesting-code-review`, corregir todo hallazgo, marcar únicamente che
 | R10.10 | T7 | ejemplos JSON documentados pasan los parsers productivos |
 | R10.11 | T7, T12, T13 | tests de freshness regeneran ambas matrices y cotejan el tag publicado |
 | R10.12 | T7, T12 | tests de documentación activa y enlaces prueban reachability bidireccional |
-| R10.13 | T8, T12, T13 | evidencia exige npm 7.0.0, registry v2.0.0, hashes y URLs reales |
+| R10.13 | T8, T12, T13 | evidencia exige npm 8.0.0, registry v2.0.0, hashes y URLs reales |
 | R10.14 | T7 | `active-documentation.test.ts` verifica inglés y prohíbe prosa R3 fuera de owners |
 
 ## Auto-revisión y analyze gate

--- a/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
+++ b/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
@@ -1208,7 +1208,7 @@ _Requirements: R6.4, R6.5, R6.7, R9.2, R9.4, R10.2, R10.3, R10.5, R10.6, R10.7, 
 
 **Skills:** `test-driven-development`, `writing-skills`, `verification-before-completion`
 
-- [ ] **Step 1: Escribir contrato rojo del orden terminal y emisión tipada**
+- [x] **Step 1: Escribir contrato rojo del orden terminal y emisión tipada**
 
 ```js
 test('runs coverage exactly once before archive (R6.4)', () => {
@@ -1236,11 +1236,11 @@ test('keeps empirical coverage terminal and out of implementation QA (R6.7)', ()
 });
 ```
 
-- [ ] **Step 2: Actualizar skills y versiones sin ampliar autoridad**
+- [x] **Step 2: Actualizar skills y versiones sin ampliar autoridad**
 
 Agregar coverage como nuevo paso del checklist tras leer el ledger y antes de triage/archive. Interactivo presenta outcomes; desatendido usa solo reglas vigentes y registra recomendaciones no autorizadas. Emisores agregan flag únicamente al mapear un catálogo exacto. `setup-sensors` queda como escape para custom/compatible-unverified/hardening. Bumps: harness-retro `2.4.0`, setup-sensors `1.1.0`, SDD `1.7.0`, QA `1.5.0`, verification `1.2.0`, debugging `1.1.0`.
 
-- [ ] **Step 3: Crear renderer y freshness del soporte del registry**
+- [x] **Step 3: Crear renderer y freshness del soporte del registry**
 
 ```js
 export function renderSensorSupport(packs, pins) {
@@ -1252,7 +1252,7 @@ export function renderSensorSupport(packs, pins) {
 
 `SUPPORT.md` tiene markers y solo contenido generado. Test regenera y compara bytes; incluye certified/compatible-unverified/not-applicable, tool/range/OS y fecha/pins, sin prosa duplicada.
 
-- [ ] **Step 4: Construir workflow de certificación que bloquee el tag**
+- [x] **Step 4: Construir workflow de certificación que bloquee el tag**
 
 Workflow reusable con resolver/contract suite en Ubuntu/macOS/Windows; real tools min/current principalmente Ubuntu; smoke current macOS/Windows; future sintético debe ser compatible-unverified. `validate.yml` lo llama. `auto-tag.yml` también lo llama y el job `tag` declara `needs: sensor-certification`; no confiar en un workflow paralelo.
 


### PR DESCRIPTION
Refs #20. Adds the missing CLI consumer contract required before publishing R3 v2 packs: optional inert hardening assets, native variants with empty assets, closed ESLint environment, explicit normalized npm/pnpm/yarn/bun selection, and fail-closed structured execution on Windows. Also aligns the factual R3 release traceability with the published 8.0.0 baseline. Registry T9 remains on its own ordered branch; it will require the bridge release before its minCliVersion can be raised.