### PR TITLE
fix(tests): eliminar la carrera de observación que rompía R3.5 en Windows

### DIFF
--- a/cli/tests/commands/watch/runner.test.ts
+++ b/cli/tests/commands/watch/runner.test.ts
@@ -92,7 +92,28 @@ describe('runner concurrente', () => {
     });
 
     test('job largo pasa por running con identidad real; jamas se mata por duracion (R3.5)', async () => {  // verifies R3.5
-        seedJob(repo, { argv: ['node', '-e', 'setTimeout(()=>process.exit(0), 1500)'] });
+        // El hijo vive hasta que EL TEST lo libera, no hasta que se cumple un reloj.
+        //
+        // Con una duracion fija (era 1500 ms) esto era una carrera imposible de ganar:
+        // el test espera OBSERVAR el estado transitorio `running`, y en win32 cada
+        // consulta de vitalidad spawnea tasklist/WMI — cientos de ms bajo carga, el mismo
+        // costo que documenta el `jest.setTimeout` de arriba. Si la primera observacion
+        // llegaba despues de que el hijo ya habia muerto, el estado saltaba directo a
+        // `exited` y `running` NO VOLVIA A OCURRIR NUNCA: la condicion quedaba
+        // permanentemente falsa y `until` giraba hasta agotar su presupuesto. Subir el
+        // timeout no lo arregla — no falta tiempo, falta que el estado sea observable.
+        // Fallo real: run 32211063150, solo windows-latest, con Ubuntu y macOS en verde.
+        //
+        // El centinela invierte el control: el hijo sigue vivo mientras el test lo
+        // necesite, asi que `running` es observable con cualquier latencia de plataforma.
+        // Refuerza R3.5 en vez de aflojarlo — "jamas se mata por duracion" se prueba
+        // mejor con un job que vive tanto como haga falta que con uno de 1,5 s. El
+        // setTimeout de 60 s es solo una red: si el test muere antes de liberar, el hijo
+        // no queda huerfano reteniendo handles sobre el tmpdir (ver rmSyncRetryingEbusy).
+        const sentinel = path.join(repo, 'release-r35.sentinel');
+        seedJob(repo, {
+            argv: ['node', '-e', `const fs=require('fs'),f=${JSON.stringify(sentinel)};setTimeout(()=>process.exit(0),60000);setInterval(()=>{if(fs.existsSync(f))process.exit(0)},50)`],
+        });
         spawnPendingWrappers(repo, 'rama', fakeSpawner);
         await until(() => {
             collectAndReconcile(repo, 'rama');
@@ -107,6 +128,9 @@ describe('runner concurrente', () => {
         // exec-wrapper.test.ts) — este test no puede exigir mas certeza de
         // la que la plataforma real puede dar.
         expect(running.processRef!.psArgsDigest).toMatch(/^([0-9a-f]{16}|unknown)$/);
+        // Recien ahora se libera al hijo: la transicion a `exited` la decide el test,
+        // no el reloj, asi que tampoco esa mitad depende de la latencia de la plataforma.
+        fs.writeFileSync(sentinel, '');
         await until(() => {
             collectAndReconcile(repo, 'rama');
             return readJournal(repo, 'rama').state!.jobs['j1'].executionState === 'exited';


### PR DESCRIPTION
Desbloquea el release que #89 dejó sin publicar. **Al mergear, publica 8.1.3 con la licencia Apache-2.0.**

## Qué pasó

El release de #89 falló. **Sólo `windows-latest`** — Ubuntu y macOS en verde:

```
FAIL tests/commands/watch/runner.test.ts (29.88 s)
  ● job largo pasa por running con identidad real; jamas se mata por duracion (R3.5)
    timeout esperando condicion
Tests: 1 failed, 2581 passed   ·   Time: 629 s
```

`needs: test` bloqueó el job de release → no se publicó nada. `main` quedó con `"license": "Apache-2.0"` y npm siguió entregando `8.1.2` con `ISC`.

Nada que ver con el diff de #89 (workflow, un test estructural nuevo y `docs/decisions.md`).

## La causa — y por qué subir el timeout no la arregla

El test sembraba un hijo de **duración fija**:

```js
argv: ['node', '-e', 'setTimeout(()=>process.exit(0), 1500)']
```

…y después esperaba **observar el estado transitorio `running`**.

En win32 cada consulta de vitalidad spawnea `tasklist`/WMI — cientos de milisegundos bajo carga, el mismo costo que ya documenta el `jest.setTimeout` de ese archivo. Con la suite tardando 629 s, la primera observación podía llegar **después de que el hijo ya había muerto**.

Y ahí está el punto: en ese caso el estado salta directo a `exited`, y **`running` no vuelve a ocurrir nunca**. La condición queda permanentemente falsa. `until` gira hasta agotar su presupuesto y tira. Con 8 s o con 8 minutos, el resultado es el mismo: **no falta tiempo, falta que el estado sea observable.**

(El arreglo anterior de Windows en este archivo subió el `jest.setTimeout` a 60 s y funcionó — pero para el test de *stall*, donde el problema sí era duración acumulada. Acá el mecanismo es otro.)

## El arreglo

El hijo vive hasta que **el test lo libera**, con un archivo centinela. El control se invierte: el proceso sigue vivo mientras el test lo necesite, así que `running` es observable con cualquier latencia de plataforma, y la transición a `exited` la decide el test en vez del reloj.

```js
const sentinel = path.join(repo, 'release-r35.sentinel');
// ... el hijo hace poll del centinela y sale cuando aparece
await until(() => /* ... */ === 'running');
expect(running.processRef!.psArgsDigest).toMatch(/^([0-9a-f]{16}|unknown)$/);
fs.writeFileSync(sentinel, '');            // recién ahora se libera
await until(() => /* ... */ === 'exited');
```

**Refuerza R3.5 en vez de aflojarlo.** *"Jamás se mata por duración"* se prueba mejor con un job que vive tanto como haga falta que con uno de 1,5 s: ahora el job podría vivir un minuto entero y el test seguiría exigiendo que nadie lo mate.

Y es **más rápido**: 578 ms contra la espera fija de ~1,5 s (29,9 s en el Windows que falló).

El `setTimeout` de 60 s dentro del hijo es sólo una red: si el test muere antes de liberar, no queda un huérfano reteniendo handles sobre el tmpdir — el mismo problema de EBUSY en Windows que `rmSyncRetryingEbusy` ya documenta en este archivo.

## Verificación

**Mutación**, como exige la CONSTITUTION: quitando la escritura del centinela el hijo nunca sale y el test falla con `timeout esperando condicion` a los 8,2 s. La segunda mitad no es vacua.

| | |
|---|---|
| Test aislado | 15/15 ✓ en 6,8 s |
| Suite completa | **2601 tests en verde, 234 suites** (4 skipped) |
| `typecheck` + `build` | ✓ |

Falta lo que sólo CI puede dar: la matriz Windows/macOS. Es justamente lo que este PR viene a arreglar, así que su propia corrida es la prueba.

## Una decisión que tomé y prefiero explicitar

La lección —*un test que espera observar un estado transitorio de un proceso de duración fija es una carrera, no una prueba*— quedó escrita **en el propio test**, que es donde alguien la va a leer cuando toque ese archivo.

**No agregué un tercer registro de decisión hoy.** Es craft de tests, no una decisión de producto, y ya entraron D-021 y D-022 en esta tanda. Si te parece que merece promoverse a `CONSTITUTION.md` como regla general, es tu llamado — lo digo acá para que sea una decisión tomada y no un pendiente que se pierde.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw)_