### PR TITLE
fix(release): permitir publicar desde CI un cambio de metadata que no es feat ni fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,22 @@ on:
         description: 'Dry run (no publica)'
         type: boolean
         default: false
+      # `determineBump` devuelve null cuando ningun commit desde el ultimo release es
+      # feat/fix/perf ni breaking (cli/src/release/core.ts). Es lo correcto: un `chore:`
+      # de docs no debe publicar a npm. Pero deja un hueco real — un cambio que altera
+      # METADATA PUBLICADA del paquete y no es feat ni fix no tiene forma de llegar al
+      # registro. Paso con el PR #88: corrigio `"license": "ISC"` -> `"Apache-2.0"`,
+      # se mergeo como `chore(legal):`, el workflow corrio en verde y no publico nada.
+      # `main` quedo correcto y npm siguio entregando ISC.
+      #
+      # El CLI ya sabia resolverlo (`--force major|minor|patch`, cubierto por
+      # tests/release/orchestrator.test.ts); lo que faltaba era que CI pudiera
+      # alcanzarlo. Ver docs/decisions.md D-022.
+      bump:
+        description: 'Forzar un release aunque no haya commits releasables (metadata publicada)'
+        type: choice
+        default: 'auto'
+        options: ['auto', 'patch', 'minor', 'major']
 
 permissions:
   contents: write
@@ -97,7 +113,13 @@ jobs:
       # Repetirlos en ubuntu seria correr por cuarta vez lo que ya paso, y daria la
       # impresion de que el gate vive en este job cuando vive en la matriz.
 
+      # `bump` solo existe en workflow_dispatch: un push a main nunca fuerza nada, sigue
+      # decidiendo `determineBump`. El valor 'auto' es el default explicito y no agrega
+      # flag, de modo que el camino normal es byte-identico al anterior.
       - name: Release
         working-directory: cli
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true && '--dry-run' || '' }}
+          FORCE_BUMP: ${{ github.event_name == 'workflow_dispatch' && inputs.bump != 'auto' && format('--force {0}', inputs.bump) || '' }}
         run: |
-          node dist/src/release/index.js ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true && '--dry-run' || '' }}
+          node dist/src/release/index.js $DRY_RUN $FORCE_BUMP

--- a/cli/tests/structural/release-flags-are-reachable-from-ci.test.ts
+++ b/cli/tests/structural/release-flags-are-reachable-from-ci.test.ts
@@ -1,0 +1,75 @@
+// Guard estructural — una capacidad del release que CI no puede invocar no existe en la
+// práctica, y su ausencia no se nota hasta el día que hace falta.
+//
+// Pasó con `--force`. El flag estaba implementado y cubierto por tests
+// (tests/release/orchestrator.test.ts: "--force patch publica aunque no haya commits
+// releasables"), pero `release.yml` solo pasaba `--dry-run`. Consecuencia real: el PR #88
+// corrigió `"license": "ISC"` -> `"Apache-2.0"` en el paquete publicado, se mergeó como
+// `chore(legal):`, `determineBump` devolvió null — correctamente, un chore no es un
+// release —, el workflow corrió EN VERDE y no publicó nada. `main` quedó bien y npm
+// siguió entregando la licencia equivocada. No había forma de publicarlo desde CI.
+//
+// La regla no enumera los flags a mano: los deriva del propio `parseArgs`, así que un
+// flag agregado mañana obliga a decidir explícitamente si CI puede alcanzarlo, en vez de
+// heredar el silencio.
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const CLI_ROOT = path.resolve(__dirname, '..', '..');
+const REPO_ROOT = path.resolve(CLI_ROOT, '..');
+const RELEASE_ENTRY = path.join(CLI_ROOT, 'src', 'release', 'index.ts');
+const RELEASE_WORKFLOW = path.join(REPO_ROOT, '.github', 'workflows', 'release.yml');
+
+// Flags deliberadamente NO expuestos a CI, con la razón por la que no lo están. Sacar uno
+// de acá sin exponerlo en el workflow rompe el test a propósito.
+const NOT_FOR_CI: Record<string, string> = {
+    '--no-push': 'uso local: un release desde CI siempre empuja',
+    '--branch': 'CI siempre libera desde main; el gate de rama vive en el orquestador',
+};
+
+/** Los flags que `parseArgs` realmente acepta, leídos del código, no de una lista. */
+function acceptedFlags(): string[] {
+    const source = fs.readFileSync(RELEASE_ENTRY, 'utf8');
+    const found = [...source.matchAll(/a === '(--[a-z-]+)'/g)].map((m) => m[1]);
+    return [...new Set(found)];
+}
+
+/** El workflow sin sus comentarios. La alcanzabilidad se mide sobre lo que EJECUTA: un
+ *  comentario que menciona `--force` no lo hace invocable, y la primera versión de este
+ *  test se dejaba engañar por exactamente eso. */
+function withoutComments(source: string): string {
+    return source
+        .split('\n')
+        .filter((line) => !/^\s*#/.test(line))
+        .join('\n');
+}
+
+describe('flags del release: implementados <=> alcanzables desde CI', () => {
+    const workflowSource = fs.readFileSync(RELEASE_WORKFLOW, 'utf8');
+    const executable = withoutComments(workflowSource);
+    const workflow = yaml.load(workflowSource) as {
+        on?: { workflow_dispatch?: { inputs?: Record<string, unknown> } };
+    };
+
+    it('parseArgs declara al menos un flag', () => {
+        expect(acceptedFlags().length).toBeGreaterThan(0);
+    });
+
+    it('cada flag del release está expuesto en release.yml o excluido con motivo', () => {
+        const unreachable = acceptedFlags().filter(
+            (flag) => !executable.includes(flag) && !(flag in NOT_FOR_CI),
+        );
+        expect(unreachable).toEqual([]);
+    });
+
+    it('workflow_dispatch expone el bump forzado', () => {
+        const inputs = workflow.on?.workflow_dispatch?.inputs ?? {};
+        expect(Object.keys(inputs)).toContain('bump');
+    });
+
+    it('el paso de Release pasa --force solo cuando el bump no es auto', () => {
+        expect(workflowSource).toMatch(/inputs\.bump != 'auto'/);
+        expect(workflowSource).toMatch(/--force \{0\}/);
+    });
+});

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -26,6 +26,7 @@ Formato: qué se decidió, por qué, qué implica. Sin historia larga — eso vi
 | [D-019](#d-019) | 2026-08-14 | Schema v2 is a deliberate, reviewable migration | Active |
 | [D-020](#d-020) | 2026-08-14 | Retrospective coverage runs before ledger archive | Active |
 | [D-021](#d-021) | 2026-08-18 | AWM se licencia bajo Apache-2.0; la marca queda fuera del grant | Vigente |
+| [D-022](#d-022) | 2026-08-19 | Un cambio de metadata publicada se titula `fix:`, y CI puede forzar el bump | Vigente |
 
 ---
 
@@ -531,3 +532,38 @@ verificación arrojara titularidad compartida, la licencia elegida no se
 invalida — se vuelve una decisión que hay que acordar con el cotitular, y una
 licencia coherente sigue siendo estrictamente mejor que la contradicción
 MIT/ISC que había antes.
+
+## D-022
+
+**Un cambio que altera metadata publicada del paquete se titula `fix:`, y CI tiene una salida de emergencia para forzar el bump.**
+
+`determineBump` devuelve `null` cuando ningún commit desde el último release es `feat`,
+`fix`, `perf` ni breaking (`cli/src/release/core.ts`). Eso es correcto y hay que
+conservarlo: un `chore:` de documentación no debe publicar a npm.
+
+Pero deja un hueco que costó un release. El PR #88 corrigió la licencia publicada
+—`"license": "ISC"` → `"Apache-2.0"`— y se mergeó titulado `chore(legal):`. El workflow
+corrió **en verde**, `determineBump` devolvió `null`, y no se publicó nada: `main` quedó
+con la licencia correcta mientras npm siguió entregando `8.1.2` con `ISC`. El defecto que
+el PR venía a arreglar siguió vivo justo donde importaba, y el pipeline verde decía lo
+contrario.
+
+Es la misma familia que D-005 y que la lección de `auto-tag` en el registry: **un job
+verde tiene dos causas posibles, y desde afuera son indistinguibles.** Acá el job no
+falló — simplemente no hizo nada, que es la variante más silenciosa.
+
+**Implica:**
+- **Regla de título:** un cambio que altera lo que se publica —campos de
+  `cli/package.json` que viajan al registro, contenido del paquete— se titula `fix:`,
+  aunque coloquialmente sea "una tarea". El criterio no es cómo se siente el cambio, es
+  si el consumidor recibe algo distinto.
+- **Salida de emergencia:** `release.yml` expone un input `bump` en `workflow_dispatch`
+  (`auto` | `patch` | `minor` | `major`) que se traduce a `--force`. El flag ya existía en
+  el CLI y estaba cubierto por tests; lo que faltaba era que CI pudiera alcanzarlo. Un
+  push a `main` nunca fuerza nada: `auto` es el default y el camino normal queda idéntico.
+- **Gate que lo sostiene:** `tests/structural/release-flags-are-reachable-from-ci.test.ts`
+  deriva los flags del propio `parseArgs` y exige que cada uno esté expuesto en el
+  workflow o excluido con un motivo escrito. Un flag agregado mañana obliga a decidir en
+  vez de heredar el silencio. La comprobación corre sobre el workflow **sin comentarios**:
+  mencionar un flag en un comentario no lo hace invocable, y la primera versión del test
+  se dejaba engañar por eso.


### PR DESCRIPTION
Cierra el hueco que dejó a #88 sin publicar. **Al mergear, este PR entrega el patch con la licencia Apache-2.0 corregida.**

## Lo que pasó

#88 corrigió la licencia publicada del paquete: `"license": "ISC"` → `"Apache-2.0"`. Se mergeó titulado `chore(legal):`.

- El workflow `release` corrió y terminó **`conclusion: success`**.
- `determineBump` devolvió `null` — correctamente: `chore` no es `feat`, `fix`, `perf` ni breaking.
- **No se publicó nada.**

Resultado: `main` quedó con `"license": "Apache-2.0"` y npm siguió entregando `8.1.2` con **`ISC`**. El defecto que #88 venía a arreglar siguió vivo exactamente donde importa — en lo que recibe quien corre `npm i` — mientras el pipeline en verde decía lo contrario.

Es la misma familia que D-005 y que la lección de `auto-tag` en el registry: **un job verde tiene dos causas posibles y desde afuera son indistinguibles.** Acá el job no falló; simplemente no hizo nada, que es la variante más silenciosa de las dos.

## Lo que NO cambia

`determineBump` queda igual. Que un `chore:` de documentación no publique a npm es correcto y se conserva. **Un push a `main` nunca fuerza nada.**

## Lo que cambia

**1. `release.yml` expone el bump forzado.** Input `bump` en `workflow_dispatch` (`auto` | `patch` | `minor` | `major`) que se traduce a `--force`.

El flag **ya existía** en el CLI (`parseArgs`, `src/release/index.ts`) y ya estaba cubierto por `tests/release/orchestrator.test.ts` — *"--force patch publica aunque no haya commits releasables"*. Lo único que faltaba era que CI pudiera alcanzarlo. `auto` es el default explícito y no agrega flag, así que el camino normal queda byte-idéntico.

**2. Gate estructural nuevo:** `tests/structural/release-flags-are-reachable-from-ci.test.ts`.

Deriva los flags del **propio `parseArgs`**, no de una lista a mano, y exige que cada uno esté expuesto en el workflow o excluido con un motivo escrito (`--no-push` y `--branch` lo están: son de uso local). Un flag agregado mañana obliga a decidir sobre su alcanzabilidad en vez de heredar el silencio.

**Verificado por mutación**, como exige la CONSTITUTION:

| Mutación | Resultado |
|---|---|
| Quitar el wiring de `--force` del paso Release | ✗ falla (2 aserciones) |
| Quitar el input `bump` del `workflow_dispatch` | ✗ falla |
| Sin mutar | ✓ 4/4 |

Y una corrección sobre mi propia primera versión del test: matcheaba el archivo completo, **incluidos los comentarios**, así que quitar el wiring dejando el comentario lo dejaba pasar. La comprobación de alcanzabilidad ahora corre sobre el workflow sin comentarios — mencionar un flag no lo hace invocable.

**3. `docs/decisions.md` → D-022.** La regla que faltaba: *un cambio que altera metadata publicada se titula `fix:`, aunque coloquialmente sea una tarea.* El criterio no es cómo se siente el cambio, es si el consumidor recibe algo distinto.

## Por qué este PR se titula `fix:`

A propósito, y es la parte que lo cierra: al mergearse, `determineBump` devuelve `patch`, se publica **8.1.3**, y esa versión lleva el `"license": "Apache-2.0"` que #88 ya dejó en `main`. **El arreglo se entrega a sí mismo** — sin dispatch manual y sin publicar a mano desde una máquina, que rompería la serialización y el Trusted Publisher por OIDC (D-009).

## Verificación

`npm run typecheck`, `npm run build` y la suite completa: **2601 tests en verde, 234 suites** (4 skipped). El YAML del workflow parsea y expone `['dry_run', 'bump']`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw)_