### PR TITLE
fix(release): sincronizar package-lock.json en el bump de versión

### DIFF
--- a/cli/src/release/index.ts
+++ b/cli/src/release/index.ts
@@ -33,6 +33,7 @@ export function parseArgs(argv: string[]): ReleaseOpts {
 
 function realIO(repoRoot: string, cliDir: string): ReleaseIO {
   const pkgPath = path.join(cliDir, 'package.json');
+  const lockPath = path.join(cliDir, 'package-lock.json');
   const changelogPath = path.join(repoRoot, 'CHANGELOG.md');
   const npmrcPath = path.join(cliDir, '.npmrc');
   return {
@@ -44,6 +45,16 @@ function realIO(repoRoot: string, cliDir: string): ReleaseIO {
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
       pkg.version = v;
       fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+    },
+    // El round-trip JSON.parse/stringify preserva el orden de claves y el formato que
+    // npm escribe (2 espacios + newline final), asi que el diff de un bump son las dos
+    // lineas de version y nada mas — verificado sobre el lockfile real de este repo.
+    writeLockVersion: (v) => {
+      if (!fs.existsSync(lockPath)) return;
+      const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+      lock.version = v;
+      if (lock.packages?.['']) lock.packages[''].version = v;
+      fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2) + '\n');
     },
     readChangelog: () => (fs.existsSync(changelogPath) ? fs.readFileSync(changelogPath, 'utf8') : ''),
     writeChangelog: (c) => fs.writeFileSync(changelogPath, c),

--- a/cli/src/release/orchestrator.ts
+++ b/cli/src/release/orchestrator.ts
@@ -10,6 +10,13 @@ export interface ReleaseIO {
   run(cmd: string, args: string[], opts?: { cwd?: string }): string;
   readPackageVersion(): string;
   writePackageVersion(v: string): void;
+  /** Sincroniza la version del paquete raiz en `package-lock.json`. Va aparte de
+   *  `writePackageVersion` a proposito: el lockfile tiene DOS campos que deben moverse
+   *  juntos (`version` y `packages[""].version`), y el resto del archivo —resolucion de
+   *  dependencias— no le corresponde a un bump. Sin esto el lockfile queda una version
+   *  atras en CADA release y `r3-cli-major-version.test.ts` deja `main` en rojo, invisible
+   *  hasta el PR siguiente por el `[skip ci]` del commit de bump. Ver #92. */
+  writeLockVersion(v: string): void;
   readChangelog(): string;
   writeChangelog(content: string): void;
   writeNpmrc(token: string): void;
@@ -93,9 +100,10 @@ export function release(opts: ReleaseOpts, io: ReleaseIO): ReleaseResult {
 
   // aplicar
   io.writePackageVersion(version);
+  io.writeLockVersion(version);
   const section = renderChangelog(version, io.today(), commits);
   io.writeChangelog(section + '\n' + io.readChangelog());
-  io.run('git', ['add', 'cli/package.json', 'CHANGELOG.md']);
+  io.run('git', ['add', 'cli/package.json', 'cli/package-lock.json', 'CHANGELOG.md']);
   io.run('git', ['commit', '-m', `chore(release): v${version} [skip ci]`]);
   io.run('git', ['tag', '-a', `v${version}`, '-m', `v${version}`]);
 

--- a/cli/tests/release/orchestrator.test.ts
+++ b/cli/tests/release/orchestrator.test.ts
@@ -3,10 +3,14 @@ import { release, ReleaseIO, ReleaseOpts } from '../../src/release/orchestrator'
 import { GIT_LOG_FORMAT, US, RS } from '../../src/release/core';
 
 function makeIO(over: Partial<ReleaseIO> & { commits?: string; tags?: string; npmView?: string } = {}): {
-  io: ReleaseIO; calls: string[];
+  io: ReleaseIO; calls: string[]; versions: () => { pkg: string; lock: string };
 } {
   const calls: string[] = [];
   let pkgVersion = '2.1.1';
+  // El lockfile arranca en la MISMA version que el package.json, como en el repo real.
+  // Si el release no lo sincroniza, este valor se queda atras — que es exactamente el
+  // estado que dejaba `main` en rojo (#92).
+  let lockVersion = '2.1.1';
   const io: ReleaseIO = {
     run(cmd, args) {
       const full = `${cmd} ${args.join(' ')}`;
@@ -21,6 +25,7 @@ function makeIO(over: Partial<ReleaseIO> & { commits?: string; tags?: string; np
     },
     readPackageVersion: () => pkgVersion,
     writePackageVersion: (v) => { pkgVersion = v; calls.push(`WRITE_PKG ${v}`); },
+    writeLockVersion: (v) => { lockVersion = v; calls.push(`WRITE_LOCK ${v}`); },
     readChangelog: () => '',
     writeChangelog: (c) => calls.push(`WRITE_CHANGELOG ${c.split('\n')[0]}`),
     writeNpmrc: () => calls.push('WRITE_NPMRC'),
@@ -30,7 +35,7 @@ function makeIO(over: Partial<ReleaseIO> & { commits?: string; tags?: string; np
     env: { NPM_TOKEN: 'tok' },
     ...over,
   };
-  return { io, calls };
+  return { io, calls, versions: () => ({ pkg: pkgVersion, lock: lockVersion }) };
 }
 
 const opts = (o: Partial<ReleaseOpts> = {}): ReleaseOpts =>
@@ -51,6 +56,29 @@ describe('release — happy path', () => {
     // npmrc creado y SIEMPRE removido
     expect(calls).toContain('WRITE_NPMRC');
     expect(calls).toContain('REMOVE_NPMRC');
+  });
+
+  // #92: el bump escribia solo package.json, asi que el lockfile quedaba una version
+  // atras en CADA release. `r3-cli-major-version.test.ts` exige que coincidan, y el
+  // `[skip ci]` del commit de bump hacia que ese rojo no apareciera hasta el PR
+  // siguiente — que llegaba roto por algo que no habia hecho.
+  it('sincroniza package-lock.json con package.json y lo incluye en el commit de bump', () => {
+    const { io, calls, versions } = makeIO({ commits: `feat: x${US}${RS}` });
+    release(opts(), io);
+
+    expect(versions()).toEqual({ pkg: '2.2.0', lock: '2.2.0' });
+    expect(calls).toContain('WRITE_LOCK 2.2.0');
+    // Escribir el archivo no alcanza: si no se stagea, el commit de release lo deja
+    // fuera y el lockfile queda sucio en el working tree del runner.
+    expect(calls).toContain('git add cli/package.json cli/package-lock.json CHANGELOG.md');
+  });
+
+  it('no toca el lockfile cuando no hay nada que publicar', () => {
+    const { io, calls, versions } = makeIO({ commits: `docs: solo docs${US}${RS}` });
+    release(opts(), io);
+
+    expect(versions()).toEqual({ pkg: '2.1.1', lock: '2.1.1' });
+    expect(calls.some((c) => c.startsWith('WRITE_LOCK'))).toBe(false);
   });
 
   it('sin commits releasables → no publica (exit 0 lógico)', () => {


### PR DESCRIPTION
Closes #92.

> **Mergear #91 primero.** Esta rama sale de `main`, que hoy tiene el lockfile en `8.1.2` y el `package.json` en `8.1.3`, así que **hereda ese rojo**. #91 corrige el dato; este PR corrige la causa. Con #91 mergeado, este queda en verde.

## El defecto

El bump de release escribía **sólo** `cli/package.json`. El lockfile quedaba una versión atrás después de **cada** release, y `tests/structural/r3-cli-major-version.test.ts` exige que coincidan — así que el commit de release dejaba `main` en rojo.

```
$ grep -nE "package-lock|lockfile|--package-lock-only" cli/src/release/*.ts
(sin resultados)
```

El `[skip ci]` del commit de bump es **correcto** — no tiene sentido re-correr la matriz de tres plataformas sobre un commit que sólo mueve un número. Pero significa que el rojo que ese commit introduce lo descubre el **PR siguiente**, que aparece roto por algo que no hizo. Pasó con 8.1.3: el PR de documentación fue el primero en verlo.

Y que hasta ahora no doliera es lo que lo hacía peor: el lockfile se resincronizaba de rebote cuando alguien corría `npm install` en un PR posterior, así que el defecto quedaba tapado por trabajo ajeno en vez de aparecer.

## El arreglo

- **`ReleaseIO` gana `writeLockVersion`**, separado de `writePackageVersion` a propósito: el lockfile tiene **dos** campos que deben moverse juntos (`version` y `packages[""].version`), y el resto del archivo —resolución de dependencias— no le corresponde a un bump.
- **El commit de bump stagea también `cli/package-lock.json`.** Escribir el archivo sin stagearlo lo dejaría sucio en el working tree del runner, que es medio arreglo.
- El round-trip `JSON.parse`/`stringify` preserva el orden de claves y el formato que npm escribe (2 espacios + newline final). Verificado contra el lockfile real de este repo: **el diff de un bump son exactamente las dos líneas de versión**, no un reformateo de miles.

## Verificación

Por mutación, como exige la CONSTITUTION:

| Mutación | Resultado |
|---|---|
| Quitar `io.writeLockVersion(version)` | ✗ falla |
| Quitar `cli/package-lock.json` del `git add` | ✗ falla |
| Sin mutar | ✓ 25/25 en `tests/release/` |

Y un caso negativo, para que la aserción no sea vacua: **un run sin commits releasables no toca el lockfile** — si el release no publica, tampoco reescribe versiones.

Suite completa: 2602 pasan; el único rojo es el `r3-cli-major-version` heredado de `main` que #91 corrige.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrhcHQkbiSzy25jUkMcxw)_