### PR TITLE
test(ci): verify published R3 support matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,24 @@ jobs:
         working-directory: cli
         run: npx tsc --noEmit
 
+      # The support-matrix block is derived from an immutable registry release,
+      # not from the mutable sibling checkout available to maintainers. Checking
+      # out the exact public tag on every supported OS prevents documentation
+      # drift from being merged as an untested assertion.
+      - name: Checkout published sensor registry
+        uses: actions/checkout@v4
+        with:
+          repository: Kodria/awm-baseline-registry
+          ref: v2.0.0
+          path: awm-baseline-registry
+
+      - name: Regenerate published sensor support matrix
+        working-directory: cli
+        run: npx ts-node scripts/sensor-support-matrix.ts --registry-root ../awm-baseline-registry --registry-tag v2.0.0 --registry-commit c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd
+
+      - name: Verify published sensor support matrix
+        run: git diff --exit-code -- docs/support-matrix.md
+
       - name: Test
         working-directory: cli
         run: npx jest --runInBand

--- a/cli/scripts/sensor-support-matrix.ts
+++ b/cli/scripts/sensor-support-matrix.ts
@@ -157,7 +157,9 @@ export function spliceSensorSupportMatrix(markdown: string, generated: string): 
     const begin = markdown.indexOf(SENSOR_BEGIN_MARKER);
     const end = markdown.indexOf(SENSOR_END_MARKER);
     if (begin === -1 || end === -1 || end < begin) throw new Error(`support-matrix.md lacks ${SENSOR_BEGIN_MARKER} / ${SENSOR_END_MARKER}`);
-    const eol = markdown.includes('\r\n') ? '\r\n' : '\n';
+    // Preserve the line ending of the block this renderer owns. Another generated
+    // block may legitimately have a different EOL during a Windows checkout.
+    const eol = markdown.slice(begin, end).includes('\r\n') ? '\r\n' : '\n';
     const block = generated.split('\n').join(eol);
     return markdown.slice(0, begin + SENSOR_BEGIN_MARKER.length) + eol + eol + block + eol + eol + markdown.slice(end);
 }

--- a/cli/scripts/support-matrix.ts
+++ b/cli/scripts/support-matrix.ts
@@ -141,7 +141,10 @@ export function spliceGenerated(markdown: string, generated: string): string {
     if (begin === -1 || end === -1 || end < begin) {
         throw new Error(`support-matrix.md no tiene los marcadores ${BEGIN_MARKER} / ${END_MARKER}`);
     }
-    const eol = markdown.includes('\r\n') ? '\r\n' : '\n';
+    // Each renderer owns only its marked block. A document can temporarily contain
+    // another generated block with different line endings, so using the first CRLF
+    // anywhere in the file would rewrite this block and create CI-only drift.
+    const eol = markdown.slice(begin, end).includes('\r\n') ? '\r\n' : '\n';
     const block = generated.split('\n').join(eol);
     return markdown.slice(0, begin + BEGIN_MARKER.length)
         + eol + eol + block + eol + eol

--- a/cli/tests/structural/support-matrix-is-current.test.ts
+++ b/cli/tests/structural/support-matrix-is-current.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../../scripts/sensor-support-matrix';
 
 const SENSOR_FIXTURE_REGISTRY = path.join(__dirname, '..', 'fixtures', 'sensor-support-matrix', 'registry');
+const CI_WORKFLOW_PATH = path.resolve(__dirname, '../../..', '.github', 'workflows', 'ci.yml');
 
 
 describe('docs/support-matrix.md refleja el codigo', () => {
@@ -59,6 +60,17 @@ describe('docs/support-matrix.md refleja el codigo', () => {
         };
         expect(packageJson.scripts?.['docs:matrix']).toContain('--registry-root ../../awm-baseline-registry');
         expect(packageJson.scripts?.['docs:matrix:prepublication']).toContain(`--registry-root ${R3_PREPUBLICATION_FIXTURE_RELATIVE_PATH}`);
+    });
+
+    it('CI regenerates the published matrix from the immutable registry tag', () => {
+        const workflow = fs.readFileSync(CI_WORKFLOW_PATH, 'utf8');
+
+        expect(workflow).toContain('repository: Kodria/awm-baseline-registry');
+        expect(workflow).toContain('ref: v2.0.0');
+        expect(workflow).toContain('path: awm-baseline-registry');
+        expect(workflow).toContain('Verify published sensor support matrix');
+        expect(workflow).toContain('--registry-root ../awm-baseline-registry --registry-tag v2.0.0 --registry-commit c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd');
+        expect(workflow).toContain('git diff --exit-code -- docs/support-matrix.md');
     });
 
     it('retains the published registry certification rows verbatim instead of inventing fixture evidence', () => {
@@ -212,6 +224,20 @@ describe('docs/support-matrix.md refleja el codigo', () => {
 
         expect(out).toContain('linea uno\r\nlinea dos');
         expect(out.split('\r\n').length - 1).toBe(out.split('\n').length - 1); // ni un LF suelto
+    });
+
+    it('preserva el EOL del bloque de providers aunque otro bloque sea CRLF', () => {
+        const mixedDoc = `intro\r\n${BEGIN_MARKER}\nold\n${END_MARKER}\nfin\n`;
+        const out = spliceGenerated(mixedDoc, 'linea uno\nlinea dos');
+
+        expect(out).toContain(`${BEGIN_MARKER}\n\nlinea uno\nlinea dos\n\n${END_MARKER}`);
+    });
+
+    it('preserva el EOL del bloque de sensores aunque otro bloque sea CRLF', () => {
+        const mixedDoc = `intro\r\n${SENSOR_BEGIN_MARKER}\nold\n${SENSOR_END_MARKER}\nfin\n`;
+        const out = spliceSensorSupportMatrix(mixedDoc, 'linea uno\nlinea dos');
+
+        expect(out).toContain(`${SENSOR_BEGIN_MARKER}\n\nlinea uno\nlinea dos\n\n${SENSOR_END_MARKER}`);
     });
 
     it('marks an unsupported scope rather than leaving it absent', () => {

--- a/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
+++ b/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
@@ -1311,7 +1311,7 @@ _Requirements: R7.7, R7.8, R9.1, R9.2, R9.3, R9.4, R10.11, R10.13_
 
 - [ ] **Step 1: Instalar consumidor publicado y pin exacto en homes temporales**
 
-Crear tmpdirs con `mktemp -d`; instalar `agentic-workflow-manager@8.0.0` allí y clonar/registrar exclusivamente `awm-baseline-registry@v2.0.0`. No tocar `~/.awm`. Guardar comandos y hashes, no rutas temporales absolutas.
+Crear tmpdirs con `mktemp -d`; instalar `agentic-workflow-manager@8.1.0` allí y clonar/registrar exclusivamente `awm-baseline-registry@v2.0.0`. No tocar `~/.awm`. Guardar comandos y hashes, no rutas temporales absolutas.
 
 - [ ] **Step 2: Ejecutar matriz end-to-end new/legacy/future**
 
@@ -1327,12 +1327,12 @@ Run:
 
 ```bash
 cd cli
-npx ts-node scripts/sensor-support-matrix.ts --registry-root ../../awm-baseline-registry
+npx ts-node scripts/sensor-support-matrix.ts --registry-root ../../awm-baseline-registry --registry-tag v2.0.0 --registry-commit c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd
 npx jest tests/structural/support-matrix-is-current.test.ts --runInBand
 git diff --check ../docs/support-matrix.md
 ```
 
-Expected: tabla idéntica a manifests de `v2.0.0`. `published-acceptance.json` registra `cliVersion:8.0.0`, `registryTag:v2.0.0`, commit/tag hashes, resultado 3-OS y hashes de fixtures.
+Expected: tabla idéntica a manifests de `v2.0.0`. `published-acceptance.json` registra `cliVersion:8.1.0`, `registryTag:v2.0.0`, commit/tag hashes, resultado 3-OS y hashes de fixtures.
 
 - [ ] **Step 5: Ejecutar reconciliación completa de ambos repos**
 
@@ -1352,12 +1352,12 @@ Expected: solo artefactos R3 intencionales; suites verdes; no harness evidence a
 Resolver URLs y abortar si falta alguna:
 
 ```bash
-CLI_PR_URL=$(gh pr list --repo Kodria/agentic-workflow --head feat/issue-20-r3-empirical-coverage --state all --json url --jq '.[0].url')
+CLI_PR_URL=$(gh pr list --repo Kodria/agentic-workflow --head feat/r3-pack-hardening-bridge --state all --json url --jq '.[0].url')
 REGISTRY_PR_URL=$(gh pr list --repo Kodria/awm-baseline-registry --head feat/issue-20-r3-compatible-packs --state all --json url --jq '.[0].url')
 test -n "$CLI_PR_URL" && test -n "$REGISTRY_PR_URL"
 ```
 
-Comentar issue #20 con PRs, npm 8.0.0, registry v2.0.0, comandos, schemas, matriz y retro. Cerrar #70 citando las variantes ESLint/TS y hardening opt-in. Cerrar #20 solo si sus demás releases están completas; si no, dejar baton exacto sin afirmar cierre global.
+Comentar issue #20 con PRs, npm 8.1.0, registry v2.0.0, comandos, schemas, matriz y retro. Cerrar #70 citando las variantes ESLint/TS y hardening opt-in. Cerrar #20 solo si sus demás releases están completas; si no, dejar baton exacto sin afirmar cierre global.
 
 - [ ] **Step 7: Persistir aceptación, solicitar review final y transferir a QA/retro/finishing**
 

--- a/docs/research/r3/published-acceptance.json
+++ b/docs/research/r3/published-acceptance.json
@@ -74,8 +74,10 @@
     "recommendationMutation": false
   },
   "supportMatrix": {
-    "updated": false,
-    "reason": "the checked-in generator and freshness test are pinned to the pre-publication fixture and explicitly reject a published-registry block; changing this requires a separate generator/test migration"
+    "updated": true,
+    "registryTag": "v2.0.0",
+    "registryCommit": "c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd",
+    "freshnessGate": "CI checks out the immutable registry tag, regenerates the matrix, and rejects documentation drift on Linux, macOS, and Windows"
   },
   "verdict": "incomplete: preserve as evidence only; do not treat as T13 completion or published cross-platform certification"
 }


### PR DESCRIPTION
Completa el gate documental de T13: CI clona el tag inmutable v2.0.0 del registry, regenera la matriz y rechaza drift en los tres SO. También reconcilia la evidencia publicada y la referencia 8.1.0. Refs #20.