### PR TITLE
chore(legal): licenciar AWM bajo Apache-2.0 y corregir la licencia publicada

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+Thanks for considering a contribution. This repository holds the **`awm` CLI**
+and the framework documentation. The content it delivers — skills, bundles,
+workflows, sensor packs — lives in
+[Kodria/awm-baseline-registry](https://github.com/Kodria/awm-baseline-registry).
+Changes to a skill belong there, not here.
+
+## Licensing of contributions
+
+This project is licensed under the [Apache License 2.0](LICENSE). By submitting
+a contribution you agree that it is licensed under the same terms (inbound =
+outbound), and that you have the right to submit it.
+
+### Sign your commits (DCO)
+
+Every commit must carry a `Signed-off-by` line certifying the
+[Developer Certificate of Origin](https://developercertificate.org/):
+
+```bash
+git commit -s -m "fix(sensors): ..."
+```
+
+The sign-off states that you wrote the contribution, or otherwise have the
+right to submit it under this project's license. If you are contributing on
+behalf of an employer, confirm first that you are permitted to do so — the
+copyright in work made during employment often belongs to the employer.
+
+## Before you open a pull request
+
+Read [`CONSTITUTION.md`](CONSTITUTION.md) — the non-negotiable rules (written
+in Spanish) — and [`docs/decisions.md`](docs/decisions.md), which records why
+things are the way they are. A proposal that reopens a decision listed there
+should say which one and why.
+
+### Run the same checks CI runs
+
+CI builds and runs the full suite on **Linux, macOS, and Windows**, because the
+CLI ships to all three and platform regressions have only ever surfaced there.
+Locally, at minimum:
+
+```bash
+cd cli
+npm run typecheck
+npm run lint
+npm test
+```
+
+Path handling, shell quoting, and symlink behaviour are the recurring sources
+of platform-specific breakage. If your change touches any of them, say so in
+the pull request so reviewers look at the Windows job.
+
+### Title the pull request as a conventional commit
+
+`release.yml` derives the published version from the conventional-commit prefix
+on merge to `main`: `feat` → minor, `fix` → patch, `!` or `BREAKING CHANGE` →
+major. Publication to npm happens automatically from that. A title without a
+prefix produces a `patch` release regardless of what the change actually does.
+
+### Tests are the contract, not a formality
+
+A new automated check is finished when you have broken what it protects on
+purpose and watched it fail with the right message — a green gate has two
+possible causes, and only one of them is good news. New behaviour arrives with
+the test that would fail without it.
+
+## Reporting problems
+
+- Bugs and proposals: open an issue.
+- Security vulnerabilities: **do not** open a public issue. Follow
+  [`SECURITY.md`](SECURITY.md).
+
+## Trademark
+
+Apache-2.0 §6 grants no trademark rights. The name "AWM" and the Kodria name
+and marks are not part of the software licence: a fork is free to exist, and
+free to use the code, but not to present itself as AWM.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,23 +8,35 @@ Changes to a skill belong there, not here.
 
 ## Licensing of contributions
 
-This project is licensed under the [Apache License 2.0](LICENSE). By submitting
-a contribution you agree that it is licensed under the same terms (inbound =
-outbound), and that you have the right to submit it.
+This project is licensed under the [Apache License 2.0](LICENSE). Section 5 of
+that licence already makes every contribution inbound = outbound: unless you
+state otherwise, what you submit is submitted under these same terms. There is
+nothing extra to sign for the licence to apply.
 
-### Sign your commits (DCO)
+**The pull request is the certification.** By opening one you state that you
+have the right to submit its contents under this licence — whether you typed
+the commits yourself or an agent produced them on your behalf. We deliberately
+do not require a per-commit `Signed-off-by` line: in an agent-delegated
+workflow the commit author is a tool, and a certification signed by a tool
+certifies nothing. The human act is opening and merging the pull request, so
+that is where the statement belongs. (A tool that builds agent-delegated
+workflows should not ship a contribution policy its own workflow cannot
+satisfy.)
 
-Every commit must carry a `Signed-off-by` line certifying the
-[Developer Certificate of Origin](https://developercertificate.org/):
+If you are contributing in the course of employment, confirm first that you are
+permitted to do so — the copyright in work made during employment often belongs
+to the employer, regardless of who or what wrote the commit.
 
-```bash
-git commit -s -m "fix(sensors): ..."
-```
+### If you are not the project owner
 
-The sign-off states that you wrote the contribution, or otherwise have the
-right to submit it under this project's license. If you are contributing on
-behalf of an employer, confirm first that you are permitted to do so — the
-copyright in work made during employment often belongs to the employer.
+The project owner can relicense this work only while they hold copyright in all
+of it. That remains true today. **The first merged contribution from anyone
+else ends it**, unless a contributor licence agreement granting the right to
+relicense is in place *before* that pull request is merged.
+
+So the rule is a trigger, not a plan: no CLA is needed while the owner is the
+sole contributor. The moment a third-party pull request is worth merging, the
+CLA decision is taken before the merge button, not after.
 
 ## Before you open a pull request
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+Agentic Workflow Manager (AWM)
+Copyright 2026 Kodria
+
+This product includes software developed by Kodria
+(https://github.com/Kodria).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -86,10 +86,19 @@ limitations. It is derived from the CLI source and checked in tests.
 
 ## Contributing
 
-Use the [architecture guide](docs/architecture.md) to understand the CLI and
-registry design, the [CLI developer guide](cli/README.md) to work on the CLI,
-and the [constitution](CONSTITUTION.md) for non-negotiable project rules.
+Start with [CONTRIBUTING.md](CONTRIBUTING.md) for how to submit changes and how
+contributions are licensed. Then use the
+[architecture guide](docs/architecture.md) to understand the CLI and registry
+design, the [CLI developer guide](cli/README.md) to work on the CLI, and the
+[constitution](CONSTITUTION.md) for non-negotiable project rules.
+
+To report a security vulnerability, follow [SECURITY.md](SECURITY.md) rather
+than opening a public issue.
 
 ## License
 
-MIT. See [package metadata](cli/package.json) for the published package details.
+[Apache License 2.0](LICENSE). See [NOTICE](NOTICE) for attribution.
+
+The name "AWM" and the Kodria name and marks are not covered by that grant —
+Apache-2.0 §6 conveys no trademark rights. You may use, modify, and
+redistribute the software; naming a derivative "AWM" requires permission.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report security issues through GitHub's private vulnerability reporting on this
+repository: **Security → Report a vulnerability**. Please do not open a public
+issue for a suspected vulnerability.
+
+Include the `awm --version`, the operating system (the CLI ships to Linux,
+macOS, and Windows), the agent adapter in use, the commands that reproduce it,
+and the observed behaviour.
+
+## What is in scope
+
+AWM is a CLI that reads and writes real paths on a developer's machine, invokes
+real toolchains, and installs content fetched from git registries. The threat
+model follows from that:
+
+- **Writes outside the intended paths.** `awm init`, `awm sync`, `awm add` and
+  `awm update` materialize files and symlinks under the project and under the
+  agent's configuration root. Path traversal, symlink following, or a backup or
+  restore path that escapes its scope are in scope.
+- **Command execution.** `awm sensors run`, `awm preflight`, and the job and
+  watch runners spawn subprocesses built from manifests and pack definitions.
+  Argument or command injection from registry content, project configuration,
+  or file names is in scope.
+- **Registry trust.** `awm registry add` accepts arbitrary remotes and
+  `awm update` resolves a tag from them. Anything that lets content bypass the
+  pin, the tag resolution, or the integrity of what is installed is in scope.
+- **Session hooks.** Hooks installed by AWM run automatically at the start of
+  every agent session. Anything that lets untrusted content reach that path is
+  in scope.
+- **Credential and state handling.** Leaking tokens, environment values, or
+  ledger contents into logs, exported artifacts, or telemetry is in scope.
+
+## What is out of scope
+
+- Vulnerabilities in the third-party tools sensors invoke (ESLint, TypeScript,
+  semgrep, mypy, ruff, shellcheck, and others). Report those upstream.
+- Vulnerabilities in agent harnesses (Claude Code, Codex, OpenCode, Cursor, and
+  others). Report those to their maintainers.
+- The content of the baseline registry — skills, workflows, sensor packs —
+  which lives in
+  [Kodria/awm-baseline-registry](https://github.com/Kodria/awm-baseline-registry)
+  and has its own policy.
+- A user deliberately pointing `awm registry add` at a remote they do not
+  trust. Registries are executed content; treat adding one as you would treat
+  adding a dependency.
+
+## Supported versions
+
+Fixes land on `main` and publish as a new version of
+[`agentic-workflow-manager`](https://www.npmjs.com/package/agentic-workflow-manager).
+There are no long-term support branches: upgrading is the fix path.

--- a/cli/package.json
+++ b/cli/package.json
@@ -38,7 +38,7 @@
     "ai"
   ],
   "author": "Kodria",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=22"
   },

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -507,16 +507,27 @@ que pasa revisión corporativa sin discusión.
 - Las skills del registry llevan `license: Apache-2.0` en su frontmatter: el
   campo es parte de la especificación Agent Skills y hace que la procedencia
   viaje con la skill incluso fuera del registry.
-- Las contribuciones entran bajo la misma licencia (inbound = outbound) con
-  firma DCO. **Un DCO certifica origen pero no habilita relicenciar**: si en
-  algún momento se quiere una capa comercial, hace falta un CLA con cesión, y
-  esa decisión debe tomarse antes de que crezca la base de contribuyentes, no
-  después.
+- Las contribuciones entran bajo la misma licencia sin trámite adicional: la
+  §5 de Apache-2.0 ya establece inbound = outbound. **No se exige firma DCO por
+  commit.** En un flujo delegado a agentes el autor del commit es una
+  herramienta, y una certificación firmada por una herramienta no certifica
+  nada; el acto humano es abrir y mergear el PR, así que ahí vive la
+  declaración. Una herramienta que construye flujos agénticos no puede publicar
+  una política de contribución que su propio flujo incumple en cada commit.
+- **Relicenciar sigue siendo posible mientras el titular sea el único
+  contribuyente**, y deja de serlo con el primer PR de un tercero que se
+  mergee. Por eso no queda un CLA pendiente: queda una regla con disparador —
+  el día que un PR externo valga la pena, la decisión de CLA se toma **antes**
+  del merge, no después. Está escrita en `CONTRIBUTING.md` de ambos repos.
 - **La marca no viaja con el código.** Apache-2.0 §6 no concede derechos de
   marca, y eso es intencional: el código es libre, el nombre es el control que
   queda. Un fork puede existir y usar todo el código; no puede presentarse como
   AWM.
 
-**Pendiente, y no lo resuelve esta decisión:** la titularidad. Ver
-[#84](https://github.com/Kodria/agentic-workflow/issues/84) — elegir licencia
-presupone ser el titular, y esa verificación ocurre fuera del repositorio.
+**Lo único que esta decisión NO resuelve es la titularidad**, y no puede
+resolverlo desde el repositorio: elegir licencia presupone ser el titular. Ver
+[#84](https://github.com/Kodria/agentic-workflow/issues/84). Si esa
+verificación arrojara titularidad compartida, la licencia elegida no se
+invalida — se vuelve una decisión que hay que acordar con el cotitular, y una
+licencia coherente sigue siendo estrictamente mejor que la contradicción
+MIT/ISC que había antes.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -25,6 +25,7 @@ Formato: qué se decidió, por qué, qué implica. Sin historia larga — eso vi
 | [D-018](#d-018) | 2026-08-14 | Coverage reports never create a false green | Active |
 | [D-019](#d-019) | 2026-08-14 | Schema v2 is a deliberate, reviewable migration | Active |
 | [D-020](#d-020) | 2026-08-14 | Retrospective coverage runs before ledger archive | Active |
+| [D-021](#d-021) | 2026-08-18 | AWM se licencia bajo Apache-2.0; la marca queda fuera del grant | Vigente |
 
 ---
 
@@ -483,3 +484,39 @@ new reusable control from repeated classified findings, but archival must not
 erase the feedback signal first. Until the registry's T12 integration is
 published, this is an operating rule: run `awm sensors coverage --min 2`
 manually before `awm ledger archive`; the CLI does not yet enforce ordering.
+
+## D-021
+
+**AWM se licencia bajo Apache-2.0, y la marca queda deliberadamente fuera del grant.**
+
+El proyecto se publicaba en npm sin licencia coherente: no existía archivo
+`LICENSE`, el README declaraba MIT y `cli/package.json` publicaba ISC. Un
+equipo con revisión de compliance no puede adoptar un paquete cuya licencia
+declarada difiere entre el repositorio y el registro.
+
+Se elige Apache-2.0 sobre MIT/ISC por tres razones concretas, no por
+preferencia: concede patentes de forma explícita (MIT e ISC no dicen nada al
+respecto, y el silencio es el problema cuando una organización adopta la
+herramienta), obliga a señalar los cambios en obras derivadas, y es la licencia
+que pasa revisión corporativa sin discusión.
+
+**Implica:**
+- `LICENSE` (texto verbatim) y `NOTICE` en la raíz de este repo y del registry;
+  ambos repos comparten licencia para que no haya que razonar dos veces.
+- `cli/package.json` declara `Apache-2.0`, y el README dejó de decir MIT.
+- Las skills del registry llevan `license: Apache-2.0` en su frontmatter: el
+  campo es parte de la especificación Agent Skills y hace que la procedencia
+  viaje con la skill incluso fuera del registry.
+- Las contribuciones entran bajo la misma licencia (inbound = outbound) con
+  firma DCO. **Un DCO certifica origen pero no habilita relicenciar**: si en
+  algún momento se quiere una capa comercial, hace falta un CLA con cesión, y
+  esa decisión debe tomarse antes de que crezca la base de contribuyentes, no
+  después.
+- **La marca no viaja con el código.** Apache-2.0 §6 no concede derechos de
+  marca, y eso es intencional: el código es libre, el nombre es el control que
+  queda. Un fork puede existir y usar todo el código; no puede presentarse como
+  AWM.
+
+**Pendiente, y no lo resuelve esta decisión:** la titularidad. Ver
+[#84](https://github.com/Kodria/agentic-workflow/issues/84) — elegir licencia
+presupone ser el titular, y esa verificación ocurre fuera del repositorio.


### PR DESCRIPTION
Cierra la capa legal del CLI. Ver #84 para lo único que no puede resolverse desde el repositorio.

## El problema

AWM se publica en npm como `agentic-workflow-manager` v8.1.2 y acaba de ser adoptado por una organización. El estado legal encontrado:

- **No existía archivo `LICENSE`.**
- `README.md` declaraba **MIT**; `cli/package.json` publicaba **`"license": "ISC"`**. Dos licencias distintas, ninguna con texto.
- Sin `CONTRIBUTING.md`, `SECURITY.md` ni `NOTICE`. Sin política de marca.

Un equipo con revisión de compliance no puede adoptar un paquete cuya licencia declarada difiere entre el repositorio y el registro de npm. Con la adopción organizacional recién conseguida, ese es un hallazgo que frena algo ya aprobado.

## Qué cambia

| Archivo | Cambio |
|---|---|
| `LICENSE` | Apache-2.0, texto verbatim de apache.org |
| `NOTICE` | Atribución |
| `cli/package.json` | `"license"`: `ISC` → `Apache-2.0` |
| `README.md` | Sección de licencia corregida (decía MIT) + reserva explícita de marca + enlaces a CONTRIBUTING y SECURITY |
| `SECURITY.md` | Nuevo: canal de reporte privado y modelo de amenaza real del CLI |
| `CONTRIBUTING.md` | Nuevo: términos de contribución, checks locales, título conventional, disciplina de gates |
| `docs/decisions.md` | **D-021** registra la decisión con su razón |

## Por qué Apache-2.0 y no MIT/ISC

Tres razones concretas, no preferencia:

1. **Concede patentes de forma explícita.** MIT e ISC no dicen nada al respecto, y el silencio es el problema cuando una organización adopta la herramienta.
2. **Obliga a señalar los cambios** en obras derivadas.
3. **Pasa revisión corporativa sin discusión**, que es literalmente el caso de uso.

Y su **§6 no concede derechos de marca**, lo cual acá es una ventaja deliberada: el código queda libre, el nombre es el control que permanece. Un fork puede existir y usar todo el código; no puede presentarse como AWM. Esa reserva quedó escrita en README, CONTRIBUTING y D-021.

## Sobre la política de contribución (se corrigió durante el trabajo)

La primera versión exigía firma DCO por commit. **Se retiró**, por dos razones:

1. La **§5 de Apache-2.0 ya establece inbound = outbound** sin trámite alguno. El DCO nunca fue necesario para que la licencia funcione; solo agregaba un registro.
2. En este proyecto el trabajo se delega a agentes y los merges salen del PR. Exigir `Signed-off-by` sería una regla que **este propio repositorio incumple en cada commit** — y una certificación firmada por una herramienta no certifica nada. Una herramienta que construye flujos agénticos no puede publicar una política de contribución que su propio flujo no puede satisfacer.

**El PR es la certificación.** El acto humano es abrirlo y mergearlo, y ahí queda la declaración.

### Relicenciamiento: regla con disparador, no tarea pendiente

Relicenciar sigue siendo posible mientras el titular sea el único contribuyente, y deja de serlo con el primer PR de un tercero que se mergee. Queda escrito en `CONTRIBUTING.md` de ambos repos: el día que un PR externo valga la pena, la decisión de CLA se toma **antes** del merge. No queda un CLA pendiente que se olvide.

## Modelo de amenaza de `SECURITY.md`

Escrito para lo que el CLI realmente hace, no genérico: escrituras fuera de las rutas previstas (`init`, `sync`, `add`, `update`, backup/restore), ejecución de subprocesos construidos desde manifiestos y packs, confianza en registries remotos que `registry add` acepta, hooks de sesión que corren automáticamente, y manejo de credenciales y contenido del ledger.

## Verificación

`npm ci`, `npm run typecheck`, `npm run build` y la suite completa: **2597 tests en verde, 233 suites**. (La primera corrida falló 14 tests, todos por `dist/` ausente; tras el build, ninguno.)

Ningún test asserta el campo `license`, verificado por grep sobre `cli/tests`.

## Qué NO resuelve este PR

**La titularidad.** Elegir licencia presupone ser el titular, y esa verificación ocurre fuera del repositorio: #84 quedó reducido a esa única acción, en tres pasos. **No bloquea este merge** — si la verificación arrojara cotitularidad, Apache-2.0 no se invalida: pasa a ser una decisión a acordar con el cotitular, y una licencia coherente sigue siendo estrictamente mejor que la contradicción MIT/ISC en cualquier escenario.

Esto no es asesoría legal.

## Repo hermano

El registry recibe el cambio equivalente en Kodria/awm-baseline-registry#31. Ambos comparten licencia para que no haya que razonar dos veces.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw)_