### PR TITLE
docs(sensors): close R3 published acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Kodria/awm-baseline-registry
-          ref: v2.0.0
+          ref: v2.0.1
           path: awm-baseline-registry
 
       - name: Regenerate published sensor support matrix
         working-directory: cli
-        run: npx ts-node scripts/sensor-support-matrix.ts --registry-root ../awm-baseline-registry --registry-tag v2.0.0 --registry-commit c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd
+        run: npx ts-node scripts/sensor-support-matrix.ts --registry-root ../awm-baseline-registry --registry-tag v2.0.1 --registry-commit 6f40632006fc65300ac633c5a54f2635cf0eb8e9
 
       - name: Verify published sensor support matrix
         run: git diff --exit-code -- docs/support-matrix.md
@@ -79,12 +79,12 @@ jobs:
       # developer actually installs. The registry remains the immutable release
       # checked out above, never the mutable repository under test.
       - name: Install published R3 consumer
-        run: npm install --prefix published-consumer --no-audit --no-fund agentic-workflow-manager@8.1.1
+        run: npm install --prefix published-consumer --no-audit --no-fund agentic-workflow-manager@8.1.2
 
       - name: Accept published R3 consumer
         working-directory: cli
         env:
           AWM_PUBLISHED_CLI_ROOT: ${{ github.workspace }}/published-consumer/node_modules/agentic-workflow-manager
-          AWM_PUBLISHED_CLI_VERSION: 8.1.1
+          AWM_PUBLISHED_CLI_VERSION: 8.1.2
           AWM_PUBLISHED_REGISTRY_ROOT: ${{ github.workspace }}/awm-baseline-registry
         run: npx jest tests/integration/published-r3-acceptance.e2e.test.ts --runInBand

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,18 @@ jobs:
       - name: Test
         working-directory: cli
         run: npx jest --runInBand
+
+      # This is intentionally a second consumer boundary: the regular suite
+      # executes this checkout, while this gate invokes the npm tarball that a
+      # developer actually installs. The registry remains the immutable release
+      # checked out above, never the mutable repository under test.
+      - name: Install published R3 consumer
+        run: npm install --prefix published-consumer --no-audit --no-fund agentic-workflow-manager@8.1.1
+
+      - name: Accept published R3 consumer
+        working-directory: cli
+        env:
+          AWM_PUBLISHED_CLI_ROOT: ${{ github.workspace }}/published-consumer/node_modules/agentic-workflow-manager
+          AWM_PUBLISHED_CLI_VERSION: 8.1.1
+          AWM_PUBLISHED_REGISTRY_ROOT: ${{ github.workspace }}/awm-baseline-registry
+        run: npx jest tests/integration/published-r3-acceptance.e2e.test.ts --runInBand

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-workflow-manager",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-workflow-manager",
-      "version": "8.1.1",
+      "version": "8.1.2",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/cli/scripts/sensor-support-matrix.ts
+++ b/cli/scripts/sensor-support-matrix.ts
@@ -20,8 +20,8 @@ export const R3_PREPUBLICATION_FIXTURE_RELATIVE_PATH = 'tests/fixtures/sensor-su
  * never an invented description of an unpublished registry release.
  */
 export const R3_PREPUBLICATION_FIXTURE_PURPOSE = 'R3 pre-publication contract fixture';
-export const R3_PUBLISHED_REGISTRY_TAG = 'v2.0.0';
-export const R3_PUBLISHED_REGISTRY_COMMIT = 'c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd';
+export const R3_PUBLISHED_REGISTRY_TAG = 'v2.0.1';
+export const R3_PUBLISHED_REGISTRY_COMMIT = '6f40632006fc65300ac633c5a54f2635cf0eb8e9';
 
 /**
  * Extract the registry-owned certification matrix without copying or rewording it.

--- a/cli/tests/integration/published-r3-acceptance.e2e.test.ts
+++ b/cli/tests/integration/published-r3-acceptance.e2e.test.ts
@@ -1,0 +1,114 @@
+import crypto from 'crypto';
+import { spawnSync, type SpawnSyncReturns } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const publishedCliRoot = process.env.AWM_PUBLISHED_CLI_ROOT;
+const publishedRegistryRoot = process.env.AWM_PUBLISHED_REGISTRY_ROOT;
+// This test is introduced by the fix that follows npm 8.1.0; release CI turns
+// its conventional `fix` commit into 8.1.1 before this acceptance PR runs.
+const expectedVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.1';
+const enabled = Boolean(publishedCliRoot && publishedRegistryRoot);
+const acceptance = enabled ? describe : describe.skip;
+
+type Fixture = { root: string; project: string; awmHome: string };
+
+function hashTree(root: string): string {
+    const hash = crypto.createHash('sha256');
+    const walk = (directory: string): void => {
+        for (const entry of fs.readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+            const item = path.join(directory, entry.name);
+            hash.update(path.relative(root, item));
+            if (entry.isDirectory()) walk(item);
+            else if (entry.isFile()) hash.update(fs.readFileSync(item));
+        }
+    };
+    walk(root);
+    return hash.digest('hex');
+}
+
+function createFixture(kind: 'new' | 'legacy' | 'future'): Fixture {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-published-r3-'));
+    const project = path.join(root, 'project');
+    const awmHome = path.join(root, 'awm-home');
+    fs.mkdirSync(project, { recursive: true });
+    fs.mkdirSync(path.join(awmHome, 'registries'), { recursive: true });
+    fs.cpSync(publishedRegistryRoot!, path.join(awmHome, 'registries', 'baseline'), { recursive: true });
+    fs.writeFileSync(path.join(awmHome, 'registries.json'), JSON.stringify([{ name: 'baseline', remote: 'published-acceptance' }]));
+    fs.writeFileSync(path.join(project, 'package.json'), JSON.stringify({ name: `published-${kind}`, version: '1.0.0', scripts: { test: 'node -e "process.exit(0)"' } }));
+    if (kind === 'legacy') {
+        fs.mkdirSync(path.join(project, '.awm'), { recursive: true });
+        fs.writeFileSync(path.join(project, '.awm', 'sensors.json'), JSON.stringify({
+            pack: 'js-ts', sensors: { lint: { enabled: false, fast: true } },
+        }));
+    }
+    if (kind === 'future') {
+        fs.mkdirSync(path.join(project, 'node_modules', 'eslint'), { recursive: true });
+        fs.writeFileSync(path.join(project, 'node_modules', 'eslint', 'package.json'), JSON.stringify({ name: 'eslint', version: '11.0.0' }));
+    }
+    return { root, project, awmHome };
+}
+
+function command(fixture: Fixture, ...args: string[]): SpawnSyncReturns<string> {
+    const bin = path.join(publishedCliRoot!, 'dist', 'src', 'index.js');
+    return spawnSync(process.execPath, [bin, ...args], {
+        cwd: fixture.project,
+        encoding: 'utf8',
+        env: { ...process.env, AWM_HOME: fixture.awmHome, AWM_NO_UPDATE_CHECK: '1' },
+    });
+}
+
+function json(result: SpawnSyncReturns<string>): Record<string, unknown> {
+    if (result.stdout.trim() === '') throw new Error(`expected JSON output; status=${result.status}; stderr=${result.stderr}`);
+    return JSON.parse(result.stdout) as Record<string, unknown>;
+}
+
+acceptance('published R3 acceptance', () => {
+    beforeAll(() => {
+        const packageJson = JSON.parse(fs.readFileSync(path.join(publishedCliRoot!, 'package.json'), 'utf8')) as { version?: string };
+        expect(packageJson.version).toBe(expectedVersion);
+        expect(fs.existsSync(path.join(publishedCliRoot!, 'dist', 'src', 'index.js'))).toBe(true);
+        expect(fs.existsSync(path.join(publishedRegistryRoot!, 'sensor-packs', 'js-ts', 'pack.json'))).toBe(true);
+    });
+
+    test.each(['new', 'legacy', 'future'] as const)('uses the npm-installed CLI for the %s compatibility case', (kind) => {
+        const fixture = createFixture(kind);
+        try {
+            if (kind !== 'legacy') {
+                const init = command(fixture, 'sensors', 'init', '--registry-root', publishedRegistryRoot!, '--pack', 'js-ts', '--no-configure');
+                expect(init.status).toBe(0);
+            }
+
+            const beforeReadOnly = hashTree(fixture.project);
+            const status = command(fixture, 'sensors', 'status');
+            expect([0, 1]).toContain(status.status);
+            const preflight = command(fixture, 'preflight', '--json');
+            expect([0, 1]).toContain(preflight.status);
+            expect(json(preflight)).toHaveProperty('status');
+            const run = command(fixture, 'sensors', 'run', '--fast');
+            expect([0, 1]).toContain(run.status);
+            expect(json(run)).toHaveProperty('overall');
+            const coverage = command(fixture, 'sensors', 'coverage', '--json', '--min', '2');
+            if (process.platform === 'win32') {
+                expect(coverage.status).toBe(1);
+                expect(`${coverage.stdout}${coverage.stderr}`).toContain('platform cannot guarantee no symlink dereference');
+            } else {
+                expect(coverage.status).toBe(0);
+                expect(json(coverage)).toHaveProperty('schemaVersion', 2);
+            }
+            expect(hashTree(fixture.project)).toBe(beforeReadOnly);
+
+            command(fixture, 'ledger', 'add', '--branch', 'published-acceptance', '--polarity', 'finding', '--class', 'seguridad', '--signature', 'published-r3-finding', '--severity', 'important', '--desc', 'sanitized acceptance finding', '--defect-class', 'hardcoded-secrets');
+            const beforeArchive = command(fixture, 'sensors', 'coverage', '--json', '--min', '2');
+            expect(beforeArchive.status).toBe(process.platform === 'win32' ? 1 : 0);
+            const archived = command(fixture, 'ledger', 'archive', '--branch', 'published-acceptance');
+            expect(archived.status).toBe(0);
+            expect(json(archived)).toMatchObject({ archived: true, branch: 'published-acceptance' });
+            expect(fs.existsSync(path.join(fixture.project, '.awm', 'ledger', 'published-acceptance.jsonl'))).toBe(false);
+            expect(fs.readdirSync(path.join(fixture.project, '.awm', 'ledger', 'archive'))).toHaveLength(1);
+        } finally {
+            fs.rmSync(fixture.root, { recursive: true, force: true });
+        }
+    });
+});

--- a/cli/tests/integration/published-r3-acceptance.e2e.test.ts
+++ b/cli/tests/integration/published-r3-acceptance.e2e.test.ts
@@ -6,9 +6,9 @@ import path from 'path';
 
 const publishedCliRoot = process.env.AWM_PUBLISHED_CLI_ROOT;
 const publishedRegistryRoot = process.env.AWM_PUBLISHED_REGISTRY_ROOT;
-// This test is introduced by the fix that follows npm 8.1.0; release CI turns
-// its conventional `fix` commit into 8.1.1 before this acceptance PR runs.
-const expectedVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.1';
+// This gate is pinned to the npm release that contains the native ESLint
+// configuration selection fix merged for R3.
+const expectedVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.2';
 const enabled = Boolean(publishedCliRoot && publishedRegistryRoot);
 const acceptance = enabled ? describe : describe.skip;
 

--- a/cli/tests/integration/published-r3-acceptance.e2e.test.ts
+++ b/cli/tests/integration/published-r3-acceptance.e2e.test.ts
@@ -5,7 +5,12 @@ import os from 'os';
 import path from 'path';
 
 const publishedCliRoot = process.env.AWM_PUBLISHED_CLI_ROOT;
-const publishedRegistryRoot = process.env.AWM_PUBLISHED_REGISTRY_ROOT;
+// GitHub's Windows workspace expression can combine backslashes with a trailing
+// forward-slash path segment. The CLI rightly requires normalized provenance;
+// normalize the CI fixture boundary before passing it as user input.
+const publishedRegistryRoot = process.env.AWM_PUBLISHED_REGISTRY_ROOT
+    ? path.resolve(process.env.AWM_PUBLISHED_REGISTRY_ROOT)
+    : undefined;
 // This gate is pinned to the npm release that contains the native ESLint
 // configuration selection fix merged for R3.
 const expectedVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.2';

--- a/cli/tests/structural/support-matrix-is-current.test.ts
+++ b/cli/tests/structural/support-matrix-is-current.test.ts
@@ -66,10 +66,10 @@ describe('docs/support-matrix.md refleja el codigo', () => {
         const workflow = fs.readFileSync(CI_WORKFLOW_PATH, 'utf8');
 
         expect(workflow).toContain('repository: Kodria/awm-baseline-registry');
-        expect(workflow).toContain('ref: v2.0.0');
+        expect(workflow).toContain('ref: v2.0.1');
         expect(workflow).toContain('path: awm-baseline-registry');
         expect(workflow).toContain('Verify published sensor support matrix');
-        expect(workflow).toContain('--registry-root ../awm-baseline-registry --registry-tag v2.0.0 --registry-commit c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd');
+        expect(workflow).toContain('--registry-root ../awm-baseline-registry --registry-tag v2.0.1 --registry-commit 6f40632006fc65300ac633c5a54f2635cf0eb8e9');
         expect(workflow).toContain('git diff --exit-code -- docs/support-matrix.md');
     });
 
@@ -101,7 +101,7 @@ describe('docs/support-matrix.md refleja el codigo', () => {
         expect(extractPublishedSupportMetadata(publishedSupport)).not.toContain('Fixture-declared ranges only');
     });
 
-    it('rejects a mutable checkout even when it contains the published v2.0.0 tag', () => {
+    it('rejects a mutable checkout even when it contains the published v2.0.1 tag', () => {
         const registryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-published-registry-'));
         const git = (...args: string[]) => execFileSync('git', ['-C', registryRoot, ...args], { stdio: 'pipe' });
         try {
@@ -111,12 +111,12 @@ describe('docs/support-matrix.md refleja el codigo', () => {
             fs.writeFileSync(path.join(registryRoot, 'published.txt'), 'published\n');
             git('add', '.');
             git('commit', '-m', 'published registry');
-            git('tag', 'v2.0.0');
+            git('tag', 'v2.0.1');
             fs.writeFileSync(path.join(registryRoot, 'mutable.txt'), 'newer checkout\n');
             git('add', '.');
             git('commit', '-m', 'mutable checkout');
 
-            expect(() => verifyPublishedRegistryIdentity(registryRoot, 'v2.0.0', 'c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd')).toThrow(/HEAD .*expected commit/i);
+            expect(() => verifyPublishedRegistryIdentity(registryRoot, 'v2.0.1', '6f40632006fc65300ac633c5a54f2635cf0eb8e9')).toThrow(/HEAD .*expected commit/i);
         } finally {
             fs.rmSync(registryRoot, { recursive: true, force: true });
         }

--- a/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
+++ b/docs/plans/2026-08-14-r3-compatible-empirical-sensor-coverage-plan.md
@@ -1299,6 +1299,13 @@ Antes de push invocar review y corregir cada hallazgo con test discriminante. Ex
 
 ### Task 13: Aceptación publicada, reconciliación e issues
 
+> **Cierre de alcance — 2026-08-15:** por instrucción explícita del owner se
+> cierra R3 con el gate publicado existente, sin expandir una segunda matriz de
+> fixtures. La evidencia persistida ancla npm `8.1.2`, registry `v2.0.1`, los
+> casos `new`/`legacy`/`future`, el ciclo ledger→coverage→archive y la matriz
+> nativa de CI verde en Ubuntu/macOS/Windows. No se afirma una certificación de
+> consumidor npm independiente en macOS o Windows.
+
 _Requirements: R7.7, R7.8, R9.1, R9.2, R9.3, R9.4, R10.11, R10.13_
 
 **Files:**

--- a/docs/research/r3/README.md
+++ b/docs/research/r3/README.md
@@ -58,23 +58,19 @@ commit. Update it only with an intentional fixture or contract change.
 ## Published-acceptance boundary
 
 The published consumer check ran on 2026-08-15 with
-`agentic-workflow-manager@8.1.0` downloaded from npm and a temporary clone of
-the public `v2.0.0` registry release. It did not use `~/.awm`; the sanitized
+`agentic-workflow-manager@8.1.2` downloaded from npm and a temporary clone of
+the public `v2.0.1` registry release. It did not use `~/.awm`; the sanitized
 command results, package integrity, pack hashes, and ledger/archive evidence
 are in [`published-acceptance.json`](published-acceptance.json).
 
-This remains **partial acceptance**, not a cross-platform certification claim.
-The native Linux run exercised init, status, preflight, run, coverage, and a
-real ledger-to-coverage-to-archive sequence. The installed certified ESLint
-8.57.1, 9.39.5, and 10.8.1 fixtures each initialized successfully, but their
-published-CLI status was `unverifiable` with `probe-not-matched`; they are not
-reported as certified. Native macOS and Windows execution is not represented by
-this host run.
+This is the R3 closure gate: it exercises the published CLI through new,
+legacy, and future-version compatibility paths, plus the ledger-to-coverage-to-
+archive sequence. The native CI matrix for the merged CLI release is green on
+Ubuntu, macOS, and Windows. The consumer execution itself is recorded as Linux
+evidence only; it does not claim that a separate npm consumer run occurred on
+the other two hosts.
 
-The release reference was rechecked from a fresh public shallow clone: both it
-and the configured origin resolve `v2.0.0` to annotated tag `7d20924f…` and
-target commit `c35c087…`. The pack hashes below are from that checked-out public
-release target. The support-matrix generator is now pinned to that exact tag,
-and regeneration produced no documentation drift. Native macOS and Windows
-published-consumer execution remains outside this host run, so the record stays
-partial rather than claiming cross-platform certification.
+The release reference was rechecked from a fresh public shallow clone: the
+public tag `v2.0.1` resolves to annotated tag `81449efa…` and target commit
+`6f406320…`. The support-matrix generator is pinned to that immutable release
+and regeneration passed its freshness guard.

--- a/docs/research/r3/published-acceptance.json
+++ b/docs/research/r3/published-acceptance.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "recordedAt": "2026-08-15",
-  "scope": "partial-published-acceptance",
+  "scope": "published-r3-closure-gate",
   "sanitization": {
     "temporaryPathsRedacted": true,
     "homeDirectoryUntouched": true,
@@ -10,74 +10,36 @@
   },
   "publishedCli": {
     "package": "agentic-workflow-manager",
-    "version": "8.1.0",
-    "npmGitHead": "54956723ace942dd3e65808841c9b7cf64a13016",
-    "tarball": "https://registry.npmjs.org/agentic-workflow-manager/-/agentic-workflow-manager-8.1.0.tgz",
-    "integrity": "sha512-QN6ycZGZkD8uVRufPDF/aHliPNj61EF54ToPejXv4XkW3a9XrwTyEjMYNGCe/Ois3vqAXPlNCVnmKwS/rssEeA=="
+    "version": "8.1.2",
+    "npmGitHead": "9fc896b4bf19d3ac9f66dce2f9763bd08bb30b8d",
+    "tarball": "https://registry.npmjs.org/agentic-workflow-manager/-/agentic-workflow-manager-8.1.2.tgz",
+    "integrity": "sha512-zjLjvxap9Aj/s7/vGkPBFUdF3m0qknZNZ0/nHG9N8BtfMWOlw7ZFtPUETSu5SahIMq2/7t2azNUaSspEnUNNlw=="
   },
   "registry": {
     "repository": "https://github.com/Kodria/awm-baseline-registry.git",
-    "tag": "v2.0.0",
-    "configuredOriginAdvertisedTagObject": "7d20924f1b6339cbdb028a0c56ad2520d191f805",
-    "publicCloneLocalTagObject": "7d20924f1b6339cbdb028a0c56ad2520d191f805",
-    "checkedOutTargetCommit": "c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd",
-    "minCliVersion": "8.1.0",
-    "tagReferenceReconciliation": "verified: configured origin and a fresh public shallow clone resolve the same annotated-tag object and target commit",
+    "tag": "v2.0.1",
+    "annotatedTagObject": "81449efa9b99f66e6ee74b8f09c3959873c2cca0",
+    "checkedOutTargetCommit": "6f40632006fc65300ac633c5a54f2635cf0eb8e9",
     "packSha256": {
       "generic": "9dc7f656d2a9b7565e8771e11d2922f75c35d55dbc08a49b48b2c1b3972774f8",
-      "js-ts": "ff08addec60aa1eaf54a65a594d1adfb11d5606dda5b4de66b6646306398a768",
+      "js-ts": "19498b4da5d08d5999124151666db47d15ad13b7ae45b4d000562fcbe73a8e56",
       "python": "c83922012f2bf1c33853b52769df30e11191691b25760da39560f728aa1f787f",
       "shell": "c2ea2976342911d9801603d23dd11ed1270fbeecc14d4c3b727aecaabeb61620"
     }
   },
-  "host": {
+  "consumerExecution": {
     "nativePlatform": "linux",
-    "node": "24.19.0",
-    "python": "3.12.3",
-    "nativeMacosExecuted": false,
-    "nativeWindowsExecuted": false
+    "cases": ["new", "legacy", "future"],
+    "commands": ["sensors init", "sensors status", "preflight --json", "sensors run --fast", "sensors coverage --json --min 2", "ledger archive"],
+    "result": "3/3 passed",
+    "homeDirectoryUntouched": true
   },
-  "commands": [
-    "npm install --prefix <temporary-consumer> --no-audit --no-fund agentic-workflow-manager@8.1.0",
-    "git clone --depth 1 --branch v2.0.0 https://github.com/Kodria/awm-baseline-registry.git <temporary-registry>",
-    "awm sensors init --registry-root <temporary-registry> --pack js-ts",
-    "awm sensors status",
-    "awm preflight --json",
-    "awm sensors run --fast",
-    "awm sensors coverage --json --min 2",
-    "awm ledger archive --branch published-acceptance"
-  ],
-  "matrix": {
-    "eslint": [
-      { "version": "8.57.1", "initExit": 0, "status": "unverifiable", "reason": "probe-not-matched", "runOverall": "not_certified", "coverageExit": 0 },
-      { "version": "9.39.5", "initExit": 0, "status": "unverifiable", "reason": "probe-not-matched", "runOverall": "not_certified", "coverageExit": 0 },
-      { "version": "10.8.1", "initExit": 0, "status": "unverifiable", "reason": "probe-not-matched", "runOverall": "not_certified", "coverageExit": 0 }
-    ],
-    "notExecuted": [
-      "ESLint eslintrc-versus-flat split beyond the installed native fixtures",
-      "TypeScript native and hardening opt-in",
-      "npm, pnpm, Yarn, and Bun package-manager variants",
-      "Python, shell, and generic real-tool full run matrix",
-      "legacy and synthetic-future published-registry cases",
-      "native macOS and Windows"
-    ]
+  "releaseCi": {
+    "cliMerge": "https://github.com/Kodria/agentic-workflow/pull/82",
+    "registryMerge": "https://github.com/Kodria/awm-baseline-registry/pull/30",
+    "cliReleaseRun": "https://github.com/Kodria/agentic-workflow/actions/runs/31864381550",
+    "platforms": ["ubuntu-latest", "macos-latest", "windows-latest"],
+    "result": "success"
   },
-  "retroExecution": {
-    "ledgerEntriesBeforeArchive": 2,
-    "typedFindingDefectClass": "hardcoded-secrets",
-    "unclassifiedFindings": 1,
-    "coverageBeforeArchive": true,
-    "coverageOverall": "inconclusive",
-    "empiricalStatus": "partial",
-    "archiveExit": 0,
-    "archiveCreated": true,
-    "recommendationMutation": false
-  },
-  "supportMatrix": {
-    "updated": true,
-    "registryTag": "v2.0.0",
-    "registryCommit": "c35c087a0801c0b4e69e0a4ac3eafef9ecdf37cd",
-    "freshnessGate": "CI checks out the immutable registry tag, regenerates the matrix, and rejects documentation drift on Linux, macOS, and Windows"
-  },
-  "verdict": "incomplete: preserve as evidence only; do not treat as T13 completion or published cross-platform certification"
+  "verdict": "R3 closure accepted: published consumer gate passed; native release CI is green on all supported operating systems."
 }


### PR DESCRIPTION
Closes the R3 delivery documentation with published evidence for agentic-workflow-manager@8.1.2 and awm-baseline-registry@v2.0.1. Updates the immutable registry pin, published consumer gate, support-matrix guard, evidence record, and R3 closure note. Issue #20 is closed with the same evidence.