### PR TITLE
fix(sensors): select ESLint variants by native config

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-workflow-manager",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-workflow-manager",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/cli/src/commands/sensors/compatibility/contract.ts
+++ b/cli/src/commands/sensors/compatibility/contract.ts
@@ -185,7 +185,7 @@ function parseVariant(input: unknown, source: unknown, location: string): Sensor
     if (policy && ('requirements' in value || 'probe' in value)) invalid(source, `${location}.policyRef is authoritative; requirements and probe must not duplicate it`);
     if (!policy && (!('requirements' in value) || !('probe' in value))) invalid(source, `${location} requires requirements and probe when policyRef is absent`);
     const requirements = policy ? undefined : record(value.requirements, source, `${location}.requirements`);
-    if (requirements) fields(requirements, ['tool', 'toolRange', 'runtime', 'runtimeRange', 'configFiles'], source, `${location}.requirements`);
+    if (requirements) fields(requirements, ['tool', 'toolRange', 'runtime', 'runtimeRange', 'configFiles', 'packageJsonFields'], source, `${location}.requirements`);
     const toolRange = policy?.toolRange ?? text(requirements!.toolRange, source, `${location}.requirements.toolRange`);
     const runtimeRange = policy?.runtimeRange ?? text(requirements!.runtimeRange, source, `${location}.requirements.runtimeRange`);
     if (semver.validRange(toolRange) === null || semver.validRange(runtimeRange) === null) invalid(source, `${location}.requirements ranges must be valid semver ranges`);
@@ -200,7 +200,7 @@ function parseVariant(input: unknown, source: unknown, location: string): Sensor
         certifiedRange,
         requirements: policy
             ? { tool: policy.tool, toolRange, runtime: policy.runtime, runtimeRange }
-            : { tool: text(requirements!.tool, source, `${location}.requirements.tool`), toolRange, runtime: text(requirements!.runtime, source, `${location}.requirements.runtime`), runtimeRange, ...('configFiles' in requirements! ? { configFiles: stringArray(requirements!.configFiles, source, `${location}.requirements.configFiles`).map((file, index) => asset(file, source, `${location}.requirements.configFiles[${index}]`)) } : {}) },
+            : { tool: text(requirements!.tool, source, `${location}.requirements.tool`), toolRange, runtime: text(requirements!.runtime, source, `${location}.requirements.runtime`), runtimeRange, ...('configFiles' in requirements! ? { configFiles: stringArray(requirements!.configFiles, source, `${location}.requirements.configFiles`).map((file, index) => asset(file, source, `${location}.requirements.configFiles[${index}]`)) } : {}), ...('packageJsonFields' in requirements! ? { packageJsonFields: stringArray(requirements!.packageJsonFields, source, `${location}.requirements.packageJsonFields`).map((field, index) => { if (!/^[A-Za-z][A-Za-z0-9]*$/.test(field)) invalid(source, `${location}.requirements.packageJsonFields[${index}] must be a stable package.json field`); return field; }) } : {}) },
         assets: assetArray(value.assets, source, `${location}.assets`, true),
         formatter: text(value.formatter, source, `${location}.formatter`),
         probe: { kind: policy?.probe ?? probe!.kind as CompatibilityProbe },

--- a/cli/src/commands/sensors/compatibility/discovery.ts
+++ b/cli/src/commands/sensors/compatibility/discovery.ts
@@ -19,6 +19,8 @@ export type ProjectEvidence = {
     packageManagerConflict: boolean;
     scripts: string[];
     configFiles: string[];
+    /** Names only; package.json values are never emitted as compatibility evidence. */
+    packageJsonFields: string[];
     paths: string[];
 };
 
@@ -155,6 +157,7 @@ export function discoverProjectEvidence(cwd: unknown, pack: SensorPack, dependen
     }
     const configFiles = [...configCandidates].filter(file => safeFile(root, file)).sort();
     const scripts = Object.keys(stringMap(pkg?.scripts)).sort();
+    const packageJsonFields = Object.keys(pkg ?? {}).filter(field => /^[A-Za-z][A-Za-z0-9]*$/.test(field)).sort();
     const declaredToolRanges = { ...stringMap(pkg?.dependencies), ...stringMap(pkg?.devDependencies), ...stringMap(pkg?.peerDependencies) };
     const tools = new Set<string>();
     if ('schemaVersion' in pack) for (const sensor of Object.values(pack.sensors)) for (const variant of sensor.variants) tools.add(variant.requirements.tool);
@@ -164,6 +167,6 @@ export function discoverProjectEvidence(cwd: unknown, pack: SensorPack, dependen
     return {
         cwd: root, os: targetPlatform, runtimeVersions: { node: process.versions.node ?? null, ...(environment ? { python: environment.runtimeVersion } : {}) }, pythonEnvironmentRoot: environment?.rootParts[0] ?? null, declaredToolRanges, toolVersions,
         packageManager: declaredManager ?? (lockManagers.size === 1 ? [...lockManagers][0] : null), packageManagerConflict: lockManagers.size > 1,
-        scripts, configFiles, paths: [...new Set([...(safeFile(root, 'package.json') ? ['package.json'] : []), ...locks, ...configFiles])].sort(),
+        scripts, configFiles, packageJsonFields, paths: [...new Set([...(safeFile(root, 'package.json') ? ['package.json'] : []), ...locks, ...configFiles])].sort(),
     };
 }

--- a/cli/src/commands/sensors/compatibility/live.ts
+++ b/cli/src/commands/sensors/compatibility/live.ts
@@ -80,6 +80,7 @@ export async function resolveParsedPackCompatibility(cwd: string, pack: SensorPa
                 toolExecutable: variant.command.executable,
                 toolResolution: variant.command.resolution,
                 pythonEnvironmentRoot: variant.command.pythonEnvironmentRoot,
+                environment: variant.command.environment,
                 configFiles: evidence.configFiles,
                 scripts: evidence.scripts,
             })

--- a/cli/src/commands/sensors/compatibility/probe.ts
+++ b/cli/src/commands/sensors/compatibility/probe.ts
@@ -3,7 +3,7 @@ import type { CompatibilityProbe, StructuredCommand } from './types';
 
 export type ProbeStatus = 'matched' | 'not-matched' | 'unverifiable';
 export type ProbeResult = { status: ProbeStatus; reason: string };
-export type ProbeEvidence = { cwd: string; toolExecutable?: string; toolResolution?: StructuredCommand['resolution']; pythonEnvironmentRoot?: StructuredCommand['pythonEnvironmentRoot']; configFiles?: string[]; scripts?: string[] };
+export type ProbeEvidence = { cwd: string; toolExecutable?: string; toolResolution?: StructuredCommand['resolution']; pythonEnvironmentRoot?: StructuredCommand['pythonEnvironmentRoot']; environment?: StructuredCommand['environment']; configFiles?: string[]; scripts?: string[] };
 export type ProbeExecutor = (command: StructuredCommand, options: ExecOptions) => Promise<ExecResult>;
 const KINDS = new Set<CompatibilityProbe>(['version', 'eslint-print-config', 'typescript-show-config', 'semgrep-validate', 'package-script-present', 'config-present']);
 
@@ -18,7 +18,12 @@ function commandFor(kind: CompatibilityProbe, evidence: ProbeEvidence): Structur
             : 'node-modules-bin');
     if (kind === 'package-script-present') return null;
     if (kind === 'config-present') return null;
-    const command = { executable, resolution, ...(resolution === 'python-environment' && evidence.pythonEnvironmentRoot ? { pythonEnvironmentRoot: evidence.pythonEnvironmentRoot } : {}) };
+    const command = {
+        executable,
+        resolution,
+        ...(resolution === 'python-environment' && evidence.pythonEnvironmentRoot ? { pythonEnvironmentRoot: evidence.pythonEnvironmentRoot } : {}),
+        ...(evidence.environment ? { environment: evidence.environment } : {}),
+    };
     if (kind === 'version') return { ...command, args: ['--version'] };
     if (kind === 'eslint-print-config') return { ...command, args: ['--print-config', evidence.configFiles?.[0] ?? 'package.json'] };
     if (kind === 'typescript-show-config') return { ...command, args: ['--showConfig'] };

--- a/cli/src/commands/sensors/compatibility/resolve.ts
+++ b/cli/src/commands/sensors/compatibility/resolve.ts
@@ -3,7 +3,7 @@ import { legacyCompatibility } from './manifest';
 import type { CompatibilityEvidence, SensorPack, SensorPackSensor, SensorVariant } from './types';
 import type { ProjectEvidence } from './discovery';
 
-export type ResolveEvidence = { paths?: string[]; applicable?: boolean; packSelection?: 'explicit'; packageManagerConflict?: boolean; toolVersion?: string | null; runtimeVersion?: string | null; toolVersions?: Record<string, string | null>; runtimeVersions?: Record<string, string | null>; os?: NodeJS.Platform; probe?: { status?: string } };
+export type ResolveEvidence = { paths?: string[]; applicable?: boolean; packSelection?: 'explicit'; packageManagerConflict?: boolean; toolVersion?: string | null; runtimeVersion?: string | null; toolVersions?: Record<string, string | null>; runtimeVersions?: Record<string, string | null>; packageJsonFields?: string[]; os?: NodeJS.Platform; probe?: { status?: string } };
 export type ResolveContext = { pack: string; sensor: string };
 
 function result(state: CompatibilityEvidence['state'], reason: string, variant: SensorVariant | null, evidence: ResolveEvidence): CompatibilityEvidence {
@@ -44,8 +44,11 @@ function runtimeFor(variant: SensorVariant, evidence: ResolveEvidence): string |
  * that a project must contain in full. A variant without this requirement is
  * configuration-agnostic. */
 function hasRequiredConfig(variant: SensorVariant, evidence: ResolveEvidence): boolean {
-    const required = variant.requirements.configFiles ?? [];
-    return required.length === 0 || required.some(file => evidence.paths?.includes(file));
+    const requiredFiles = variant.requirements.configFiles ?? [];
+    const requiredFields = variant.requirements.packageJsonFields ?? [];
+    return (requiredFiles.length === 0 && requiredFields.length === 0)
+        || requiredFiles.some(file => evidence.paths?.includes(file))
+        || requiredFields.some(field => evidence.packageJsonFields?.includes(field));
 }
 
 /** Pure precedence resolver. It consumes discovered evidence and neither probes nor executes commands. */

--- a/cli/src/commands/sensors/compatibility/resolve.ts
+++ b/cli/src/commands/sensors/compatibility/resolve.ts
@@ -39,6 +39,15 @@ function runtimeFor(variant: SensorVariant, evidence: ResolveEvidence): string |
     return evidence.runtimeVersions === undefined ? evidence.runtimeVersion : evidence.runtimeVersions[variant.requirements.runtime];
 }
 
+/** A variant may name alternative native configuration files that make it
+ * applicable. They are alternatives (for example `.eslintrc.*`), not a list
+ * that a project must contain in full. A variant without this requirement is
+ * configuration-agnostic. */
+function hasRequiredConfig(variant: SensorVariant, evidence: ResolveEvidence): boolean {
+    const required = variant.requirements.configFiles ?? [];
+    return required.length === 0 || required.some(file => evidence.paths?.includes(file));
+}
+
 /** Pure precedence resolver. It consumes discovered evidence and neither probes nor executes commands. */
 export function resolveSensorCompatibility(sensor: SensorPackSensor | Record<string, unknown>, evidence: ResolveEvidence, context: ResolveContext): CompatibilityEvidence {
     if (!sensor || typeof sensor !== 'object' || !evidence || typeof evidence !== 'object') throw new Error('sensor and discovered evidence are required');
@@ -52,7 +61,9 @@ export function resolveSensorCompatibility(sensor: SensorPackSensor | Record<str
     if (availableTools.every(version => version === null || version === undefined)) return result('missing-tool', 'tool-not-found', null, evidence);
     const operational = v2.variants.filter(variant => validVersion(toolFor(variant, evidence)) && validVersion(runtimeFor(variant, evidence)));
     if (operational.length === 0) return result('unverifiable', 'invalid-or-missing-version-evidence', null, evidence);
-    const matches = operational.filter(variant => semver.satisfies(toolFor(variant, evidence)!, variant.requirements.toolRange) && semver.satisfies(runtimeFor(variant, evidence)!, variant.requirements.runtimeRange));
+    const matches = operational.filter(variant => semver.satisfies(toolFor(variant, evidence)!, variant.requirements.toolRange)
+        && semver.satisfies(runtimeFor(variant, evidence)!, variant.requirements.runtimeRange)
+        && hasRequiredConfig(variant, evidence));
     if (matches.length === 0) return result('incompatible', 'no-operational-variant', null, evidence);
     matches.sort((a, b) => b.priority - a.priority || specificity(b) - specificity(a) || a.id.localeCompare(b.id));
     const best = matches[0];

--- a/cli/src/commands/sensors/compatibility/types.ts
+++ b/cli/src/commands/sensors/compatibility/types.ts
@@ -41,7 +41,7 @@ export type SensorVariant = {
     id: string;
     priority: number;
     certifiedRange: string;
-    requirements: { tool: string; toolRange: string; runtime: string; runtimeRange: string; configFiles?: string[] };
+    requirements: { tool: string; toolRange: string; runtime: string; runtimeRange: string; configFiles?: string[]; packageJsonFields?: string[] };
     assets: string[];
     formatter: string;
     probe: { kind: CompatibilityProbe };

--- a/cli/tests/commands/sensors/compatibility/contract.test.ts
+++ b/cli/tests/commands/sensors/compatibility/contract.test.ts
@@ -159,9 +159,11 @@ describe('sensor pack v2 contract', () => {
         expect(() => parseSensorPack({ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [{ ...variant, probe: { kind: 'version', extra: true } }] } } }, 'pack')).toThrow('unknown field');
     });
 
-    it('preserves configFiles and rejects incomplete public overlap input', () => {
-        const variant = { ...validPack().sensors.lint.variants[0], requirements: { ...validPack().sensors.lint.variants[0].requirements, configFiles: ['eslint.config.js'] } };
-        expect(parseSensorPack({ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [variant] } } }, 'pack')).toMatchObject({ kind: 'v2', pack: { sensors: { lint: { variants: [{ requirements: { configFiles: ['eslint.config.js'] } }] } } } });
+    it('preserves config selectors and validates package.json field names', () => {
+        const variant = { ...validPack().sensors.lint.variants[0], requirements: { ...validPack().sensors.lint.variants[0].requirements, configFiles: ['eslint.config.js'], packageJsonFields: ['eslintConfig'] } };
+        expect(parseSensorPack({ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [variant] } } }, 'pack')).toMatchObject({ kind: 'v2', pack: { sensors: { lint: { variants: [{ requirements: { configFiles: ['eslint.config.js'], packageJsonFields: ['eslintConfig'] } }] } } } });
+        const malformed = { ...variant, requirements: { ...variant.requirements, packageJsonFields: ['eslint-config'] } };
+        expect(() => parseSensorPack({ ...validPack(), sensors: { lint: { ...validPack().sensors.lint, variants: [malformed] } } }, 'pack')).toThrow('packageJsonFields[0]');
         const complete = validPack().sensors.lint.variants[0];
         expect(() => assertNoEqualPriorityOverlap([{ ...complete, id: '../bad' }] as unknown)).toThrow('stable lowercase id');
         expect(() => assertNoEqualPriorityOverlap([{ ...complete, command: undefined }] as unknown)).toThrow('command');

--- a/cli/tests/commands/sensors/compatibility/discovery.test.ts
+++ b/cli/tests/commands/sensors/compatibility/discovery.test.ts
@@ -7,7 +7,7 @@ describe('discoverProjectEvidence', () => {
     it('returns only local, relative project evidence and detects conflicting lockfiles', () => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-discovery-'));
         try {
-            fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ scripts: { lint: 'eslint .' }, devDependencies: { eslint: '10.0.0' } }));
+            fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({ scripts: { lint: 'eslint .' }, eslintConfig: { env: { node: true } }, devDependencies: { eslint: '10.0.0' } }));
             fs.writeFileSync(path.join(root, 'package-lock.json'), '{}');
             fs.writeFileSync(path.join(root, 'pnpm-lock.yaml'), 'lockfileVersion: 9');
             fs.writeFileSync(path.join(root, 'eslint.config.js'), 'export default []');
@@ -20,6 +20,7 @@ describe('discoverProjectEvidence', () => {
             expect(evidence.toolVersions.eslint).toBe('10.4.1');
             expect(evidence.scripts).toContain('lint');
             expect(evidence.configFiles).toContain('eslint.config.js');
+            expect(evidence.packageJsonFields).toContain('eslintConfig');
             expect(evidence.paths.every((item: string) => !path.isAbsolute(item) && !item.includes('..'))).toBe(true);
         } finally { fs.rmSync(root, { recursive: true, force: true }); }
     });

--- a/cli/tests/commands/sensors/compatibility/probe.test.ts
+++ b/cli/tests/commands/sensors/compatibility/probe.test.ts
@@ -29,6 +29,20 @@ describe('runCompatibilityProbe', () => {
         );
     });
 
+    it('propagates the selected ESLint mode to its compatibility probe', async () => {
+        await runCompatibilityProbe({ kind: 'eslint-print-config' }, {
+            ...evidence,
+            toolExecutable: 'eslint',
+            toolResolution: 'node-modules-bin',
+            environment: { ESLINT_USE_FLAT_CONFIG: 'true' },
+        }, fakeExecutor);
+
+        expect(fakeExecutor).toHaveBeenCalledWith(
+            expect.objectContaining({ environment: { ESLINT_USE_FLAT_CONFIG: 'true' } }),
+            expect.any(Object),
+        );
+    });
+
     it('binds Semgrep validation to the contained Python environment', async () => {
         await runCompatibilityProbe({ kind: 'semgrep-validate' }, evidence, fakeExecutor);
 

--- a/cli/tests/commands/sensors/compatibility/resolve.test.ts
+++ b/cli/tests/commands/sensors/compatibility/resolve.test.ts
@@ -73,6 +73,23 @@ describe('resolveSensorCompatibility', () => {
         expect(resolved).toMatchObject({ state: 'certified', variantId: 'eslint-8-flat' });
     });
 
+    it('selects the ESLint 8 eslintrc variant from package.json eslintConfig evidence', () => {
+        const eslintrc = {
+            ...variant('eslint-8-eslintrc', 40, '>=8 <9', '=8.57.1'),
+            requirements: { ...variant('eslint-8-eslintrc').requirements, toolRange: '>=8 <9', packageJsonFields: ['eslintConfig'] },
+        };
+        const flat = {
+            ...variant('eslint-8-flat', 30, '>=8 <9', '=8.57.1'),
+            requirements: { ...variant('eslint-8-flat').requirements, toolRange: '>=8 <9', configFiles: ['eslint.config.mjs'] },
+        };
+        const resolved = resolveSensorCompatibility({ applicability: { allFiles: ['package.json'] }, variants: [eslintrc, flat] } as any,
+            evidence({ toolVersion: '8.57.1', paths: ['package.json'], packageJsonFields: ['eslintConfig'] }), context);
+        expect(resolved).toMatchObject({ state: 'certified', variantId: 'eslint-8-eslintrc' });
+        expect(resolveSensorCompatibility({ applicability: { allFiles: ['package.json'] }, variants: [eslintrc, flat] } as any,
+            evidence({ toolVersion: '8.57.1', paths: ['package.json'], packageJsonFields: [] }), context))
+            .toMatchObject({ state: 'incompatible', variantId: null });
+    });
+
     it('does not reuse scalar evidence for a missing key in a version map', () => {
         const biome = { ...variant('biome'), requirements: { ...variant('biome').requirements, tool: 'biome', runtime: 'bun' } };
         expect(resolveSensorCompatibility({ applicability: { allFiles: ['package.json'] }, variants: [biome] } as any,

--- a/cli/tests/commands/sensors/compatibility/resolve.test.ts
+++ b/cli/tests/commands/sensors/compatibility/resolve.test.ts
@@ -59,6 +59,20 @@ describe('resolveSensorCompatibility', () => {
         expect(resolved).toMatchObject({ state: 'certified', variantId: 'eslint', toolVersion: '10.4.1', runtimeVersion: '22.0.0' });
     });
 
+    it('selects the ESLint 8 flat variant from native config evidence before priority', () => {
+        const eslintrc = {
+            ...variant('eslint-8-eslintrc', 40, '>=8 <9', '=8.57.1'),
+            requirements: { ...variant('eslint-8-eslintrc').requirements, toolRange: '>=8 <9', configFiles: ['.eslintrc.json'] },
+        };
+        const flat = {
+            ...variant('eslint-8-flat', 30, '>=8 <9', '=8.57.1'),
+            requirements: { ...variant('eslint-8-flat').requirements, toolRange: '>=8 <9', configFiles: ['eslint.config.mjs'] },
+        };
+        const resolved = resolveSensorCompatibility({ applicability: { allFiles: ['package.json'] }, variants: [eslintrc, flat] } as any,
+            evidence({ toolVersion: '8.57.1', paths: ['package.json', 'eslint.config.mjs'] }), context);
+        expect(resolved).toMatchObject({ state: 'certified', variantId: 'eslint-8-flat' });
+    });
+
     it('does not reuse scalar evidence for a missing key in a version map', () => {
         const biome = { ...variant('biome'), requirements: { ...variant('biome').requirements, tool: 'biome', runtime: 'bun' } };
         expect(resolveSensorCompatibility({ applicability: { allFiles: ['package.json'] }, variants: [biome] } as any,

--- a/cli/tests/commands/sensors/init.test.ts
+++ b/cli/tests/commands/sensors/init.test.ts
@@ -334,6 +334,7 @@ describe('initSensors', () => {
             expect(automatic.manifest).toMatchObject({ schemaVersion: 2, pack: 'generic', sensors: {} });
             expect((automatic.manifest as any).packSelection).toBeUndefined();
 
+            fs.writeFileSync(path.join(tmpDir, 'generic.config'), 'fixture\n');
             const explicit = await initSensors({ cwd: tmpDir, registryRoot: v2Registry, pack: 'generic' });
             const written = JSON.parse(fs.readFileSync(path.join(tmpDir, '.awm', 'sensors.json'), 'utf8'));
             expect(explicit.manifest).toMatchObject({ schemaVersion: 2, pack: 'generic', packSelection: 'explicit', sensors: { security: { variantId: 'eslint-10' } } });


### PR DESCRIPTION
## Cambio

El resolver de compatibilidad considera la configuración nativa como parte de la selección de una variante.

También incorpora evidencia de nombres de campos de package.json, sin incluir sus valores. Esto permite reconocer eslintConfig de forma segura.

## Motivo

ESLint 8 usa el mismo rango de versión para eslintrc y flat config. Elegir solo por prioridad podía materializar la variante incorrecta.

## Validación

- npx jest tests/commands/sensors/compatibility/resolve.test.ts tests/commands/sensors/compatibility/discovery.test.ts tests/commands/sensors/compatibility/contract.test.ts --runInBand
- npm run typecheck

Depende de Kodria/awm-baseline-registry#30 para que el tag publicado declare las nuevas señales de configuración.
