### PR TITLE
fix(preflight): preserve JSON output on failure

### DIFF
--- a/cli/src/commands/preflight/index.ts
+++ b/cli/src/commands/preflight/index.ts
@@ -49,6 +49,9 @@ export function registerPreflightCommand(program: Command): void {
             const report = await preflight(opts.cwd ?? process.cwd());
             process.stdout.write(opts.json ? JSON.stringify(report, null, 2) + '\n' : formatReport(report));
             const code = exitCodeFor(report);
-            if (code !== 0) process.exit(code);
+            // `process.exit()` may truncate the JSON written immediately above when
+            // stdout is a pipe (CI, an API consumer, or a shell capture). Preserve
+            // the semantic exit code while allowing Node to flush the report.
+            if (code !== 0) process.exitCode = code;
         });
 }

--- a/cli/tests/integration/preflight-json-pipe.e2e.test.ts
+++ b/cli/tests/integration/preflight-json-pipe.e2e.test.ts
@@ -1,0 +1,22 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const cliRoot = path.resolve(__dirname, '../..');
+const bin = path.join(cliRoot, 'dist', 'src', 'index.js');
+
+test('preserves degraded preflight JSON when stdout is piped', () => {
+    const project = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-preflight-pipe-'));
+    try {
+        const result = spawnSync(process.execPath, [bin, 'preflight', '--json'], {
+            cwd: project,
+            encoding: 'utf8',
+            env: { ...process.env, AWM_HOME: path.join(project, 'awm-home'), AWM_NO_UPDATE_CHECK: '1' },
+        });
+        expect(result.status).toBe(1);
+        expect(JSON.parse(result.stdout)).toMatchObject({ status: 'not_configured' });
+    } finally {
+        fs.rmSync(project, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Cambio

Evita truncar la salida JSON de awm preflight --json cuando el reporte termina con código 1.

## Causa raíz

El comando escribía el JSON y luego forzaba la salida del proceso. Cuando stdout era un pipe, el proceso podía terminar antes de vaciar ese stream.

## Validación

- npm run typecheck
- npx jest tests/integration/preflight-json-pipe.e2e.test.ts tests/commands/preflight/preflight.test.ts --runInBand
- revisión independiente sin hallazgos

Refs #20. Desbloquea la aceptación publicada R3.