### PR TITLE
docs(cli-reference): documentar job, track, watch, context-budget y preflight

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-workflow-manager",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-workflow-manager",
-      "version": "8.1.2",
+      "version": "8.1.3",
       "license": "ISC",
       "dependencies": {
         "@clack/prompts": "^1.0.1",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -108,6 +108,36 @@ awm agent disable claude-code --default codex
 
 Re-enable a provider through a normal `awm init --agent <provider>` run.
 
+### `awm preflight`
+
+Verify the project harness can actually gate **before** development starts.
+
+```
+awm preflight [--json] [--cwd <path>]
+```
+
+| Flag | Description |
+|---|---|
+| `--json` | Emit the report as JSON. Preserved on failure, so a red run is still machine-readable. |
+| `--cwd <path>` | Project directory to check. Default: current directory. |
+
+Where `awm doctor` answers *"is AWM installed correctly?"*, preflight answers *"can this project stop bad work from landing?"* — the distinction matters when onboarding a repository, because an install can be perfect while the project has nothing enforceable behind it.
+
+### `awm context-budget`
+
+Check the size of the files injected into **every** agent session.
+
+```
+awm context-budget [--json] [--cwd <path>]
+```
+
+| Flag | Description |
+|---|---|
+| `--json` | Emit the report as JSON. |
+| `--cwd <path>` | Directory to measure. Default: current directory. |
+
+`CONSTITUTION.md`, `AGENTS.md`, and the skills the harness re-anchors are paid for on **every** session, not once. This command makes that recurring cost visible before it starts crowding out the work.
+
 ---
 
 ## Registry & artifacts
@@ -435,6 +465,81 @@ clustering signal, and a win is never merged with a finding on the strength of a
 ### `awm ledger archive`
 
 Rotate the current branch's ledger out of the active flow (into `.awm/ledger/archive/`). `harness-retro` calls this when it closes a branch.
+
+---
+
+## Durable execution (journal, supervisor, parallel tracks)
+
+The three commands below are one mechanism seen from three angles. `awm job` is the
+**journal**: the durable record of what work was requested and what came back. `awm watch`
+is the **supervisor**: the process that actually runs that work and relieves controllers
+that died. `awm track` coordinates **parallel tracks** over worktrees.
+
+The division of labour is deliberate and load-bearing: `job` and `track` are almost
+entirely **request-only and read-only** surfaces. They record intent; the supervisor is
+what mutates state. That is what lets a controller die mid-flight without losing work or
+duplicating it.
+
+### `awm job`
+
+The durable work journal of the SDD cycle. Subcommands split into requests, reads, and
+gates:
+
+| Subcommand | Description |
+|---|---|
+| `request <cmd...>` | Record the *intent* to run a verification. The supervisor executes it — this does not. |
+| `register` | Record a cycle entity (`task`, `cycle-plan`, `dispatch`, `task-status`, `next-action`, `custody-decision`) **before** acting on it. |
+| `verdict` | Record a ReviewObligation verdict at the moment it is received. |
+| `list` / `ps` / `show <jobId>` | Read the journal: declared jobs, live processes, one job in full. |
+| `reconcile` | Read-only report of the R1.8 matrix plus `next_action`. The mutation belongs to the supervisor. |
+| `gate` | Fail-closed interlock: exits non-zero if **anything** blocks certification. |
+| `reap` | List job processes with full identity. `--execute --jobs <ids...>` terminates them, with confirmation. |
+| `export` | Export the journal. |
+| `controller-heartbeat` | Emit the controller liveness signal the supervisor watches. |
+
+> `gate` is the one to reach for in automation: it is the interlock that refuses to
+> certify, not a report you have to interpret.
+
+### `awm watch`
+
+The durable supervisor. It executes requested jobs, relieves controllers whose heartbeat
+went silent, and **never kills live work**.
+
+```
+awm watch [--init] [--provider <p>] [--heartbeat-timeout <min>]
+          [--activity-window <min>] [--max-parallel <n>]
+```
+
+| Flag | Description |
+|---|---|
+| `--init` | Bootstrap: create the current branch's journal, detect verifiers, and exit. |
+| `--provider <p>` | `codex` or `claude-code`. Default: `codex`. |
+| `--heartbeat-timeout <min>` | Minutes of heartbeat silence before a controller is considered gone. Default: `5`. |
+| `--activity-window <min>` | Extra minutes without process activity before relieving it. Default: `10`. |
+| `--max-parallel <n>` | Cap of simultaneously ACTIVE tracks. Default: derived from the bundled benchmark. |
+
+The two timeouts are separate on purpose: a silent heartbeat is not the same as a dead
+process. A controller can stop reporting while its work is still advancing, and the
+activity window is what keeps that work from being reclaimed out from under it.
+
+### `awm track`
+
+Parallel tracks over worktrees: a request-only surface plus a read-only aggregate status.
+
+| Subcommand | Description |
+|---|---|
+| `add <trackId>` | Emit a track-prepare request. The plan supervisor consumes it. |
+| `join <trackId>` | Emit a track-join request. Integration is owned exclusively by the plan supervisor. |
+| `finalize` | Emit a track-finalize request: the plan controller's global QA self-report over the already-merged HEAD. |
+| `list` | List the `TrackRef`s declared in the plan journal (read-only). |
+| `status` | Read-only aggregate: each track's gate plus the cohort phase. |
+| `verify-independence` | Verify a track plan's declared independence. Exits non-zero on any violation, so it is usable as a gate. |
+| `remove <trackId>` | **Not implemented.** Emits a teardown request the supervisor does not yet know how to apply, and rejects it. |
+| `supervisor-wrapper` | **Internal process**, launched detached by the plan supervisor. Not for manual invocation. |
+
+> `add`, `join` and `finalize` only *request*. Nothing integrates because you ran them —
+> the plan supervisor decides, which is what keeps two tracks from merging into each other
+> at the same time.
 
 ---
 


### PR DESCRIPTION
Cierra #85.

## El problema

`docs/cli-reference.md` se presenta como *"the exhaustive command surface"*, pero cinco comandos registrados en `cli/src/index.ts` no aparecían ahí. Sólo existían en `docs/plans/`, que son documentos de decisión, no referencia de usuario.

Para alguien evaluando adoptar AWM, la brecha entre lo que el CLI hace y lo que la documentación dice que hace es lo primero que ve.

## Qué se documenta

Todo verificado contra la salida real de `--help` del binario compilado, no contra lectura del código.

**En "Setup & diagnostics"**, que es donde el usuario los va a buscar:

- **`awm preflight`** — contrastado explícitamente con `doctor`: uno responde *"¿está AWM bien instalado?"*, el otro *"¿puede este proyecto frenar trabajo malo?"*. La distinción importa al onboardear un repo, porque una instalación puede estar perfecta sobre un proyecto sin nada exigible detrás.
- **`awm context-budget`** — con el porqué: `CONSTITUTION.md`, `AGENTS.md` y las skills que el harness reancla se pagan en **cada** sesión, no una vez.

**Sección nueva: "Durable execution (journal, supervisor, parallel tracks)"** para `job`, `watch` y `track`.

Van juntos a propósito. Son un mecanismo visto desde tres ángulos, y documentarlos sueltos pierde justamente lo que los hace funcionar: **`job` y `track` son superficies de request y lectura; el supervisor es el único que muta estado.** Esa división es lo que permite que un controlador muera a mitad de vuelo sin perder ni duplicar trabajo — y no se deduce de una lista de flags.

Detalles concretos que quedan escritos porque sorprenden si no lo están:

- Los dos timeouts de `awm watch` son distintos a propósito: un heartbeat en silencio no es un proceso muerto, y la ventana de actividad es lo que evita reclamar trabajo que sigue avanzando.
- **`track remove` NO está implementado**: emite un request que el supervisor no sabe aplicar y rechaza.
- **`track supervisor-wrapper` es un proceso interno**, lanzado detached. No se invoca a mano.
- `job gate` es el interlock fail-closed — lo que conviene usar en automatización, en vez de interpretar un reporte.

## Barrido completo

Verifiqué los **21 comandos registrados** contra el documento, no sólo los cinco del issue. No queda ninguno sin cubrir.

## Un rojo preexistente que este PR también corrige

`cli/package-lock.json` quedó en **8.1.2** mientras `cli/package.json` ya decía **8.1.3**, así que `tests/structural/r3-cli-major-version.test.ts` **falla en `main` ahora mismo**. El commit de release lleva `[skip ci]`, de modo que el rojo no aparece hasta el PR siguiente — este.

Sincronizo los dos campos del paquete raíz del lockfile, que es lo mínimo para que CI pueda estar en verde.

> **La causa de fondo queda reportada, no arreglada acá:** el orquestador de release **no toca el lockfile** en ningún momento (`cli/src/release/*.ts`). Va a volver a desincronizarse en cada release. Arreglarlo toca `ReleaseIO` y sus tests, o sea código de release — no entra en un cambio de documentación. Si querés, lo hago en un PR aparte.

## Verificación

| | |
|---|---|
| Estructurales | 71/71 ✓ (con el lockfile sincronizado; sin eso, 1 falla) |
| Suite completa | **2601 tests en verde, 234 suites** (4 skipped) |
| Cobertura de comandos | 21/21 documentados |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw)_