### PR TITLE
fix(sensors): execute materialized changed commands

### DIFF
--- a/.awm/sensors.json
+++ b/.awm/sensors.json
@@ -5,6 +5,7 @@
     "typecheck": {
       "cmd": "npm --prefix cli run typecheck",
       "fast": true,
+      "timeout": 30000,
       "formatter": "tsc"
     },
     "lint": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@
   and `awm sensors coverage --min <count>`.
 - **ledger:** accept an optional reusable `--defect-class <id>` for coverage
   analysis.
+- **sensors:** make execution evidence explicit and bounded: v2 timeout
+  precedence, shell-free changed scope, conclusive verdict exits, and static
+  `READY` distinct from empirical execution.
+- **preflight:** add the read-only `--verify-sensors` handoff gate, which
+  rejects every sensor verdict except `pass` before unattended work begins.
 
 ## v6.5.2 - 2026-08-11
 

--- a/cli/src/commands/preflight/checks.ts
+++ b/cli/src/commands/preflight/checks.ts
@@ -382,7 +382,7 @@ function checkHost(cwd: string): PreflightCheck {
 }
 
 export async function preflight(cwd: string = process.cwd(), opts: PreflightOptions = {}): Promise<PreflightReport> {
-    if (!opts || typeof opts !== 'object' || (opts.verifySensors !== undefined && typeof opts.verifySensors !== 'boolean')) {
+    if (!opts || typeof opts !== 'object' || Array.isArray(opts) || (opts.verifySensors !== undefined && typeof opts.verifySensors !== 'boolean')) {
         throw new Error('preflight options must contain an optional boolean verifySensors');
     }
     const manifest = readManifest(cwd);

--- a/cli/src/commands/preflight/checks.ts
+++ b/cli/src/commands/preflight/checks.ts
@@ -271,6 +271,13 @@ function renderExecutionFailure(output: Awaited<ReturnType<typeof runSensors>>):
     }).join('; ');
 }
 
+function executionRemedy(output: Awaited<ReturnType<typeof runSensors>>): string {
+    if (output.sensors.every(sensor => sensor.status === 'pass')) {
+        return 'configure at least one runnable sensor with `awm sensors init`, then rerun `awm preflight --verify-sensors`';
+    }
+    return 'diagnose the named sensor; if a healthy progressing run needs longer, set a finite sensor timeout and rerun `awm preflight --verify-sensors`';
+}
+
 /** Run the full read-only sensor gate and reject every verdict except `pass`. */
 export async function checkSensorExecution(cwd: string): Promise<PreflightCheck> {
     try {
@@ -282,7 +289,7 @@ export async function checkSensorExecution(cwd: string): Promise<PreflightCheck>
             id: 'sensors-execution',
             ok: false,
             detail: renderExecutionFailure(output),
-            remedy: 'diagnose the named sensor; if a healthy progressing run needs longer, set a finite sensor timeout and rerun `awm preflight --verify-sensors`',
+            remedy: executionRemedy(output),
         };
     } catch {
         // Fail closed without relaying an arbitrary tool/configuration error to JSON.

--- a/cli/src/commands/preflight/checks.ts
+++ b/cli/src/commands/preflight/checks.ts
@@ -17,11 +17,11 @@ import { resolveOnPath } from '../../core/paths';
  * `npx` that would fetch a remote package, validates referenced config files); nothing
  * in the flow ever called it.
  *
- * The consequence is a discovery point at the worst possible moment. `awm sensors run`
- * exits 0 on `not_certified` by design (exit 2 is a blocking error in Claude Code
- * hooks), so the only thing standing between "no sensors configured" and "sensors
- * green" is each agent remembering to read `overall` out of the JSON instead of the
- * exit code. That is a prose defence over a mechanical problem, and prose does not hold.
+ * The consequence is a discovery point at the worst possible moment. Although `awm
+ * sensors run` now exits nonzero for every non-pass verdict, a static readiness check
+ * cannot prove that the project's real commands complete. The empirical option below
+ * makes that missing evidence a mechanical preflight failure rather than a prose
+ * defence over a mechanical problem.
  *
  * So this answers one question, mechanically, before any of that matters — and it is
  * deliberately agnostic to stack, language and tooling. It never asks "is eslint

--- a/cli/src/commands/preflight/checks.ts
+++ b/cli/src/commands/preflight/checks.ts
@@ -5,6 +5,7 @@ import { computeSensorStatus } from '../sensors/status';
 import { detectStack } from '../sensors/init';
 import { SensorManifest } from '../sensors/types';
 import { readBaseline } from '../sensors/baseline';
+import { runSensors } from '../sensors/run';
 import { resolveOnPath } from '../../core/paths';
 
 /**
@@ -28,7 +29,7 @@ import { resolveOnPath } from '../../core/paths';
  */
 
 export type PreflightCheck = {
-    id: 'context' | 'manifest' | 'tools' | 'pack' | 'host' | 'sensors-baseline';
+    id: 'context' | 'manifest' | 'tools' | 'pack' | 'host' | 'sensors-baseline' | 'sensors-execution';
     ok: boolean;
     detail: string;
     /** What the operator should do. Absent when `ok`. */
@@ -48,6 +49,11 @@ export type PreflightReport = {
      */
     status: 'ready' | 'degraded' | 'not_configured';
     checks: PreflightCheck[];
+};
+
+export type PreflightOptions = {
+    /** Run the full sensor gate and require its empirical verdict to be `pass`. */
+    verifySensors?: boolean;
 };
 
 const MANIFEST = path.join('.awm', 'sensors.json');
@@ -239,6 +245,56 @@ function checkSensorsBaseline(cwd: string, manifest: SensorManifest | null): Pre
 }
 
 /**
+ * Empirical diagnostics intentionally name only stable execution facts. Sensor output
+ * can include source, environment values, or tool-specific unbounded text; preflight
+ * is a phase gate, not a log transport, so none of that crosses this boundary.
+ */
+function executionReason(sensor: Awaited<ReturnType<typeof runSensors>>['sensors'][number]): string {
+    const reason = sensor.skipReason ?? sensor.incomplete ?? '';
+    if (/^timeout after \d+ms/.test(reason)) return 'timeout';
+    if (/^output exceeded \d+ bytes/.test(reason)) return 'output limit exceeded';
+    const exit = /^exit (\d+):/.exec(reason);
+    if (exit) return `exit ${exit[1]} without parseable findings`;
+    if (sensor.status === 'fail') return 'reported findings or an actionable execution failure';
+    if (sensor.status === 'skipped') return 'not applicable to this execution';
+    return 'execution did not establish a conclusive result';
+}
+
+function renderExecutionFailure(output: Awaited<ReturnType<typeof runSensors>>): string {
+    const failed = output.sensors.filter(sensor => sensor.status !== 'pass');
+    if (failed.length === 0) return `sensor verdict was ${output.overall}; no sensor established an empirical pass`;
+    return failed.map(sensor => {
+        const evidence = sensor.execution;
+        if (!evidence) return `${sensor.name} (${sensor.status}): no bounded execution evidence; ${executionReason(sensor)}`;
+        return `${sensor.name} (${sensor.status}): timeout ${evidence.timeoutMs}ms (${evidence.timeoutSource}), `
+            + `elapsed ${evidence.elapsedMs}ms; ${executionReason(sensor)}`;
+    }).join('; ');
+}
+
+/** Run the full read-only sensor gate and reject every verdict except `pass`. */
+export async function checkSensorExecution(cwd: string): Promise<PreflightCheck> {
+    try {
+        const output = await runSensors({ cwd, all: true });
+        if (output.overall === 'pass') {
+            return { id: 'sensors-execution', ok: true, detail: 'all selected sensors completed with pass' };
+        }
+        return {
+            id: 'sensors-execution',
+            ok: false,
+            detail: renderExecutionFailure(output),
+            remedy: 'diagnose the named sensor; if a healthy progressing run needs longer, set a finite sensor timeout and rerun `awm preflight --verify-sensors`',
+        };
+    } catch {
+        // Fail closed without relaying an arbitrary tool/configuration error to JSON.
+        return {
+            id: 'sensors-execution', ok: false,
+            detail: 'sensor execution could not establish an empirical verdict',
+            remedy: 'repair the sensor configuration, then rerun `awm preflight --verify-sensors`',
+        };
+    }
+}
+
+/**
  * Extract just the hostname portion of a git remote URL — never match against the
  * full URL string. A bare substring check against the whole remote (`remote.includes
  * ('gitlab')`) false-positives on an org/repo name that happens to contain the word,
@@ -325,7 +381,10 @@ function checkHost(cwd: string): PreflightCheck {
     return { id: 'host', ok: true, detail: 'git host not recognized (github/gitlab) — PR/MR automation not applicable' };
 }
 
-export async function preflight(cwd: string = process.cwd()): Promise<PreflightReport> {
+export async function preflight(cwd: string = process.cwd(), opts: PreflightOptions = {}): Promise<PreflightReport> {
+    if (!opts || typeof opts !== 'object' || (opts.verifySensors !== undefined && typeof opts.verifySensors !== 'boolean')) {
+        throw new Error('preflight options must contain an optional boolean verifySensors');
+    }
     const manifest = readManifest(cwd);
     const manifestExists = fs.existsSync(path.join(cwd, MANIFEST));
 
@@ -336,6 +395,9 @@ export async function preflight(cwd: string = process.cwd()): Promise<PreflightR
         // a baseline that has nothing to snapshot) on a repo that was never set up
         // buries the one thing the operator needs to read.
         ...(manifestExists ? [await checkTools(cwd), checkPack(cwd, manifest), checkSensorsBaseline(cwd, manifest)] : []),
+        // The empirical mode is intentionally opt-in: ordinary preflight remains a
+        // quick static inspection and must not dispatch project software.
+        ...(opts.verifySensors === true ? [await checkSensorExecution(cwd)] : []),
         // Runs unconditionally — orthogonal to sensor configuration entirely, this is
         // about PR/MR tooling, not sensors.
         checkHost(cwd),

--- a/cli/src/commands/preflight/index.ts
+++ b/cli/src/commands/preflight/index.ts
@@ -44,9 +44,10 @@ export function registerPreflightCommand(program: Command): void {
         .command('preflight')
         .description('verify the project harness can actually gate before development starts')
         .option('--json', 'emit the report as JSON')
+        .option('--verify-sensors', 'run the complete sensor gate before unattended execution')
         .option('--cwd <path>', 'project directory to check (default: current)')
         .action(async (opts) => {
-            const report = await preflight(opts.cwd ?? process.cwd());
+            const report = await preflight(opts.cwd ?? process.cwd(), { verifySensors: opts.verifySensors === true });
             process.stdout.write(opts.json ? JSON.stringify(report, null, 2) + '\n' : formatReport(report));
             const code = exitCodeFor(report);
             // `process.exit()` may truncate the JSON written immediately above when

--- a/cli/src/commands/preflight/index.ts
+++ b/cli/src/commands/preflight/index.ts
@@ -5,10 +5,10 @@ import { preflight, PreflightReport } from './checks';
 /**
  * Exit code. Anything but `ready` exits 1.
  *
- * Unlike `awm sensors run` — which exits 0 on `not_certified` because exit 2 is a
- * blocking error in Claude Code hooks — preflight is never a hook. It is invoked
- * explicitly by a phase gate, so the exit code can carry the verdict and the caller
- * does not have to remember to read a field out of JSON.
+ * `awm sensors run` exits zero only for an empirical `pass`; preflight mirrors that
+ * binary-gate rule for its own `ready` status. It is invoked explicitly by a phase
+ * gate, so the exit code carries the verdict and the caller need not infer it from
+ * a field in JSON.
  */
 export function exitCodeFor(report: PreflightReport): number {
     return report.status === 'ready' ? 0 : 1;

--- a/cli/src/commands/sensors/changed.ts
+++ b/cli/src/commands/sensors/changed.ts
@@ -104,6 +104,20 @@ export function hasUnsafeWin32Chars(file: string): boolean {
 }
 
 /**
+ * Explain why a resolved diff cannot safely be interpolated into a legacy shell
+ * command. Structured v2 commands never need this check: their file names remain
+ * literal argv entries and never meet a shell.
+ */
+export function changedScopeError(changed: ChangedFiles): string | undefined {
+    if (changed.error) return changed.error;
+    if (isWindowsNative() && changed.files.some(hasUnsafeWin32Chars)) {
+        return 'a changed filename contains a cmd.exe metacharacter (& | < > ^ % or newline/CR) '
+            + 'that quoting cannot reliably neutralize on native Windows — refusing to interpolate it';
+    }
+    return undefined;
+}
+
+/**
  * CommandLineToArgvW-safe quoting (the algorithm behind Python's
  * `subprocess.list2cmdline`, Rust's `std::process::Command` on Windows, and .NET's
  * argument escaper). Per the documented rule

--- a/cli/src/commands/sensors/compatibility/contract.ts
+++ b/cli/src/commands/sensors/compatibility/contract.ts
@@ -2,6 +2,7 @@ import semver from 'semver';
 import fs from 'fs';
 import path from 'path';
 import { parseCoverageContract } from '../coverage/contract';
+import { positiveTimeout } from './timeout';
 import type {
     CompatibilityProbe,
     CompatibilityEvidence,
@@ -177,7 +178,7 @@ export function parseStructuredCommand(input: unknown, source: unknown): Structu
 
 function parseVariant(input: unknown, source: unknown, location: string): SensorVariant {
     const value = record(input, source, location);
-    fields(value, ['id', 'priority', 'requirements', 'certifiedRange', 'command', 'assets', 'formatter', 'probe', 'policyRef'], source, location);
+    fields(value, ['id', 'priority', 'requirements', 'certifiedRange', 'command', 'changedCommand', 'assets', 'formatter', 'probe', 'policyRef'], source, location);
     const certifiedRange = text(value.certifiedRange, source, `${location}.certifiedRange`);
     if (semver.validRange(certifiedRange) === null) invalid(source, `${location}.certifiedRange must be a valid semver range`);
     if (typeof value.priority !== 'number' || !Number.isSafeInteger(value.priority)) invalid(source, `${location}.priority must be a safe integer`);
@@ -194,6 +195,8 @@ function parseVariant(input: unknown, source: unknown, location: string): Sensor
         fields(probe, ['kind'], source, `${location}.probe`);
         if (typeof probe.kind !== 'string' || !ALLOWED_PROBES.has(probe.kind as CompatibilityProbe)) invalid(source, `${location}.probe.kind must be an allowed probe`);
     }
+    const changedCommand = 'changedCommand' in value ? parseStructuredCommand(value.changedCommand, source) : undefined;
+    if (changedCommand && !changedCommand.fileInput) invalid(source, `${location}.changedCommand must declare fileInput`);
     return {
         id: id(value.id, source, `${location}.id`),
         priority: value.priority,
@@ -206,6 +209,7 @@ function parseVariant(input: unknown, source: unknown, location: string): Sensor
         probe: { kind: policy?.probe ?? probe!.kind as CompatibilityProbe },
         ...(policy ? { policyRef: SEMGREP_POLICY_REF } : {}),
         command: parseStructuredCommand(value.command, source),
+        ...(changedCommand ? { changedCommand } : {}),
     };
 }
 
@@ -243,7 +247,7 @@ export function assertNoEqualPriorityOverlap(variants: unknown): void {
 
 function parseSensor(input: unknown, source: unknown, location: string, variantIds: Set<string>): SensorPackSensor {
     const value = record(input, source, location);
-    fields(value, ['applicability', 'variants', 'fast'], source, location);
+    fields(value, ['applicability', 'variants', 'fast', 'timeout'], source, location);
     if (!Array.isArray(value.variants) || value.variants.length === 0) invalid(source, `${location}.variants must be a nonempty array`);
     const variants = value.variants.map((variant, index) => parseVariant(variant, source, `${location}.variants[${index}]`));
     for (const variant of variants) {
@@ -263,7 +267,12 @@ function parseSensor(input: unknown, source: unknown, location: string, variantI
     if ('kind' in applicabilityInput) applicability.kind = text(applicabilityInput.kind, source, `${location}.applicability.kind`);
     if (Object.keys(applicability).length === 0) invalid(source, `${location}.applicability must declare a condition`);
     if ('fast' in value && typeof value.fast !== 'boolean') invalid(source, `${location}.fast must be a boolean`);
-    return { applicability, variants, ...('fast' in value ? { fast: value.fast as boolean } : {}) };
+    let timeout: number | undefined;
+    if ('timeout' in value) {
+        try { timeout = positiveTimeout(value.timeout, `${location}.timeout`); }
+        catch (error) { invalid(source, error instanceof Error ? error.message : `${location}.timeout must be a positive safe integer`); }
+    }
+    return { applicability, variants, ...('fast' in value ? { fast: value.fast as boolean } : {}), ...(timeout !== undefined ? { timeout } : {}) };
 }
 
 function legacyCompatibility(): CompatibilityEvidence {

--- a/cli/src/commands/sensors/compatibility/manifest.ts
+++ b/cli/src/commands/sensors/compatibility/manifest.ts
@@ -1,6 +1,7 @@
 import type { SensorConfig, SensorManifest } from '../types';
 import type { CompatibilityEvidence, StructuredCommand } from './types';
 import { parseStructuredCommand } from './contract';
+import { positiveTimeout } from './timeout';
 import semver from 'semver';
 import path from 'path';
 
@@ -12,7 +13,7 @@ export type SensorManifestV2 = {
     /** Durable operator intent. Absent means detected/fallback, never explicit. */
     packSelection?: 'explicit';
     registryRoot?: string;
-    sensors: Record<string, { enabled: boolean; fast?: boolean; variantId: string; command: StructuredCommand; assets?: string[]; policyRef?: 'shared/semgrep-policy.json'; initializedCompatibility: CompatibilityEvidence }>;
+    sensors: Record<string, { enabled: boolean; fast?: boolean; timeout?: number; variantId: string; command: StructuredCommand; assets?: string[]; policyRef?: 'shared/semgrep-policy.json'; initializedCompatibility: CompatibilityEvidence }>;
     concurrency?: number;
 };
 
@@ -116,8 +117,8 @@ function parseLegacySensor(input: unknown, source: unknown, location: string): S
         sensor.enabled = value.enabled;
     }
     if ('timeout' in value) {
-        if (typeof value.timeout !== 'number' || !Number.isSafeInteger(value.timeout) || value.timeout <= 0) invalid(source, `${location}.timeout must be a positive safe integer`);
-        sensor.timeout = value.timeout;
+        try { sensor.timeout = positiveTimeout(value.timeout, `${location}.timeout`); }
+        catch (error) { invalid(source, error instanceof Error ? error.message : `${location}.timeout must be a positive safe integer`); }
     }
     if ('changedCmd' in value) sensor.changedCmd = text(value.changedCmd, source, `${location}.changedCmd`);
     if ('changedExtensions' in value) sensor.changedExtensions = stringArray(value.changedExtensions, source, `${location}.changedExtensions`, true);
@@ -141,7 +142,7 @@ function parseLegacyManifest(value: UnknownRecord, source: unknown): LegacySenso
 
 function parseV2Sensor(input: unknown, source: unknown, location: string): SensorManifestV2['sensors'][string] {
     const value = record(input, source, location);
-    fields(value, ['enabled', 'fast', 'variantId', 'command', 'assets', 'policyRef', 'initializedCompatibility'], source, location);
+    fields(value, ['enabled', 'fast', 'timeout', 'variantId', 'command', 'assets', 'policyRef', 'initializedCompatibility'], source, location);
     if (typeof value.enabled !== 'boolean') invalid(source, `${location}.enabled must be a boolean`);
     const sensor: SensorManifestV2['sensors'][string] = {
         enabled: value.enabled, variantId: id(value.variantId, source, `${location}.variantId`),
@@ -160,6 +161,10 @@ function parseV2Sensor(input: unknown, source: unknown, location: string): Senso
     if ('fast' in value) {
         if (typeof value.fast !== 'boolean') invalid(source, `${location}.fast must be a boolean`);
         sensor.fast = value.fast;
+    }
+    if ('timeout' in value) {
+        try { sensor.timeout = positiveTimeout(value.timeout, `${location}.timeout`); }
+        catch (error) { invalid(source, error instanceof Error ? error.message : `${location}.timeout must be a positive safe integer`); }
     }
     return sensor;
 }

--- a/cli/src/commands/sensors/compatibility/timeout.ts
+++ b/cli/src/commands/sensors/compatibility/timeout.ts
@@ -1,0 +1,18 @@
+export function positiveTimeout(value: unknown, location: string): number {
+    if (typeof location !== 'string' || location.trim() === '') throw new Error('timeout location must be a nonempty string');
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+        throw new Error(`${location} must be a positive safe integer`);
+    }
+    return value;
+}
+
+export function resolveTimeout(input: {
+    project?: number;
+    pack?: number;
+    fast: boolean;
+}): { timeoutMs: number; source: 'project' | 'pack' | 'fallback' } {
+    if (!input || typeof input !== 'object' || typeof input.fast !== 'boolean') throw new Error('timeout resolution input is invalid');
+    if (input.project !== undefined) return { timeoutMs: positiveTimeout(input.project, 'project timeout'), source: 'project' };
+    if (input.pack !== undefined) return { timeoutMs: positiveTimeout(input.pack, 'pack timeout'), source: 'pack' };
+    return { timeoutMs: input.fast ? 10_000 : 120_000, source: 'fallback' };
+}

--- a/cli/src/commands/sensors/compatibility/types.ts
+++ b/cli/src/commands/sensors/compatibility/types.ts
@@ -48,6 +48,7 @@ export type SensorVariant = {
     /** A registry-owned policy whose compatibility requirements are authoritative. */
     policyRef?: 'shared/semgrep-policy.json';
     command: StructuredCommand;
+    changedCommand?: StructuredCommand;
 };
 
 export type SemgrepPolicy = {
@@ -69,6 +70,7 @@ export type SensorPackSensor = {
     applicability: { allFiles?: string[]; anyFiles?: string[]; kind?: string };
     variants: SensorVariant[];
     fast?: boolean;
+    timeout?: number;
 };
 
 export type SensorPackV2 = {

--- a/cli/src/commands/sensors/exec.ts
+++ b/cli/src/commands/sensors/exec.ts
@@ -15,6 +15,8 @@ export type ExecResult = {
     timedOut: boolean;
     /** Collected output hit `maxBuffer`; the process group was killed. */
     overflowed: boolean;
+    /** Monotonic wall-clock duration from spawn attempt through settlement. */
+    elapsedMs: number;
     /** The shell itself could not be spawned (bad cwd, no shell). */
     spawnError?: NodeJS.ErrnoException;
 };
@@ -88,6 +90,7 @@ function collectSpawn(input: SpawnInput, opts: ExecOptions): Promise<ExecResult>
     const killGraceMs = opts.killGraceMs ?? DEFAULT_KILL_GRACE_MS;
 
     return new Promise<ExecResult>((resolve) => {
+        const startedAt = process.hrtime.bigint();
         let stdout = '';
         let stderr = '';
         let timedOut = false;
@@ -123,7 +126,8 @@ function collectSpawn(input: SpawnInput, opts: ExecOptions): Promise<ExecResult>
             if (settled) return;
             settled = true;
             timers.forEach(clearTimeout);
-            resolve({ stdout, stderr, code: null, signal: null, timedOut, overflowed, ...extra });
+            const elapsedMs = Number((process.hrtime.bigint() - startedAt) / 1_000_000n);
+            resolve({ stdout, stderr, code: null, signal: null, timedOut, overflowed, elapsedMs, ...extra });
         };
 
         /** Cut the run short: kill the tree, escalate, and never hang waiting for it. */

--- a/cli/src/commands/sensors/index.ts
+++ b/cli/src/commands/sensors/index.ts
@@ -9,15 +9,7 @@ import { buildBaseline, writeBaseline } from './baseline';
 import { runCoverage } from './coverage';
 import { renderCoverageHuman, renderCoverageJson } from './coverage/render';
 import { capabilityRoot } from '../../core/registries';
-
-export type RunOutputLike = { sensors: unknown[]; overall: 'pass' | 'fail' | 'skipped' | 'not_certified' };
-
-/** Map a sensor run verdict to a process exit code. fail → 1; everything else → 0.
- *  not_certified intentionally exits 0: its signal lives in `overall`, because
- *  exit code 2 is a blocking error in Claude Code hooks. */
-export function exitCodeFor(output: RunOutputLike): number {
-    return output.overall === 'fail' ? 1 : 0;
-}
+import { exitCodeForVerdict } from './verdict';
 
 /** Commander coercion for coverage recurrence emphasis. It deliberately runs
  * before the action, so an invalid value cannot trigger ledger I/O. */
@@ -62,8 +54,7 @@ export function registerSensorsCommand(program: Command): void {
             // Emit the verdict ALWAYS — an empty `sensors` with overall:'not_certified'
             // must be visible, never a silent exit-0 that reads as "clean".
             process.stdout.write(JSON.stringify(output, null, 2) + '\n');
-            const code = exitCodeFor(output);
-            if (code !== 0) process.exit(code);
+            process.exitCode = exitCodeForVerdict(output.overall);
         });
 
     sensors

--- a/cli/src/commands/sensors/index.ts
+++ b/cli/src/commands/sensors/index.ts
@@ -101,10 +101,10 @@ export function registerSensorsCommand(program: Command): void {
 
     sensors
         .command('status')
-        .description('check sensor health for the current project')
+        .description('check static sensor readiness for the current project')
         .action(async () => {
             const status = await computeSensorStatus();
-            const icon = status.overall === 'HEALTHY' ? pc.green('✔') : pc.yellow('⚠');
+            const icon = status.overall === 'READY' ? pc.green('✔') : pc.yellow('⚠');
             console.log(`\nPack:    ${status.pack ?? 'none'}`);
             console.log(`Overall: ${icon} ${status.overall}\n`);
             for (const [name, check] of Object.entries(status.checks)) {
@@ -112,7 +112,7 @@ export function registerSensorsCommand(program: Command): void {
                 console.log(`  ${mark}  ${name.padEnd(12)} ${check.detail}`);
             }
             console.log('');
-            if (status.overall !== 'HEALTHY') process.exit(1);
+            if (status.overall !== 'READY') process.exit(1);
         });
 
     sensors

--- a/cli/src/commands/sensors/init.ts
+++ b/cli/src/commands/sensors/init.ts
@@ -298,6 +298,7 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
                     sensors[name] = {
                         enabled: prior?.enabled ?? true,
                         fast: prior?.fast ?? sensor.fast ?? false,
+                        ...(prior?.timeout !== undefined ? { timeout: prior.timeout } : {}),
                         variantId: variant.id,
                         command: variant.command,
                         assets: variant.assets,

--- a/cli/src/commands/sensors/prepare.ts
+++ b/cli/src/commands/sensors/prepare.ts
@@ -62,7 +62,11 @@ export function expandFileInput(command: StructuredCommand, files: string[]): St
     if (index < 0 || command.args.lastIndexOf(command.fileInput.placeholder) !== index) {
         throw new Error('changed command requires exactly one standalone {files} argument');
     }
-    return { ...command, args: [...command.args.slice(0, index), ...files, ...command.args.slice(index + 1)] };
+    // `fileInput` describes the unexpanded registry template. Leaving it on the
+    // materialized command makes the execution boundary (correctly) demand a
+    // placeholder that has already been replaced with literal argv entries.
+    const { fileInput: _templateInput, ...materialized } = command;
+    return { ...materialized, args: [...command.args.slice(0, index), ...files, ...command.args.slice(index + 1)] };
 }
 
 function timeout(project: number | undefined, pack: number | undefined, fast: boolean): Pick<PreparedSensorExecution, 'timeoutMs' | 'timeoutSource'> {

--- a/cli/src/commands/sensors/prepare.ts
+++ b/cli/src/commands/sensors/prepare.ts
@@ -5,6 +5,10 @@ import type { SensorManifestV2 } from './compatibility/manifest';
 import type { PreparedSensorExecution, SensorConfig } from './types';
 
 export type PrepareRunOptions = {
+    fast?: boolean;
+    slow?: boolean;
+    all?: boolean;
+    cwd?: string;
     changed?: boolean;
     ignoreBaseline?: boolean;
     base?: string;
@@ -39,6 +43,10 @@ export type PrepareV2SensorInput = {
 
 export function validateRunOptions(opts: PrepareRunOptions): void {
     if (!opts || typeof opts !== 'object' || Array.isArray(opts)) throw new Error('run options must be an object');
+    if (opts.fast !== undefined && typeof opts.fast !== 'boolean') throw new Error('run option fast must be a boolean');
+    if (opts.slow !== undefined && typeof opts.slow !== 'boolean') throw new Error('run option slow must be a boolean');
+    if (opts.all !== undefined && typeof opts.all !== 'boolean') throw new Error('run option all must be a boolean');
+    if (opts.cwd !== undefined && (typeof opts.cwd !== 'string' || opts.cwd.trim() === '')) throw new Error('run option cwd must be a nonempty string');
     if (opts.changed !== undefined && typeof opts.changed !== 'boolean') throw new Error('run option changed must be a boolean');
     if (opts.ignoreBaseline !== undefined && typeof opts.ignoreBaseline !== 'boolean') throw new Error('run option ignoreBaseline must be a boolean');
     if (opts.base !== undefined && (typeof opts.base !== 'string' || opts.base.trim() === '')) throw new Error('run option base must be a nonempty string');

--- a/cli/src/commands/sensors/prepare.ts
+++ b/cli/src/commands/sensors/prepare.ts
@@ -1,0 +1,135 @@
+import { changedScopeError, applyChangedCmd, filterByExtension, type ChangedFiles } from './changed';
+import { resolveTimeout } from './compatibility/timeout';
+import type { CompatibilityEvidence, SensorPackSensor, SensorVariant, StructuredCommand } from './compatibility/types';
+import type { SensorManifestV2 } from './compatibility/manifest';
+import type { PreparedSensorExecution, SensorConfig } from './types';
+
+export type PrepareRunOptions = {
+    changed?: boolean;
+    ignoreBaseline?: boolean;
+    base?: string;
+};
+
+type RequestedScope = PreparedSensorExecution['requestedScope'];
+
+export type PrepareLegacySensorInput = {
+    name: string;
+    config: SensorConfig;
+    packTimeout?: number;
+    requestedScope?: RequestedScope;
+    changed?: ChangedFiles;
+};
+
+export type PrepareV2SensorInput = {
+    name: string;
+    sensor: SensorManifestV2['sensors'][string];
+    liveSensor?: SensorPackSensor;
+    liveState?: CompatibilityEvidence;
+    projectTimeout?: number;
+    packTimeout?: number;
+    requestedScope?: RequestedScope;
+    changed?: ChangedFiles;
+};
+
+export function validateRunOptions(opts: PrepareRunOptions): void {
+    if (!opts || typeof opts !== 'object' || Array.isArray(opts)) throw new Error('run options must be an object');
+    if (opts.changed !== undefined && typeof opts.changed !== 'boolean') throw new Error('run option changed must be a boolean');
+    if (opts.ignoreBaseline !== undefined && typeof opts.ignoreBaseline !== 'boolean') throw new Error('run option ignoreBaseline must be a boolean');
+    if (opts.base !== undefined && (typeof opts.base !== 'string' || opts.base.trim() === '')) throw new Error('run option base must be a nonempty string');
+    if (opts.changed && opts.ignoreBaseline) {
+        throw new Error('refusing to combine --changed with a baseline capture: a partial run cannot define the accepted set');
+    }
+}
+
+/** Expand the one declared file placeholder into literal structured argv entries. */
+export function expandFileInput(command: StructuredCommand, files: string[]): StructuredCommand {
+    if (!command.fileInput) throw new Error('changed command requires fileInput');
+    const index = command.args.indexOf(command.fileInput.placeholder);
+    if (index < 0 || command.args.lastIndexOf(command.fileInput.placeholder) !== index) {
+        throw new Error('changed command requires exactly one standalone {files} argument');
+    }
+    return { ...command, args: [...command.args.slice(0, index), ...files, ...command.args.slice(index + 1)] };
+}
+
+function timeout(project: number | undefined, pack: number | undefined, fast: boolean): Pick<PreparedSensorExecution, 'timeoutMs' | 'timeoutSource'> {
+    const resolved = resolveTimeout({ project, pack, fast });
+    return { timeoutMs: resolved.timeoutMs, timeoutSource: resolved.source };
+}
+
+function fullLegacy(input: PrepareLegacySensorInput, scopeReason?: string): PreparedSensorExecution {
+    const requestedScope = input.requestedScope ?? 'full';
+    return {
+        name: input.name,
+        ...(input.config.cmd ? { command: { kind: 'legacy' as const, value: input.config.cmd } } : { syntheticStatus: 'inconclusive' as const, syntheticReason: 'no cmd configured' }),
+        ...(input.config.formatter ? { formatter: input.config.formatter } : {}),
+        ...timeout(input.config.timeout, input.packTimeout, input.config.fast ?? false),
+        requestedScope,
+        effectiveScope: 'full',
+        ...(scopeReason ? { scopeReason } : {}),
+    };
+}
+
+/** Prepare one legacy command without dispatching it. */
+export function prepareLegacySensor(input: PrepareLegacySensorInput): PreparedSensorExecution {
+    if (!input || typeof input !== 'object' || !input.config || typeof input.name !== 'string' || input.name === '') throw new Error('legacy preparation input is invalid');
+    const requestedScope = input.requestedScope ?? 'full';
+    if (requestedScope !== 'changed' || !input.changed) return fullLegacy(input);
+    const scopeError = changedScopeError(input.changed);
+    if (scopeError) return fullLegacy(input, `changed scope could not be resolved safely: ${scopeError}`);
+    if (!input.config.changedCmd) return fullLegacy(input, 'sensor does not support changed scope');
+    if (!input.config.changedCmd.includes('{files}')) {
+        const { command: _command, ...prepared } = fullLegacy(input);
+        return { ...prepared, effectiveScope: 'changed', syntheticStatus: 'inconclusive', syntheticReason: 'changedCmd has no {files} placeholder' };
+    }
+    const files = filterByExtension(input.changed.files, input.config.changedExtensions);
+    if (files.length === 0) {
+        const { command: _command, ...prepared } = fullLegacy(input);
+        return { ...prepared, effectiveScope: 'changed', files: 0, syntheticStatus: 'pass', syntheticReason: 'no changed files in scope' };
+    }
+    return {
+        name: input.name,
+        command: { kind: 'legacy', value: applyChangedCmd(input.config.changedCmd, files) },
+        ...(input.config.formatter ? { formatter: input.config.formatter } : {}),
+        ...timeout(input.config.timeout, input.packTimeout, input.config.fast ?? false),
+        requestedScope,
+        effectiveScope: 'changed',
+        files: files.length,
+    };
+}
+
+function v2Synthetic(input: PrepareV2SensorInput, reason: string): PreparedSensorExecution {
+    const requestedScope = input.requestedScope ?? 'full';
+    return {
+        name: input.name,
+        ...timeout(input.projectTimeout ?? input.sensor.timeout, input.packTimeout ?? input.liveSensor?.timeout, input.sensor.fast ?? input.liveSensor?.fast ?? false),
+        requestedScope,
+        effectiveScope: 'full',
+        syntheticStatus: 'inconclusive',
+        syntheticReason: reason,
+    };
+}
+
+/**
+ * Prepare a v2 command from the freshly resolved pack. The manifest command is
+ * deliberately never read: variantId is only a selector for live authority.
+ */
+export function prepareV2Sensor(input: PrepareV2SensorInput): PreparedSensorExecution {
+    if (!input || typeof input !== 'object' || !input.sensor || typeof input.name !== 'string' || input.name === '') throw new Error('v2 preparation input is invalid');
+    const requestedScope = input.requestedScope ?? 'full';
+    if (!input.liveState || input.liveState.state !== 'certified') return v2Synthetic(input, input.liveState ? `${input.liveState.state}: ${input.liveState.reason}` : 'compatibility could not be revalidated');
+    if (input.liveState.variantId !== input.sensor.variantId) return v2Synthetic(input, `variant-drift: manifest ${input.sensor.variantId}, live ${input.liveState.variantId ?? 'none'}; run \`awm sensors init\``);
+    const variant: SensorVariant | undefined = input.liveSensor?.variants.find(candidate => candidate.id === input.sensor.variantId);
+    if (!variant) return v2Synthetic(input, 'variant-drift: selected live variant has no command; run `awm sensors init`');
+    const common = {
+        name: input.name,
+        ...(variant.formatter ? { formatter: variant.formatter } : {}),
+        ...timeout(input.projectTimeout ?? input.sensor.timeout, input.packTimeout ?? input.liveSensor?.timeout, input.sensor.fast ?? input.liveSensor?.fast ?? false),
+        requestedScope,
+    };
+    if (requestedScope !== 'changed' || !input.changed) return { ...common, command: { kind: 'structured', value: variant.command }, effectiveScope: 'full' };
+    if (input.changed.error) return { ...common, command: { kind: 'structured', value: variant.command }, effectiveScope: 'full', scopeReason: `changed scope could not be resolved: ${input.changed.error}` };
+    if (!variant.changedCommand) return { ...common, command: { kind: 'structured', value: variant.command }, effectiveScope: 'full', scopeReason: 'sensor does not support changed scope' };
+    const files = filterByExtension(input.changed.files, variant.changedCommand.fileInput?.extensions);
+    if (files.length === 0) return { ...common, effectiveScope: 'changed', files: 0, syntheticStatus: 'pass', syntheticReason: 'no changed files in scope' };
+    return { ...common, command: { kind: 'structured', value: expandFileInput(variant.changedCommand, files) }, effectiveScope: 'changed', files: files.length };
+}

--- a/cli/src/commands/sensors/prepare.ts
+++ b/cli/src/commands/sensors/prepare.ts
@@ -12,6 +12,12 @@ export type PrepareRunOptions = {
 
 type RequestedScope = PreparedSensorExecution['requestedScope'];
 
+function resolveRequestedScope(value: unknown): RequestedScope {
+    if (value === undefined) return 'full';
+    if (value === 'full' || value === 'changed') return value;
+    throw new Error('requested scope must be "full" or "changed"');
+}
+
 export type PrepareLegacySensorInput = {
     name: string;
     config: SensorConfig;
@@ -57,7 +63,7 @@ function timeout(project: number | undefined, pack: number | undefined, fast: bo
 }
 
 function fullLegacy(input: PrepareLegacySensorInput, scopeReason?: string): PreparedSensorExecution {
-    const requestedScope = input.requestedScope ?? 'full';
+    const requestedScope = resolveRequestedScope(input.requestedScope);
     return {
         name: input.name,
         ...(input.config.cmd ? { command: { kind: 'legacy' as const, value: input.config.cmd } } : { syntheticStatus: 'inconclusive' as const, syntheticReason: 'no cmd configured' }),
@@ -72,7 +78,7 @@ function fullLegacy(input: PrepareLegacySensorInput, scopeReason?: string): Prep
 /** Prepare one legacy command without dispatching it. */
 export function prepareLegacySensor(input: PrepareLegacySensorInput): PreparedSensorExecution {
     if (!input || typeof input !== 'object' || !input.config || typeof input.name !== 'string' || input.name === '') throw new Error('legacy preparation input is invalid');
-    const requestedScope = input.requestedScope ?? 'full';
+    const requestedScope = resolveRequestedScope(input.requestedScope);
     if (requestedScope !== 'changed' || !input.changed) return fullLegacy(input);
     const scopeError = changedScopeError(input.changed);
     if (scopeError) return fullLegacy(input, `changed scope could not be resolved safely: ${scopeError}`);
@@ -98,7 +104,7 @@ export function prepareLegacySensor(input: PrepareLegacySensorInput): PreparedSe
 }
 
 function v2Synthetic(input: PrepareV2SensorInput, reason: string): PreparedSensorExecution {
-    const requestedScope = input.requestedScope ?? 'full';
+    const requestedScope = resolveRequestedScope(input.requestedScope);
     return {
         name: input.name,
         ...timeout(input.projectTimeout ?? input.sensor.timeout, input.packTimeout ?? input.liveSensor?.timeout, input.sensor.fast ?? input.liveSensor?.fast ?? false),
@@ -115,7 +121,7 @@ function v2Synthetic(input: PrepareV2SensorInput, reason: string): PreparedSenso
  */
 export function prepareV2Sensor(input: PrepareV2SensorInput): PreparedSensorExecution {
     if (!input || typeof input !== 'object' || !input.sensor || typeof input.name !== 'string' || input.name === '') throw new Error('v2 preparation input is invalid');
-    const requestedScope = input.requestedScope ?? 'full';
+    const requestedScope = resolveRequestedScope(input.requestedScope);
     if (!input.liveState || input.liveState.state !== 'certified') return v2Synthetic(input, input.liveState ? `${input.liveState.state}: ${input.liveState.reason}` : 'compatibility could not be revalidated');
     if (input.liveState.variantId !== input.sensor.variantId) return v2Synthetic(input, `variant-drift: manifest ${input.sensor.variantId}, live ${input.liveState.variantId ?? 'none'}; run \`awm sensors init\``);
     const variant: SensorVariant | undefined = input.liveSensor?.variants.find(candidate => candidate.id === input.sensor.variantId);

--- a/cli/src/commands/sensors/result.ts
+++ b/cli/src/commands/sensors/result.ts
@@ -1,0 +1,128 @@
+import { runCommand, runStructuredCommand, type ExecResult } from './exec';
+import { partition } from './baseline';
+import { parseTscOutput } from './formatters/tsc';
+import { parseEslintOutput } from './formatters/eslint';
+import { parseSemgrepOutput } from './formatters/semgrep';
+import { parseGenericOutput } from './formatters/generic';
+import { parseTestOutput } from './formatters/test';
+import { parseMypyOutput } from './formatters/mypy';
+import { parseRuffOutput } from './formatters/ruff';
+import { parseShellcheckOutput } from './formatters/shellcheck';
+import type { PreparedSensorExecution, SensorError, SensorResult } from './types';
+
+const MAX_BUFFER = 64 * 1024 * 1024;
+
+function formatterFor(name: string, formatter?: string): (raw: string) => SensorError[] {
+    if (formatter !== undefined) {
+        switch (formatter) {
+            case 'tsc': return parseTscOutput;
+            case 'eslint-llm': return parseEslintOutput;
+            case 'semgrep': return parseSemgrepOutput;
+            case 'test': return parseTestOutput;
+            case 'mypy': return parseMypyOutput;
+            case 'ruff': return parseRuffOutput;
+            case 'shellcheck': return parseShellcheckOutput;
+            case 'generic': return parseGenericOutput;
+            default: return parseGenericOutput;
+        }
+    }
+    if (name === 'typecheck') return parseTscOutput;
+    if (name === 'lint') return parseEslintOutput;
+    if (name === 'security') return parseSemgrepOutput;
+    if (name === 'test') return parseTestOutput;
+    return parseGenericOutput;
+}
+
+function executionEvidence(prepared: PreparedSensorExecution, elapsedMs: number): NonNullable<SensorResult['execution']> {
+    return {
+        timeoutMs: prepared.timeoutMs,
+        timeoutSource: prepared.timeoutSource,
+        elapsedMs,
+        requestedScope: prepared.requestedScope,
+        effectiveScope: prepared.effectiveScope,
+        ...(prepared.files !== undefined ? { files: prepared.files } : {}),
+        ...(prepared.scopeReason ? { scopeReason: prepared.scopeReason } : {}),
+    };
+}
+
+function validatePrepared(prepared: PreparedSensorExecution): void {
+    if (!prepared || typeof prepared !== 'object' || typeof prepared.name !== 'string' || prepared.name === '') throw new Error('prepared sensor requires a nonempty name');
+    if (!Number.isSafeInteger(prepared.timeoutMs) || prepared.timeoutMs <= 0) throw new Error('prepared sensor timeoutMs must be a positive safe integer');
+    if (!['project', 'pack', 'fallback'].includes(prepared.timeoutSource)) throw new Error('prepared sensor timeoutSource is invalid');
+    if (!['full', 'changed'].includes(prepared.requestedScope) || !['full', 'changed'].includes(prepared.effectiveScope)) throw new Error('prepared sensor scope is invalid');
+    if (prepared.files !== undefined && (!Number.isSafeInteger(prepared.files) || prepared.files < 0)) throw new Error('prepared sensor files must be a non-negative safe integer');
+    if (prepared.command !== undefined && (prepared.command.kind !== 'legacy' && prepared.command.kind !== 'structured')) throw new Error('prepared sensor command kind is invalid');
+}
+
+function scoped(result: SensorResult, prepared: PreparedSensorExecution): SensorResult {
+    return {
+        ...result,
+        ...(prepared.effectiveScope === 'changed' ? { scope: 'changed' as const } : {}),
+    };
+}
+
+/** Interpret one raw bounded process result without knowing its manifest format. */
+export function interpretResult(prepared: PreparedSensorExecution, raw: ExecResult): SensorResult {
+    validatePrepared(prepared);
+    if (!raw || typeof raw !== 'object' || !Number.isSafeInteger(raw.elapsedMs) || raw.elapsedMs < 0) throw new Error('execution result requires a non-negative safe-integer elapsedMs');
+    const execution = executionEvidence(prepared, raw.elapsedMs);
+    const withEvidence = (result: Omit<SensorResult, 'execution'>): SensorResult => ({
+        ...result,
+        ...(prepared.effectiveScope === 'changed' ? { scope: 'changed' as const } : {}),
+        execution,
+    });
+    const format = formatterFor(prepared.name, prepared.formatter);
+
+    if (raw.spawnError) return withEvidence({ name: prepared.name, status: 'fail', errors: [{ message: `sensor could not be started: ${raw.spawnError.message}` }] });
+    if (raw.timedOut || raw.overflowed) {
+        const reason = raw.timedOut ? `timeout after ${prepared.timeoutMs}ms` : `output exceeded ${MAX_BUFFER} bytes`;
+        const errors = format(raw.stdout + raw.stderr);
+        if (errors.length > 0) return withEvidence({ name: prepared.name, status: 'fail', errors, incomplete: `${reason} — findings below are from partial output; the run did not finish` });
+        return withEvidence({ name: prepared.name, status: 'inconclusive', errors: [], skipReason: reason });
+    }
+    if (raw.code === 0) {
+        const errors = format(raw.stdout);
+        return withEvidence({ name: prepared.name, status: errors.length ? 'fail' : 'pass', errors });
+    }
+
+    const output = raw.stdout + raw.stderr;
+    const errors = format(output);
+    if (errors.length > 0) return withEvidence({ name: prepared.name, status: 'fail', errors });
+    const lower = output.toLowerCase();
+    const toolMissing = raw.code === 127
+        || lower.includes('command not found')
+        || lower.includes('is not recognized as an internal or external command')
+        || lower.includes('enoent')
+        || lower.includes('could not determine executable');
+    if (toolMissing) return withEvidence({ name: prepared.name, status: 'fail', errors: [{ message: `sensor tool not available: ${output.slice(0, 200)}` }] });
+    if (prepared.name === 'test') return withEvidence({ name: prepared.name, status: 'fail', errors: [{ message: `SENSOR[${prepared.name}] failed (exit ${raw.code})` }] });
+    return withEvidence({ name: prepared.name, status: 'inconclusive', errors: [], skipReason: `exit ${raw.code}: ${output.slice(0, 200)}` });
+}
+
+/** Execute a validated prepared command, or render its deliberate synthetic result. */
+export async function executePrepared(prepared: PreparedSensorExecution, cwd = process.cwd()): Promise<SensorResult> {
+    validatePrepared(prepared);
+    if (prepared.syntheticStatus !== undefined || prepared.command === undefined) {
+        const status = prepared.syntheticStatus ?? 'inconclusive';
+        return scoped({
+            name: prepared.name,
+            status,
+            errors: [],
+            ...(prepared.syntheticReason ? { skipReason: prepared.syntheticReason } : {}),
+            execution: executionEvidence(prepared, 0),
+        }, prepared);
+    }
+    const options = { timeout: prepared.timeoutMs, cwd, maxBuffer: MAX_BUFFER };
+    const raw = prepared.command.kind === 'legacy'
+        ? await runCommand(prepared.command.value, options)
+        : await runStructuredCommand(prepared.command.value, options);
+    return interpretResult(prepared, raw);
+}
+
+/** Apply baseline suppression only to completed verdicts. */
+export function applyBaseline(result: SensorResult, accepted: string[] | undefined): SensorResult {
+    if (result.status === 'skipped' || result.status === 'inconclusive') return result;
+    const { newErrors, suppressed } = partition(result.name, result.errors, accepted);
+    if (suppressed === 0) return result;
+    return { ...result, errors: newErrors, status: newErrors.length > 0 ? 'fail' : 'pass', newCount: newErrors.length, baselineCount: suppressed };
+}

--- a/cli/src/commands/sensors/run.ts
+++ b/cli/src/commands/sensors/run.ts
@@ -109,7 +109,11 @@ export function findManifestDir(startCwd: string): string | null {
 }
 
 function shouldRun(isFast: boolean, opts: RunOptions): boolean {
-    return opts.all === true || (opts.fast === true ? isFast : opts.slow === true ? !isFast : true);
+    if (opts.all) return true;
+    if (opts.fast && opts.slow) return true;
+    if (opts.fast) return isFast;
+    if (opts.slow) return !isFast;
+    return true;
 }
 
 /**

--- a/cli/src/commands/sensors/run.ts
+++ b/cli/src/commands/sensors/run.ts
@@ -11,7 +11,9 @@ import { parseTestOutput } from './formatters/test';
 import { parseMypyOutput } from './formatters/mypy';
 import { parseRuffOutput } from './formatters/ruff';
 import { parseShellcheckOutput } from './formatters/shellcheck';
-import { readBaseline, partition } from './baseline';
+import { readBaseline } from './baseline';
+import { applyBaseline } from './result';
+export { applyBaseline };
 import { changedFiles, applyChangedCmd, filterByExtension, hasUnsafeWin32Chars } from './changed';
 // Solo `detectStack` (puro, lee el arbol) — NO `initSensors`, que escribe. `run` es un
 // verbo de lectura: no debe tener a mano ninguna funcion capaz de mutar el proyecto.
@@ -45,26 +47,6 @@ export type RunOptions = {
     /** Comparison point for `changed`. Defaults to `HEAD` (uncommitted work only). */
     base?: string;
 };
-
-/**
- * Apply the baseline to a sensor result: keep only findings not already accepted.
- * `status` becomes 'pass' when every finding was baseline-suppressed. Results
- * without a verdict of their own — skipped and inconclusive — are returned
- * untouched: there is nothing to ratchet, and letting them through here would
- * hand back a `pass` for a sensor that never reported anything.
- */
-export function applyBaseline(result: SensorResult, accepted: string[] | undefined): SensorResult {
-    if (result.status === 'skipped' || result.status === 'inconclusive') return result;
-    const { newErrors, suppressed } = partition(result.name, result.errors, accepted);
-    if (suppressed === 0) return result;
-    return {
-        ...result,
-        errors: newErrors,
-        status: newErrors.length > 0 ? 'fail' : 'pass',
-        newCount: newErrors.length,
-        baselineCount: suppressed,
-    };
-}
 
 function readManifest(cwd: string): SensorManifest | null {
     const p = path.join(cwd, MANIFEST_FILE);

--- a/cli/src/commands/sensors/run.ts
+++ b/cli/src/commands/sensors/run.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { runCommand, runStructuredCommand, ExecResult } from './exec';
-import { SensorManifest, SensorResult, RunOutput, SensorError } from './types';
+import { SensorResult, SensorError } from './types';
 import { parseTscOutput } from './formatters/tsc';
 import { parseEslintOutput } from './formatters/eslint';
 import { parseSemgrepOutput } from './formatters/semgrep';
@@ -11,16 +11,18 @@ import { parseTestOutput } from './formatters/test';
 import { parseMypyOutput } from './formatters/mypy';
 import { parseRuffOutput } from './formatters/ruff';
 import { parseShellcheckOutput } from './formatters/shellcheck';
+import { SensorManifest, RunOutput, PreparedSensorExecution } from './types';
 import { readBaseline } from './baseline';
-import { applyBaseline } from './result';
+import { applyBaseline, executePrepared } from './result';
 export { applyBaseline };
-import { changedFiles, applyChangedCmd, filterByExtension, hasUnsafeWin32Chars } from './changed';
+import { changedFiles, changedScopeError } from './changed';
 // Solo `detectStack` (puro, lee el arbol) — NO `initSensors`, que escribe. `run` es un
 // verbo de lectura: no debe tener a mano ninguna funcion capaz de mutar el proyecto.
 import { detectStack } from './init';
-import { isWindowsNative } from '../../core/paths';
 import { parseSensorManifest } from './compatibility/manifest';
 import { resolveLiveCompatibility } from './compatibility/live';
+import { prepareLegacySensor, prepareV2Sensor, validateRunOptions } from './prepare';
+import { reduceVerdict } from './verdict';
 
 const MANIFEST_FILE = '.awm/sensors.json';
 const DEFAULT_FAST_TIMEOUT = 10_000;
@@ -48,11 +50,6 @@ export type RunOptions = {
     base?: string;
 };
 
-function readManifest(cwd: string): SensorManifest | null {
-    const p = path.join(cwd, MANIFEST_FILE);
-    if (!fs.existsSync(p)) return null;
-    try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch { return null; }
-}
 
 async function resolveLiveV2(cwd: string, manifest: ReturnType<typeof parseSensorManifest>): Promise<Awaited<ReturnType<typeof resolveLiveCompatibility>> | null> {
     if (manifest.kind !== 'v2') return null;
@@ -61,15 +58,6 @@ async function resolveLiveV2(cwd: string, manifest: ReturnType<typeof parseSenso
     } catch { return null; }
 }
 
-async function runV2Sensor(name: string, command: import('./compatibility/types').StructuredCommand, timeout: number, cwd: string, formatter?: string): Promise<SensorResult> {
-    const res = await runStructuredCommand(command, { timeout, cwd, maxBuffer: MAX_BUFFER });
-    const format = getFormatter(name, formatter);
-    if (res.spawnError) return { name, status: 'fail', errors: [{ message: `sensor could not be started: ${res.spawnError.message}` }] };
-    if (res.timedOut || res.overflowed) return { name, status: 'inconclusive', errors: [], skipReason: res.timedOut ? `timeout after ${timeout}ms` : `output exceeded ${MAX_BUFFER} bytes` };
-    const errors = format(res.stdout + res.stderr);
-    if (res.code === 0) return { name, status: errors.length ? 'fail' : 'pass', errors };
-    return errors.length ? { name, status: 'fail', errors } : { name, status: 'inconclusive', errors: [], skipReason: `exit ${res.code}` };
-}
 
 /**
  * Detect — and only detect — that the manifest's pack no longer describes the tree:
@@ -121,139 +109,7 @@ export function findManifestDir(startCwd: string): string | null {
 }
 
 function shouldRun(isFast: boolean, opts: RunOptions): boolean {
-    if (opts.all) return true;
-    if (opts.fast && isFast) return true;
-    if (opts.slow && !isFast) return true;
-    if (!opts.fast && !opts.slow && !opts.all) return true;
-    return false;
-}
-
-/**
- * Dispatch by the pack's `formatter` field (the real tool behind the sensor slot —
- * `lint` is eslint on js-ts but ruff on python, shellcheck on shell) when present.
- * Manifests written before this field existed carry no `formatter`, so they fall back
- * to the pre-existing name-based dispatch — nothing already installed breaks.
- */
-function getFormatter(name: string, formatterField?: string): (raw: string) => SensorError[] {
-    // A `formatter` field that is PRESENT but unrecognized (a typo in a pack.json, or a
-    // future pack declaring a tool this CLI version doesn't know about yet) is a
-    // different situation from no field at all. Falling through to name-based dispatch
-    // in that case would silently misparse a foreign output shape via the wrong parser
-    // (e.g. a `bandit` formatter falling through to `parseSemgrepOutput`, reading
-    // bandit's differently-shaped JSON and producing garbage findings). Only the
-    // ABSENT case (old manifest, written before this field existed) gets name-based
-    // backward-compat dispatch; a present-but-unknown value degrades honestly to the
-    // generic raw-wrap formatter instead.
-    if (formatterField !== undefined) {
-        switch (formatterField) {
-            case 'tsc': return parseTscOutput;
-            case 'eslint-llm': return parseEslintOutput;
-            case 'semgrep': return parseSemgrepOutput;
-            case 'test': return parseTestOutput;
-            case 'mypy': return parseMypyOutput;
-            case 'ruff': return parseRuffOutput;
-            case 'shellcheck': return parseShellcheckOutput;
-            case 'generic': return parseGenericOutput;
-            default: return parseGenericOutput;
-        }
-    }
-    if (name === 'typecheck') return parseTscOutput;
-    if (name === 'lint') return parseEslintOutput;
-    if (name === 'security') return parseSemgrepOutput;
-    if (name === 'test') return parseTestOutput;
-    return parseGenericOutput;
-}
-
-function isExitCodeSensor(name: string): boolean {
-    return name === 'test';
-}
-
-async function runSensor(name: string, cmd: string, timeout: number, cwd: string, formatterField?: string): Promise<SensorResult> {
-    const res: ExecResult = await runCommand(cmd, { timeout, cwd, maxBuffer: MAX_BUFFER });
-    const format = getFormatter(name, formatterField);
-
-    // The shell itself never started (bad cwd, no shell). Nothing ran.
-    if (res.spawnError) {
-        return {
-            name,
-            status: 'fail',
-            errors: [{ message: `sensor could not be started: ${res.spawnError.message}` }],
-        };
-    }
-
-    // Cut short by the deadline or the output cap. The run is NOT a verdict — but
-    // whatever it printed before being cut is still evidence, and throwing it away
-    // is what forced the caller to re-run the same command by hand to learn
-    // anything. Findings in the partial output are real findings; their absence
-    // proves nothing, so a clean partial can never be `pass`.
-    if (res.timedOut || res.overflowed) {
-        const reason = res.timedOut
-            ? `timeout after ${timeout}ms`
-            : `output exceeded ${MAX_BUFFER} bytes`;
-        const errors = format(res.stdout + res.stderr);
-        if (errors.length > 0) {
-            return {
-                name,
-                status: 'fail',
-                errors,
-                incomplete: `${reason} — findings below are from partial output; the run did not finish`,
-            };
-        }
-        return { name, status: 'inconclusive', errors: [], skipReason: reason };
-    }
-
-    if (res.code === 0) {
-        const errors = format(res.stdout);
-        return { name, status: errors.length > 0 ? 'fail' : 'pass', errors };
-    }
-
-    // Non-zero exit — the normal path for linters/typecheckers that found
-    // findings. Parse the output; if it yields findings, that's a fail.
-    const raw = res.stdout + res.stderr;
-    const errors = format(raw);
-    if (errors.length > 0) return { name, status: 'fail', errors };
-
-    // A missing tool (binary not installed) must NOT pass silently — the gate
-    // cannot certify what it could not run. Treat it as a fail with a clear message.
-    //
-    // Exit 127 is the POSIX signal for "command not found" and is the only check
-    // here that holds across shells and locales: bash writes `command not found`
-    // but dash — `/bin/sh` on Debian/Ubuntu, hence most CI runners and containers
-    // — writes `not found`, so matching shell text alone read an absent tool as a
-    // benign skip. A failure to spawn the shell itself is a different thing and
-    // is handled above via `spawnError`. The cut-short branches are evaluated
-    // above too, so reaching here with status 127 means the command did not exist.
-    //
-    // A wrapper (`npm test`, `npx …`) that exits 127 because a binary it invokes
-    // is absent is classified the same way, deliberately: the gate still ran
-    // nothing and still cannot certify anything.
-    const lower = raw.toLowerCase();
-    const toolMissing =
-        res.code === 127 ||                             // POSIX: command not found
-        lower.includes('command not found') ||          // bash, zsh
-        // cmd.exe reports an absent binary with exit 1, so 127 does not cover
-        // Windows; this exact phrase does. Kept narrow on purpose — a loose
-        // `not found` would also match a tool that ran and said "not found"
-        // for reasons of its own.
-        lower.includes('is not recognized as an internal or external command') ||
-        lower.includes('enoent') ||
-        lower.includes('could not determine executable');
-    if (toolMissing) {
-        return {
-            name,
-            status: 'fail',
-            errors: [{ message: `sensor tool not available: ${raw.slice(0, 200)}` }],
-        };
-    }
-    // Exit-code sensors (tests): any genuine non-zero exit is a real failure,
-    // even when no per-line findings can be parsed from the output.
-    if (isExitCodeSensor(name)) {
-        return { name, status: 'fail', errors: [{ message: `SENSOR[${name}] failed (exit ${res.code})` }] };
-    }
-    // Residual case: it exited non-zero, the tool exists, and no finding
-    // could be parsed. We do not know what happened — say so instead of
-    // reporting a benign skip.
-    return { name, status: 'inconclusive', errors: [], skipReason: `exit ${res.code}: ${raw.slice(0, 200)}` };
+    return opts.all === true || (opts.fast === true ? isFast : opts.slow === true ? !isFast : true);
 }
 
 /**
@@ -284,177 +140,70 @@ async function pooled<T>(tasks: Array<() => Promise<T>>, limit: number): Promise
     return results;
 }
 
+
+/**
+ * One orchestration path for both manifest contracts. Preparation selects the
+ * authorized command; execution, baseline handling, and verdict reduction are
+ * deliberately format-agnostic.
+ */
 export async function runSensors(opts: RunOptions = {}): Promise<RunOutput> {
-    const startCwd = opts.cwd ?? process.cwd();
-    const manifestDir = findManifestDir(startCwd);
+    validateRunOptions(opts);
+    const manifestDir = findManifestDir(opts.cwd ?? process.cwd());
     if (!manifestDir) return { sensors: [], overall: 'not_certified' };
-    const manifest = readManifest(manifestDir);
-    if (!manifest) return { sensors: [], overall: 'not_certified' };
-    let parsedManifest: ReturnType<typeof parseSensorManifest>;
-    try { parsedManifest = parseSensorManifest(JSON.parse(fs.readFileSync(path.join(manifestDir, MANIFEST_FILE), 'utf8')), path.join(manifestDir, MANIFEST_FILE)); }
-    catch { return { sensors: [], overall: 'not_certified' }; }
-    if (parsedManifest.kind === 'v2') {
-        const live = await resolveLiveV2(manifestDir, parsedManifest);
-        const tasks: Array<() => Promise<SensorResult>> = [];
-        for (const [name, sensor] of Object.entries(parsedManifest.pack.sensors)) {
-            const state = live?.sensors[name];
-            const liveSensor = live?.pack.sensors[name];
-            if (!shouldRun(sensor.fast ?? liveSensor?.fast ?? false, opts)) continue;
-            if (sensor.enabled === false) {
-                tasks.push(() => Promise.resolve({ name, status: 'skipped', errors: [], skipReason: 'disabled' }));
-                continue;
-            }
-            if (!state || state.state !== 'certified') {
-                tasks.push(() => Promise.resolve({ name, status: 'inconclusive', errors: [], skipReason: state ? `${state.state}: ${state.reason}` : 'compatibility could not be revalidated' }));
-                continue;
-            }
-            if (state.variantId !== sensor.variantId) {
-                tasks.push(() => Promise.resolve({ name, status: 'inconclusive', errors: [], skipReason: `variant-drift: manifest ${sensor.variantId}, live ${state.variantId ?? 'none'}; run \`awm sensors init\`` }));
-                continue;
-            }
-            const selected = liveSensor?.variants.find(candidate => candidate.id === state.variantId);
-            if (!selected) {
-                tasks.push(() => Promise.resolve({ name, status: 'inconclusive', errors: [], skipReason: 'variant-drift: selected live variant has no command; run `awm sensors init`' }));
-                continue;
-            }
-            // Variant IDs are stable selectors, not immutable command snapshots.
-            // Only the just re-resolved pack command is authorized to execute.
-            tasks.push(() => runV2Sensor(name, selected.command, (sensor.fast ?? liveSensor?.fast ?? false) ? DEFAULT_FAST_TIMEOUT : DEFAULT_SLOW_TIMEOUT, manifestDir, selected.formatter));
-        }
-        const sensors = await pooled(tasks, Math.min(MAX_CONCURRENCY, Math.max(1, tasks.length)));
-        return { sensors, overall: sensors.some(sensor => sensor.status === 'fail') ? 'fail' : sensors.some(sensor => sensor.status === 'inconclusive') ? 'not_certified' : sensors.length ? 'pass' : 'skipped' };
-    }
-    const drift = detectPackDrift(manifestDir, manifest);
-    const activeManifest = manifest; // el manifest COMITEADO es lo que se corre; `run` no lo reescribe
-    const cwd = manifestDir; // ejecutar sensores y baseline desde donde vive el manifest
 
-    // Baseline suppresses already-accepted findings so sensors fail only on NEW
-    // ones (essential on repos with a large pre-existing baseline). Absent file or
-    // --ignore-baseline → every finding counts (backward-compatible).
-    const baseline = opts.ignoreBaseline ? null : readBaseline(cwd);
-
-    // A scoped run must never define the accepted set. `buildBaseline` snapshots the
-    // findings of the run it is given, so baselining a `--changed` run would write a
-    // baseline covering only the touched files and silently drop every accepted
-    // finding elsewhere in the repo — which then reports as NEW on the next full run.
-    // The two flags only ever meet by mistake, so refuse rather than pick a meaning.
-    if (opts.changed && opts.ignoreBaseline) {
-        throw new Error(
-            'refusing to combine --changed with a baseline capture: a partial run cannot define '
-            + 'the accepted set (it would drop every accepted finding outside the diff). '
-            + 'Run `awm sensors baseline` without --changed.',
+    let parsed: ReturnType<typeof parseSensorManifest>;
+    try {
+        parsed = parseSensorManifest(
+            JSON.parse(fs.readFileSync(path.join(manifestDir, MANIFEST_FILE), 'utf8')),
+            path.join(manifestDir, MANIFEST_FILE),
         );
+    } catch {
+        return { sensors: [], overall: 'not_certified' };
     }
 
-    // Resolved once for the whole run, not per sensor: `git` is cheap but the answer
-    // must be identical across sensors, or two of them scope to different file sets.
-    const changed = opts.changed ? changedFiles(cwd, opts.base ?? 'HEAD') : null;
+    const baseline = opts.ignoreBaseline ? null : readBaseline(manifestDir);
+    const changed = opts.changed ? changedFiles(manifestDir, opts.base ?? 'HEAD') : null;
+    // Legacy commands pass changed filenames through a shell; preserve the native
+    // Windows safety fallback. Structured v2 argv never crosses that shell layer.
+    if (parsed.kind === 'legacy' && changed && !changed.error) {
+        const scopeError = changedScopeError(changed);
+        if (scopeError) changed.error = scopeError;
+    }
+    const live = parsed.kind === 'v2' ? await resolveLiveV2(manifestDir, parsed) : null;
+    const drift = parsed.kind === 'legacy' ? detectPackDrift(manifestDir, parsed.pack) : undefined;
+    const requestedScope = opts.changed ? 'changed' as const : 'full' as const;
+    const prepared: PreparedSensorExecution[] = [];
 
-    // Security (BatBadBut / CVE-2024-27980): on native Windows, `runCommand` spawns
-    // the sensor command through cmd.exe (`shell: true`), which parses `& | < > ^ %`
-    // as ITS OWN syntax before the target program ever sees argv — quoting does not
-    // reliably neutralize this layer (the primary research this fix is based on
-    // concludes escaping it is not safely possible). A changed filename carrying one
-    // of these is refused, not escaped: routed through the exact same fallback the
-    // module already has for "scope could not be resolved" (`changed.error`), so
-    // every sensor degrades to its full unscoped command rather than interpolating
-    // an unsafe path. POSIX is unaffected — single-quote quoting there is fully
-    // literal per POSIX shell grammar, no metacharacter exception exists.
-    if (changed && !changed.error && isWindowsNative() && changed.files.some(hasUnsafeWin32Chars)) {
-        changed.error = 'a changed filename contains a cmd.exe metacharacter (& | < > ^ % or newline/CR) '
-            + 'that quoting cannot reliably neutralize on native Windows — refusing to interpolate it, '
-            + 'falling back to the full unscoped command';
+    for (const [name, sensor] of Object.entries(parsed.pack.sensors)) {
+        const liveSensor = parsed.kind === 'v2' ? live?.pack.sensors[name] : undefined;
+        const fast = parsed.kind === 'v2'
+            ? sensor.fast ?? liveSensor?.fast ?? false
+            : sensor.fast ?? false;
+        if (!shouldRun(fast, opts)) continue;
+
+        const execution = parsed.kind === 'v2'
+            ? prepareV2Sensor({ name, sensor, liveSensor, liveState: live?.sensors[name], requestedScope, changed: changed ?? undefined })
+            : prepareLegacySensor({ name, config: sensor, requestedScope, changed: changed ?? undefined });
+        prepared.push(sensor.enabled === false
+            ? { ...execution, command: undefined, syntheticStatus: 'skipped', syntheticReason: 'disabled' }
+            : execution);
     }
 
-    // Sensors are independent processes over the same tree, so they run
-    // concurrently rather than one-after-another: wall clock becomes the slowest
-    // sensor instead of the sum of all of them. Tasks are built — and dispatched —
-    // in manifest order, so the reported order stays stable.
-    const tasks: Array<() => Promise<SensorResult>> = [];
-    const settled = (r: SensorResult) => () => Promise.resolve(r);
+    const results = await pooled(prepared.map(entry => async () => {
+        const result = await executePrepared(entry, manifestDir);
+        return baseline ? applyBaseline(result, baseline[entry.name]) : result;
+    }), resolveConcurrency(parsed.pack, prepared.length));
 
-    for (const [name, config] of Object.entries(activeManifest.sensors ?? {})) {
-        const isFast = config.fast ?? false;
-        if (!shouldRun(isFast, opts)) continue;
-
-        if (config.enabled === false) {
-            tasks.push(settled({ name, status: 'skipped', errors: [], skipReason: 'disabled' }));
-            continue;
-        }
-        if (!config.cmd) {
-            // Enabled but with nothing to run: broken config, not a deliberate
-            // opt-out. `enabled: false` is how a sensor is turned off.
-            tasks.push(settled({ name, status: 'inconclusive', errors: [], skipReason: 'no cmd configured' }));
-            continue;
-        }
-
-        // Scoping applies only where the pack opted in AND the scope resolved. Any
-        // other combination falls back to the full command: slower, never wrong.
-        let cmd = config.cmd;
-        let scope: 'changed' | undefined;
-        if (changed && !changed.error && config.changedCmd) {
-            if (!config.changedCmd.includes('{files}')) {
-                // Running the template as-is would cover the whole repo while the
-                // result claimed to be scoped — a mislabel, not a slow path.
-                tasks.push(settled({
-                    name,
-                    status: 'inconclusive',
-                    errors: [],
-                    skipReason: 'changedCmd has no {files} placeholder',
-                }));
-                continue;
-            }
-            const inScope = filterByExtension(changed.files, config.changedExtensions);
-            if (inScope.length === 0) {
-                tasks.push(settled({
-                    name,
-                    status: 'skipped',
-                    errors: [],
-                    skipReason: 'no changed files in scope',
-                    scope: 'changed',
-                }));
-                continue;
-            }
-            cmd = applyChangedCmd(config.changedCmd, inScope);
-            scope = 'changed';
-        }
-
-        const timeout = config.timeout ?? (isFast ? DEFAULT_FAST_TIMEOUT : DEFAULT_SLOW_TIMEOUT);
-        tasks.push(async () => {
-            const result = await runSensor(name, cmd, timeout, cwd, config.formatter);
-            const scoped = scope ? { ...result, scope } : result;
-            return baseline ? applyBaseline(scoped, baseline[name]) : scoped;
-        });
-    }
-
-    const results = await pooled(tasks, resolveConcurrency(activeManifest, tasks.length));
-
-    // `fail` outranks `inconclusive`: when something is broken AND something
-    // could not be measured, the broken thing is the actionable verdict.
-    let overall: RunOutput['overall'] = results.some(r => r.status === 'fail') ? 'fail'
-        : results.some(r => r.status === 'inconclusive') ? 'not_certified'
-        : results.length > 0 && results.every(r => r.status === 'skipped') ? 'skipped'
-        : results.length === 0 ? 'skipped'
-        : 'pass';
-
-    // Legacy commands retain operational compatibility but their unversioned,
-    // shell-backed contract can never certify a run.
-    if (parsedManifest.kind === 'legacy' && overall === 'pass') overall = 'not_certified';
-
-    // Honest floor: a benign-green 'skipped' over a tree that clearly HAS a stack
-    // (indicators present) is a false green — the gate ran nothing real. Never green.
-    if (overall === 'skipped' && drift.detection.pack !== 'generic') {
-        overall = 'not_certified';
-    }
+    let overall = reduceVerdict(results);
+    // Legacy commands retain operational compatibility but their shell-backed
+    // contract cannot certify a green run.
+    if (parsed.kind === 'legacy' && overall === 'pass') overall = 'not_certified';
+    if (overall === 'skipped' && drift && drift.detection.pack !== 'generic') overall = 'not_certified';
 
     return {
         sensors: results,
         overall,
-        ...(drift.drift ? { packDrift: drift.drift } : {}),
-        // Always emitted on a --changed run, including when the scope failed to
-        // resolve: a green that came back from an unscoped fallback and a green from a
-        // genuinely scoped run are different claims, and the caller cannot tell them
-        // apart from the sensor list alone.
+        ...(drift?.drift ? { packDrift: drift.drift } : {}),
         ...(changed ? { changedScope: { files: changed.files.length, ...(changed.error ? { error: changed.error } : {}) } } : {}),
     };
 }

--- a/cli/src/commands/sensors/status.ts
+++ b/cli/src/commands/sensors/status.ts
@@ -3,7 +3,12 @@ import path from 'path';
 import { resolveOnPath } from '../../core/paths';
 import { SensorCheck, SensorStatusResult, SensorManifest } from './types';
 import { parseSensorManifest } from './compatibility/manifest';
-import type { StructuredCommand } from './compatibility/types';
+import { parseSensorPack } from './compatibility/contract';
+import { discoverProjectEvidence } from './compatibility/discovery';
+import { resolvePackSource } from './compatibility/pack-source';
+import { resolveProjectCompatibility, resolveSensorCompatibility } from './compatibility/resolve';
+import type { CompatibilityEvidence, StructuredCommand } from './compatibility/types';
+import type { SensorManifestV2 } from './compatibility/manifest';
 
 /** First non-flag token after `npx` — the tool the command actually runs. */
 function npxTool(parts: string[]): string | undefined {
@@ -82,6 +87,54 @@ function checkStructuredCommand(command: StructuredCommand, cwd: string, assets:
         : { ok: false, detail: `${command.executable} not found in PATH` };
 }
 
+/**
+ * Re-evaluate only locally discoverable v2 compatibility evidence. Unlike the
+ * execution path, status never runs a compatibility probe: probes such as
+ * `eslint --print-config` are process execution and would turn this command
+ * into a health check. A selected variant still proves that its current tool
+ * and runtime ranges are compatible; its probe state remains unverifiable.
+ */
+function resolveStaticV2Compatibility(cwd: string, manifest: SensorManifestV2): Record<string, CompatibilityEvidence> {
+    const source = manifest.registryRoot === undefined
+        ? resolvePackSource(manifest.pack)
+        : resolvePackSource(manifest.pack, { registries: [{ name: 'manifest-provenance', remote: 'local', contentRoot: manifest.registryRoot }] });
+    const parsed = parseSensorPack(JSON.parse(source.content), source.path);
+    if (parsed.kind !== 'v2') throw new Error(`sensor pack "${manifest.pack}" does not provide a v2 compatibility contract`);
+    const evidence = discoverProjectEvidence(cwd, parsed.pack);
+    const resolutionEvidence = {
+        ...evidence,
+        ...(manifest.packSelection === 'explicit' ? { packSelection: 'explicit' as const } : {}),
+    };
+    const initial = resolveProjectCompatibility(parsed.pack, resolutionEvidence).sensors;
+    return Object.fromEntries(Object.entries(parsed.pack.sensors).map(([name, sensor]) => {
+        const variant = initial[name]?.variantId === null
+            ? null
+            : sensor.variants.find(candidate => candidate.id === initial[name]?.variantId) ?? null;
+        // These two probe kinds consume discovery output only. Keep their useful
+        // static validation in status while leaving every command-backed probe
+        // inconclusive rather than dispatching it.
+        const probeStatus = variant?.probe.kind === 'config-present'
+            ? (evidence.configFiles.length > 0 ? 'matched' : 'not-matched')
+            : variant?.probe.kind === 'package-script-present'
+                ? (evidence.scripts.length > 0 ? 'matched' : 'not-matched')
+                : undefined;
+        return [name, probeStatus === undefined
+            ? initial[name]
+            : resolveSensorCompatibility(sensor, { ...resolutionEvidence, probe: { status: probeStatus } }, { pack: parsed.pack.name, sensor: name })];
+    }));
+}
+
+function staticCompatibilityCheck(sensor: SensorManifestV2['sensors'][string], live: CompatibilityEvidence | undefined): SensorCheck | null {
+    if (!live) return { ok: false, detail: 'live compatibility unavailable' };
+    if (live.variantId !== sensor.variantId) {
+        return { ok: false, detail: `compatibility drift: initialized ${sensor.variantId}, resolved ${live.variantId ?? live.state}` };
+    }
+    if (live.state === 'incompatible' || live.state === 'missing-tool' || live.state === 'not-applicable') {
+        return { ok: false, detail: `live compatibility ${live.state}: ${live.reason}` };
+    }
+    return null;
+}
+
 export async function computeSensorStatus(cwd: string = process.cwd()): Promise<SensorStatusResult> {
     const manifestPath = path.join(cwd, '.awm', 'sensors.json');
     if (!fs.existsSync(manifestPath)) {
@@ -94,10 +147,23 @@ export async function computeSensorStatus(cwd: string = process.cwd()): Promise<
         const parsed = parseSensorManifest(raw, manifestPath);
         if (parsed.kind === 'v2') {
             const checks: Record<string, SensorCheck> = {};
+            let compatibility: Record<string, CompatibilityEvidence>;
+            try {
+                compatibility = resolveStaticV2Compatibility(cwd, parsed.pack);
+            } catch (error) {
+                const detail = error instanceof Error ? error.message : 'live compatibility unavailable';
+                for (const [name, sensor] of Object.entries(parsed.pack.sensors)) {
+                    checks[name] = sensor.enabled === false ? { ok: true, detail: 'disabled' } : { ok: false, detail };
+                }
+                return { overall: 'DEGRADED', pack: parsed.pack.pack, checks };
+            }
             for (const [name, sensor] of Object.entries(parsed.pack.sensors)) {
-                checks[name] = sensor.enabled === false
-                    ? { ok: true, detail: 'disabled' }
-                    : checkStructuredCommand(sensor.command, cwd, sensor.assets);
+                if (sensor.enabled === false) {
+                    checks[name] = { ok: true, detail: 'disabled' };
+                    continue;
+                }
+                checks[name] = staticCompatibilityCheck(sensor, compatibility[name])
+                    ?? checkStructuredCommand(sensor.command, cwd, sensor.assets);
             }
             return { overall: Object.keys(checks).length > 0 && Object.values(checks).every(check => check.ok) ? 'READY' : 'DEGRADED', pack: parsed.pack.pack, checks };
         }

--- a/cli/src/commands/sensors/status.ts
+++ b/cli/src/commands/sensors/status.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { resolveOnPath } from '../../core/paths';
 import { SensorCheck, SensorStatusResult, SensorManifest } from './types';
 import { parseSensorManifest } from './compatibility/manifest';
-import { resolveLiveCompatibility } from './compatibility/live';
+import type { StructuredCommand } from './compatibility/types';
 
 /** First non-flag token after `npx` — the tool the command actually runs. */
 function npxTool(parts: string[]): string | undefined {
@@ -54,6 +54,34 @@ function checkCmd(cmd: string, cwd: string): SensorCheck {
     return configCheck(parts, cwd) ?? { ok: true, detail: bin };
 }
 
+/** Check a v2 command's declared local prerequisite without invoking it. */
+function checkStructuredCommand(command: StructuredCommand, cwd: string, assets: string[] = []): SensorCheck {
+    const missingAsset = assets.find(asset => !fs.existsSync(path.join(cwd, asset)));
+    if (missingAsset) return { ok: false, detail: `missing config: ${missingAsset}` };
+    if (command.resolution === 'node-modules-bin') {
+        const binary = path.join(cwd, 'node_modules', '.bin', command.executable);
+        const present = fs.existsSync(binary)
+            || fs.existsSync(`${binary}.cmd`)
+            || fs.existsSync(`${binary}.exe`);
+        return present
+            ? { ok: true, detail: `${command.executable} (node_modules/.bin)` }
+            : { ok: false, detail: `${command.executable} not installed locally` };
+    }
+    if (command.resolution === 'python-environment') {
+        if (!command.pythonEnvironmentRoot) return { ok: false, detail: `${command.executable} has no selected Python environment` };
+        const root = path.join(cwd, command.pythonEnvironmentRoot);
+        const candidates = process.platform === 'win32'
+            ? [path.join(root, 'Scripts', `${command.executable}.exe`), path.join(root, 'Scripts', `${command.executable}.cmd`)]
+            : [path.join(root, 'bin', command.executable)];
+        return candidates.some(candidate => fs.existsSync(candidate))
+            ? { ok: true, detail: `${command.executable} (${command.pythonEnvironmentRoot})` }
+            : { ok: false, detail: `${command.executable} not found in ${command.pythonEnvironmentRoot}` };
+    }
+    return resolveOnPath(command.executable)
+        ? { ok: true, detail: command.executable }
+        : { ok: false, detail: `${command.executable} not found in PATH` };
+}
+
 export async function computeSensorStatus(cwd: string = process.cwd()): Promise<SensorStatusResult> {
     const manifestPath = path.join(cwd, '.awm', 'sensors.json');
     if (!fs.existsSync(manifestPath)) {
@@ -66,31 +94,12 @@ export async function computeSensorStatus(cwd: string = process.cwd()): Promise<
         const parsed = parseSensorManifest(raw, manifestPath);
         if (parsed.kind === 'v2') {
             const checks: Record<string, SensorCheck> = {};
-            let live: Awaited<ReturnType<typeof resolveLiveCompatibility>>;
-            try {
-                live = await resolveLiveCompatibility(cwd, parsed.pack.pack, parsed.pack.registryRoot, { packSelection: parsed.pack.packSelection });
-            } catch (error) {
-                const detail = `compatibility revalidation failed: ${error instanceof Error ? error.message : String(error)}`;
-                for (const [name, sensor] of Object.entries(parsed.pack.sensors)) {
-                    checks[name] = sensor.enabled === false ? { ok: true, detail: 'disabled' } : { ok: false, detail };
-                }
-                return { overall: 'DEGRADED', pack: parsed.pack.pack, checks };
-            }
             for (const [name, sensor] of Object.entries(parsed.pack.sensors)) {
-                const state = live.sensors[name];
                 checks[name] = sensor.enabled === false
                     ? { ok: true, detail: 'disabled' }
-                    : !state
-                        ? { ok: false, detail: 'variant-drift: sensor no longer exists in the live pack; run `awm sensors init`' }
-                        : state.variantId !== sensor.variantId
-                            ? { ok: false, detail: `variant-drift: manifest ${sensor.variantId}, live ${state.variantId ?? 'none'}; run \`awm sensors init\`` }
-                    : state.state === 'certified'
-                        ? { ok: true, detail: `certified (${state.variantId})` }
-                        : state.state === 'not-applicable'
-                            ? { ok: true, detail: 'not applicable' }
-                            : { ok: false, detail: `${state.state}: ${state.reason}` };
+                    : checkStructuredCommand(sensor.command, cwd, sensor.assets);
             }
-            return { overall: Object.keys(checks).length > 0 && Object.values(checks).every(check => check.ok) ? 'HEALTHY' : 'DEGRADED', pack: parsed.pack.pack, checks };
+            return { overall: Object.keys(checks).length > 0 && Object.values(checks).every(check => check.ok) ? 'READY' : 'DEGRADED', pack: parsed.pack.pack, checks };
         }
         manifest = parsed.pack;
     } catch {
@@ -115,12 +124,10 @@ export async function computeSensorStatus(cwd: string = process.cwd()): Promise<
 
     // `Object.values({}).every(...)` is vacuously true — a manifest with zero sensor
     // entries (the registry had no pack.json for this stack; see init.ts) must not read
-    // as HEALTHY just because there was nothing to fail. Same false-green `checkManifest`
+    // as READY just because there was nothing to fail. Same false-green `checkManifest`
     // guards against in preflight.
     if (Object.keys(manifest.sensors ?? {}).length === 0) {
         return { overall: 'DEGRADED', pack: manifest.pack, checks };
     }
-    // A legacy manifest may be operational (the checks are still useful), but it
-    // has no versioned/structured contract and must never present as certified.
-    return { overall: 'DEGRADED', pack: manifest.pack, checks };
+    return { overall: Object.values(checks).every(check => check.ok) ? 'READY' : 'DEGRADED', pack: manifest.pack, checks };
 }

--- a/cli/src/commands/sensors/status.ts
+++ b/cli/src/commands/sensors/status.ts
@@ -129,7 +129,7 @@ function staticCompatibilityCheck(sensor: SensorManifestV2['sensors'][string], l
     if (live.variantId !== sensor.variantId) {
         return { ok: false, detail: `compatibility drift: initialized ${sensor.variantId}, resolved ${live.variantId ?? live.state}` };
     }
-    if (live.state === 'incompatible' || live.state === 'missing-tool' || live.state === 'not-applicable') {
+    if (live.state === 'incompatible' || live.state === 'missing-tool' || live.state === 'not-applicable' || live.reason === 'probe-not-matched') {
         return { ok: false, detail: `live compatibility ${live.state}: ${live.reason}` };
     }
     return null;

--- a/cli/src/commands/sensors/types.ts
+++ b/cli/src/commands/sensors/types.ts
@@ -160,7 +160,12 @@ export type SensorCheck = {
 };
 
 export type SensorStatusResult = {
-    overall: 'HEALTHY' | 'DEGRADED' | 'NOT_CONFIGURED';
+    /**
+     * Static readiness only: manifest and declared local prerequisites are present.
+     * This command never executes a project sensor, so READY is not a health or
+     * certification claim; use `awm sensors run` for an empirical verdict.
+     */
+    overall: 'READY' | 'DEGRADED' | 'NOT_CONFIGURED';
     pack: string | null;
     checks: Record<string, SensorCheck>;
 };

--- a/cli/src/commands/sensors/types.ts
+++ b/cli/src/commands/sensors/types.ts
@@ -78,6 +78,17 @@ export type SensorError = {
     rule?: string;
 };
 
+/** Bounded execution facts attached to every prepared sensor result. */
+export type ExecutionEvidence = {
+    timeoutMs: number;
+    timeoutSource: 'project' | 'pack' | 'fallback';
+    elapsedMs: number;
+    requestedScope: 'full' | 'changed';
+    effectiveScope: 'full' | 'changed';
+    files?: number;
+    scopeReason?: string;
+};
+
 export type SensorResult = {
     name: string;
     /**
@@ -120,6 +131,8 @@ export type SensorResult = {
     newCount?: number;
     /** Findings suppressed by the baseline. Present only when a baseline is applied. */
     baselineCount?: number;
+    /** Execution configuration and observed duration, when this result was prepared. */
+    execution?: ExecutionEvidence;
 };
 
 export type RunOutput = {

--- a/cli/src/commands/sensors/types.ts
+++ b/cli/src/commands/sensors/types.ts
@@ -1,3 +1,32 @@
+/**
+ * Kept structural so the legacy runtime contract does not import the v2
+ * compatibility layer. `compatibility/types`.StructuredCommand is assignable to
+ * this shape at the preparation boundary.
+ */
+export type PreparedStructuredCommand = {
+    executable: string;
+    resolution: 'node-modules-bin' | 'python-environment' | 'path';
+    pythonEnvironmentRoot?: '.venv' | 'venv';
+    args: string[];
+    packageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun';
+    environment?: { ESLINT_USE_FLAT_CONFIG: 'true' | 'false' };
+    fileInput?: { placeholder: '{files}'; extensions: string[] };
+};
+
+export type PreparedSensorExecution = {
+    name: string;
+    command?: { kind: 'legacy'; value: string } | { kind: 'structured'; value: PreparedStructuredCommand };
+    formatter?: string;
+    timeoutMs: number;
+    timeoutSource: 'project' | 'pack' | 'fallback';
+    requestedScope: 'full' | 'changed';
+    effectiveScope: 'full' | 'changed';
+    scopeReason?: string;
+    files?: number;
+    syntheticStatus?: 'pass' | 'skipped' | 'inconclusive';
+    syntheticReason?: string;
+};
+
 export type SensorConfig = {
     cmd?: string;
     fast?: boolean;

--- a/cli/src/commands/sensors/verdict.ts
+++ b/cli/src/commands/sensors/verdict.ts
@@ -1,5 +1,10 @@
 import type { RunOutput, SensorResult } from './types';
 
+/** Map the semantic sensor verdict to the CLI process status. Only a global pass succeeds. */
+export function exitCodeForVerdict(overall: RunOutput['overall']): 0 | 1 {
+    return overall === 'pass' ? 0 : 1;
+}
+
 /** Reduce all selected sensor outcomes through one format-agnostic verdict rule. */
 export function reduceVerdict(results: SensorResult[]): RunOutput['overall'] {
     if (!Array.isArray(results)) throw new Error('sensor results must be an array');

--- a/cli/src/commands/sensors/verdict.ts
+++ b/cli/src/commands/sensors/verdict.ts
@@ -1,0 +1,9 @@
+import type { RunOutput, SensorResult } from './types';
+
+/** Reduce all selected sensor outcomes through one format-agnostic verdict rule. */
+export function reduceVerdict(results: SensorResult[]): RunOutput['overall'] {
+    if (results.some(result => result.status === 'fail')) return 'fail';
+    if (results.some(result => result.status === 'inconclusive')) return 'not_certified';
+    if (results.some(result => result.status === 'pass')) return 'pass';
+    return 'skipped';
+}

--- a/cli/src/commands/sensors/verdict.ts
+++ b/cli/src/commands/sensors/verdict.ts
@@ -2,6 +2,13 @@ import type { RunOutput, SensorResult } from './types';
 
 /** Reduce all selected sensor outcomes through one format-agnostic verdict rule. */
 export function reduceVerdict(results: SensorResult[]): RunOutput['overall'] {
+    if (!Array.isArray(results)) throw new Error('sensor results must be an array');
+    for (const result of results) {
+        if (!result || typeof result !== 'object') throw new Error('sensor result must be an object');
+        if (!['pass', 'fail', 'inconclusive', 'skipped'].includes(result.status)) {
+            throw new Error('sensor result status is invalid');
+        }
+    }
     if (results.some(result => result.status === 'fail')) return 'fail';
     if (results.some(result => result.status === 'inconclusive')) return 'not_certified';
     if (results.some(result => result.status === 'pass')) return 'pass';

--- a/cli/tests/commands/preflight/preflight.test.ts
+++ b/cli/tests/commands/preflight/preflight.test.ts
@@ -101,6 +101,22 @@ describe('preflight', () => {
         });
     });
 
+    it('does not invent a sensor or timeout when empirical verification has no executed sensors', async () => {
+        const dir = make();
+        mockRunSensors.mockResolvedValue({ overall: 'not_certified', sensors: [] });
+
+        const report = await preflight(dir, { verifySensors: true });
+        const execution = check(report, 'sensors-execution');
+
+        expect(execution).toMatchObject({
+            ok: false,
+            detail: 'sensor verdict was not_certified; no sensor established an empirical pass',
+        });
+        expect(execution.detail).not.toMatch(/timeout|elapsed|named sensor/i);
+        expect(execution.remedy).toContain('awm sensors init');
+        expect(execution.remedy).not.toContain('named sensor');
+    });
+
     it('reports not_configured when no sensor manifest exists', async () => {
         // The team-rollout case: a developer clones the repo and never runs
         // `awm sensors init`. Today nothing notices until an unattended run is already

--- a/cli/tests/commands/preflight/preflight.test.ts
+++ b/cli/tests/commands/preflight/preflight.test.ts
@@ -74,6 +74,11 @@ describe('preflight', () => {
         expect(mockRunSensors).not.toHaveBeenCalled();
     });
 
+    it('rejects an array passed as public preflight options before filesystem work', async () => {
+        await expect(preflight(process.cwd(), [] as unknown as { verifySensors?: boolean }))
+            .rejects.toThrow('preflight options must contain an optional boolean verifySensors');
+    });
+
     it('requires an empirical sensor pass when verification is requested', async () => {
         const dir = make({
             manifest: { pack: 'generic', sensors: { security: { enabled: false } } },

--- a/cli/tests/commands/preflight/preflight.test.ts
+++ b/cli/tests/commands/preflight/preflight.test.ts
@@ -5,6 +5,7 @@ import { execFileSync, execSync } from 'child_process';
 
 import { preflight } from '../../../src/commands/preflight/checks';
 import { exitCodeFor, formatReport } from '../../../src/commands/preflight';
+import { runSensors } from '../../../src/commands/sensors/run';
 
 // Only `execSync` (used by `resolveOnPath` to check for `gh`/`glab`) is mocked — `git
 // remote get-url origin` runs for real via `execFileSync` against real tmpdir git repos,
@@ -13,7 +14,12 @@ jest.mock('child_process', () => ({
     ...jest.requireActual('child_process'),
     execSync: jest.fn(),
 }));
+jest.mock('../../../src/commands/sensors/run', () => ({
+    ...jest.requireActual('../../../src/commands/sensors/run'),
+    runSensors: jest.fn(),
+}));
 const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+const mockRunSensors = runSensors as jest.MockedFunction<typeof runSensors>;
 
 /** Turn a tmpdir into a real git repo with (optionally) an `origin` remote. */
 function gitRepo(dir: string, remoteUrl?: string): void {
@@ -56,6 +62,40 @@ afterAll(() => dirs.forEach(d => fs.rmSync(d, { recursive: true, force: true }))
 const check = (r: Awaited<ReturnType<typeof preflight>>, id: string) => r.checks.find(c => c.id === id)!;
 
 describe('preflight', () => {
+    afterEach(() => mockRunSensors.mockReset());
+
+    it('keeps default preflight static and does not dispatch sensors', async () => {
+        const dir = make({
+            manifest: { pack: 'generic', sensors: { security: { enabled: false } } },
+        });
+
+        await preflight(dir);
+
+        expect(mockRunSensors).not.toHaveBeenCalled();
+    });
+
+    it('requires an empirical sensor pass when verification is requested', async () => {
+        const dir = make({
+            manifest: { pack: 'generic', sensors: { security: { enabled: false } } },
+        });
+        mockRunSensors.mockResolvedValue({
+            overall: 'not_certified',
+            sensors: [{
+                name: 'lint', status: 'inconclusive', errors: [], skipReason: 'timeout after 30000ms',
+                execution: { timeoutMs: 30000, timeoutSource: 'project', elapsedMs: 30012, requestedScope: 'full', effectiveScope: 'full' },
+            }],
+        });
+
+        const report = await preflight(dir, { verifySensors: true });
+
+        expect(mockRunSensors).toHaveBeenCalledWith({ cwd: dir, all: true });
+        expect(report.status).toBe('degraded');
+        expect(check(report, 'sensors-execution')).toMatchObject({
+            ok: false,
+            detail: expect.stringMatching(/lint.*30000ms.*elapsed.*timeout/i),
+        });
+    });
+
     it('reports not_configured when no sensor manifest exists', async () => {
         // The team-rollout case: a developer clones the repo and never runs
         // `awm sensors init`. Today nothing notices until an unattended run is already

--- a/cli/tests/commands/sensors/baseline.test.ts
+++ b/cli/tests/commands/sensors/baseline.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import os from 'os';
 import { fingerprint, partition, readBaseline, writeBaseline, buildBaseline } from '../../../src/commands/sensors/baseline';
 import { SensorError } from '../../../src/commands/sensors/types';
+import { applyBaseline } from '../../../src/commands/sensors/result';
 
 const err = (over: Partial<SensorError> = {}): SensorError => ({
     file: 'lib/a.ts', rule: 'TS2345', message: 'Argument of type X', ...over,
@@ -80,6 +81,23 @@ describe('partition', () => {
         const { newErrors, suppressed } = partition('lint', [err()], baseline);
         expect(suppressed).toBe(1);
         expect(newErrors).toHaveLength(0);
+    });
+});
+
+describe('applyBaseline', () => {
+    it('applies the same baseline to structured findings (R2)', () => {
+        const finding = { file: 'src/a.ts', line: 1, message: 'x' };
+        const accepted = [fingerprint('lint', finding)];
+
+        expect(applyBaseline({ name: 'lint', status: 'fail', errors: [finding] }, accepted))
+            .toMatchObject({ status: 'pass', baselineCount: 1, newCount: 0 });
+    });
+
+    test.each(['inconclusive', 'skipped'] as const)('baseline never changes %s to pass (R2.1)', status => {
+        const finding = { file: 'src/a.ts', line: 1, message: 'fixture finding' };
+        const accepted = [fingerprint('lint', finding)];
+
+        expect(applyBaseline({ name: 'lint', status, errors: [finding], skipReason: 'fixture' }, accepted).status).toBe(status);
     });
 });
 

--- a/cli/tests/commands/sensors/changed-windows.test.ts
+++ b/cli/tests/commands/sensors/changed-windows.test.ts
@@ -1,4 +1,4 @@
-import { applyChangedCmd } from '../../../src/commands/sensors/changed';
+import { applyChangedCmd, changedScopeError } from '../../../src/commands/sensors/changed';
 
 describe('applyChangedCmd — Windows quoting', () => {
     const originalPlatform = process.platform;
@@ -45,5 +45,9 @@ describe('applyChangedCmd — Windows quoting', () => {
         // wrapper cleanly and recovering exactly the original single trailing `\`.
         expect(applyChangedCmd('eslint {files}', ['report\\']))
             .toBe(`eslint "report\\\\"`);
+    });
+
+    it('refuses unsafe filenames for legacy shell interpolation', () => {
+        expect(changedScopeError({ files: ['src/a&b.ts'] })).toMatch(/cmd\.exe metacharacter/);
     });
 });

--- a/cli/tests/commands/sensors/compatibility/contract.test.ts
+++ b/cli/tests/commands/sensors/compatibility/contract.test.ts
@@ -1,4 +1,5 @@
 import { assertNoEqualPriorityOverlap, parseSensorPack } from '../../../../src/commands/sensors/compatibility/contract';
+import { positiveTimeout, resolveTimeout } from '../../../../src/commands/sensors/compatibility/timeout';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -41,6 +42,25 @@ function validPack() {
 }
 
 describe('sensor pack v2 contract', () => {
+    it('exports bounded timeout validation and resolution (R3.1, R3.4)', () => {
+        expect(positiveTimeout(1, 'sensor timeout')).toBe(1);
+        expect(resolveTimeout({ project: 90_000, pack: 30_000, fast: true })).toEqual({ timeoutMs: 90_000, source: 'project' });
+        expect(resolveTimeout({ pack: 30_000, fast: true })).toEqual({ timeoutMs: 30_000, source: 'pack' });
+        expect(resolveTimeout({ fast: true })).toEqual({ timeoutMs: 10_000, source: 'fallback' });
+        expect(resolveTimeout({ fast: false })).toEqual({ timeoutMs: 120_000, source: 'fallback' });
+    });
+
+    test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1000'])('rejects invalid resolved timeout %p (R3.3)', timeout => {
+        expect(() => positiveTimeout(timeout, 'sensor timeout')).toThrow(/sensor timeout.*positive safe integer/);
+        expect(() => resolveTimeout({ project: timeout as number, fast: true })).toThrow(/project timeout.*positive safe integer/);
+    });
+
+    it('rejects malformed timeout helper inputs loudly (R3.4)', () => {
+        expect(() => positiveTimeout(1000, '')).toThrow('timeout location must be a nonempty string');
+        expect(() => resolveTimeout(null as unknown as { fast: boolean })).toThrow('timeout resolution input is invalid');
+        expect(() => resolveTimeout({ fast: 'true' } as unknown as { fast: boolean })).toThrow('timeout resolution input is invalid');
+    });
+
     it('derives Semgrep compatibility from a contained shared policy reference', () => {
         const sensorPacks = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-semgrep-policy-'));
         const packDir = path.join(sensorPacks, 'python');
@@ -77,6 +97,44 @@ describe('sensor pack v2 contract', () => {
 
     it('parses a valid versioned pack', () => {
         expect(parseSensorPack(validPack(), 'pack.json')).toMatchObject({ kind: 'v2', pack: validPack() });
+    });
+
+    it('accepts one standalone files placeholder in changedCommand (R4)', () => {
+        const pack = validPack();
+        (pack.sensors.lint.variants[0] as Record<string, unknown>).changedCommand = {
+            executable: 'eslint', resolution: 'node-modules-bin',
+            args: ['--format', 'json', '{files}'],
+            fileInput: { placeholder: '{files}', extensions: ['.js', '.ts'] },
+        };
+        expect(parseSensorPack(pack, '/registry/sensor-packs/js-ts/pack.json')).toMatchObject({
+            kind: 'v2', pack: { sensors: { lint: { variants: [{ changedCommand: { args: ['--format', 'json', '{files}'] } }] } } },
+        });
+    });
+
+    test.each([
+        { args: ['{files}', '{files}'], fileInput: { placeholder: '{files}', extensions: ['.ts'] } },
+        { args: ['prefix-{files}'], fileInput: { placeholder: '{files}', extensions: ['.ts'] } },
+        { args: ['{files}'], fileInput: { placeholder: '{files}', extensions: [] } },
+    ])('rejects unsafe changedCommand %# (R4)', changedCommand => {
+        const pack = validPack();
+        (pack.sensors.lint.variants[0] as Record<string, unknown>).changedCommand = {
+            executable: 'eslint', resolution: 'node-modules-bin', ...changedCommand,
+        };
+        expect(() => parseSensorPack(pack, '/registry/sensor-packs/js-ts/pack.json')).toThrow(/changedCommand|fileInput|\{files\}/);
+    });
+
+    test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1000'])('rejects pack sensor timeout %p (R3.3)', timeout => {
+        const pack = validPack();
+        (pack.sensors.lint as Record<string, unknown>).timeout = timeout;
+        expect(() => parseSensorPack(pack, '/registry/sensor-packs/js-ts/pack.json')).toThrow(/timeout.*positive safe integer/);
+    });
+
+    it('accepts an optional positive pack sensor timeout (R3.1)', () => {
+        const pack = validPack();
+        (pack.sensors.lint as Record<string, unknown>).timeout = 30_000;
+        expect(parseSensorPack(pack, '/registry/sensor-packs/js-ts/pack.json')).toMatchObject({
+            kind: 'v2', pack: { sensors: { lint: { timeout: 30_000 } } },
+        });
     });
 
     it('accepts an opt-in hardening asset while variants may require no assets', () => {

--- a/cli/tests/commands/sensors/compatibility/manifest.test.ts
+++ b/cli/tests/commands/sensors/compatibility/manifest.test.ts
@@ -2,6 +2,20 @@ import { legacyCompatibility, parseSensorManifest, serializeManifestV2 } from '.
 import fs from 'fs';
 import path from 'path';
 
+function validV2Manifest() {
+    return {
+        schemaVersion: 2,
+        pack: 'js-ts',
+        sensors: {
+            lint: {
+                enabled: true, variantId: 'eslint-9',
+                command: { executable: 'eslint', resolution: 'node-modules-bin', args: ['.', '--format', 'json'] },
+                initializedCompatibility: { state: 'certified', reason: 'range-and-probe', variantId: 'eslint-9', toolVersion: '9.0.0', runtimeVersion: '24.0.0', certifiedRange: '>=9 <10', evidence: [] },
+            },
+        },
+    };
+}
+
 describe('sensor manifest contract', () => {
     it('keeps compatibility contracts on an acyclic import boundary', () => {
         const source = (relative: string) => fs.readFileSync(path.join(__dirname, '../../../../src/commands/sensors', relative), 'utf8');
@@ -19,19 +33,24 @@ describe('sensor manifest contract', () => {
     });
 
     it('accepts a v2 selected variant and structured command', () => {
-        const manifest = {
-            schemaVersion: 2,
-            pack: 'js-ts',
-            sensors: {
-                lint: {
-                    enabled: true, variantId: 'eslint-9',
-                    command: { executable: 'eslint', resolution: 'node-modules-bin', args: ['.', '--format', 'json'] },
-                    initializedCompatibility: { state: 'certified', reason: 'range-and-probe', variantId: 'eslint-9', toolVersion: '9.0.0', runtimeVersion: '24.0.0', certifiedRange: '>=9 <10', evidence: [] },
-                },
-            },
-        };
+        const manifest = validV2Manifest();
         expect(parseSensorManifest(manifest, 'sensors.json')).toMatchObject({ kind: 'v2', pack: manifest });
         expect(JSON.parse(serializeManifestV2(manifest))).toEqual(manifest);
+    });
+
+    it('accepts and serializes a positive v2 project timeout (R3)', () => {
+        const manifest = validV2Manifest();
+        (manifest.sensors.lint as Record<string, unknown>).timeout = 45_000;
+        expect(parseSensorManifest(manifest, '/project/.awm/sensors.json')).toMatchObject({
+            kind: 'v2', pack: { sensors: { lint: { timeout: 45_000 } } },
+        });
+        expect(JSON.parse(serializeManifestV2(manifest))).toEqual(manifest);
+    });
+
+    test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1000'])('rejects v2 timeout %p before execution (R3.3)', timeout => {
+        const manifest = validV2Manifest();
+        (manifest.sensors.lint as Record<string, unknown>).timeout = timeout;
+        expect(() => parseSensorManifest(manifest, '/project/.awm/sensors.json')).toThrow(/timeout.*positive safe integer/);
     });
 
     it('persists only an explicit v2 pack selection as applicability provenance', () => {

--- a/cli/tests/commands/sensors/compatibility/probe.test.ts
+++ b/cli/tests/commands/sensors/compatibility/probe.test.ts
@@ -1,6 +1,17 @@
 import { runCompatibilityProbe } from '../../../../src/commands/sensors/compatibility/probe';
+import type { ExecResult } from '../../../../src/commands/sensors/exec';
 
-const fakeExecutor: jest.Mock<any, any> = jest.fn(async () => ({ code: 0, signal: null, timedOut: false, overflowed: false, stdout: 'SECRET_VALUE\nmatched', stderr: '' }));
+const execResult = (overrides: Partial<ExecResult> = {}): ExecResult => ({
+    code: 0,
+    signal: null,
+    timedOut: false,
+    overflowed: false,
+    elapsedMs: 0,
+    stdout: 'SECRET_VALUE\nmatched',
+    stderr: '',
+    ...overrides,
+});
+const fakeExecutor = jest.fn<Promise<ExecResult>, [unknown, unknown]>(async () => execResult());
 const evidence = { cwd: process.cwd(), configFiles: ['eslint.config.js'], scripts: ['lint'] } as any;
 
 describe('runCompatibilityProbe', () => {
@@ -14,9 +25,9 @@ describe('runCompatibilityProbe', () => {
         });
 
     it('never treats a timeout or overflow as a match', async () => {
-        fakeExecutor.mockResolvedValueOnce({ code: null, signal: 'SIGKILL', timedOut: true, overflowed: false, stdout: '', stderr: '' });
+        fakeExecutor.mockResolvedValueOnce(execResult({ code: null, signal: 'SIGKILL', timedOut: true, stdout: '' }));
         await expect(runCompatibilityProbe({ kind: 'version' }, evidence, fakeExecutor)).resolves.toMatchObject({ status: 'unverifiable' });
-        fakeExecutor.mockResolvedValueOnce({ code: 0, signal: null, timedOut: false, overflowed: true, stdout: 'ok', stderr: '' });
+        fakeExecutor.mockResolvedValueOnce(execResult({ overflowed: true, stdout: 'ok' }));
         await expect(runCompatibilityProbe({ kind: 'version' }, evidence, fakeExecutor)).resolves.toMatchObject({ status: 'unverifiable' });
     });
 

--- a/cli/tests/commands/sensors/exec-fixtures.ts
+++ b/cli/tests/commands/sensors/exec-fixtures.ts
@@ -6,7 +6,7 @@ import type { ExecResult } from '../../../src/commands/sensors/exec';
  * never throws, so a mocked run is a value, not an exception.
  */
 
-const base = { stdout: '', stderr: '', code: null as number | null, signal: null as NodeJS.Signals | null, timedOut: false, overflowed: false };
+const base = { stdout: '', stderr: '', code: null as number | null, signal: null as NodeJS.Signals | null, timedOut: false, overflowed: false, elapsedMs: 0 };
 
 /** Clean run: exit 0. */
 export const ok = (stdout = ''): ExecResult => ({ ...base, stdout, code: 0 });

--- a/cli/tests/commands/sensors/exec.test.ts
+++ b/cli/tests/commands/sensors/exec.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { runCommand, runStructuredCommand } from '../../../src/commands/sensors/exec';
 import { executePrepared } from '../../../src/commands/sensors/result';
+import { expandFileInput } from '../../../src/commands/sensors/prepare';
 
 const sensor = (overrides: Record<string, unknown> = {}) => ({
     name: 'lint',
@@ -156,6 +157,26 @@ describe('runCommand — spawn failure', () => {
 });
 
 describe('runStructuredCommand — public boundary validation', () => {
+    it('dispatches argv materialized from a validated changed-command template without requiring its placeholder again', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-exec-changed-argv-'));
+        const received = path.join(dir, 'received.json');
+        try {
+            const command = expandFileInput({
+                executable: 'node',
+                resolution: 'path',
+                args: ['-e', "require('fs').writeFileSync(process.argv[1], JSON.stringify(process.argv.slice(2)))", received, '{files}'],
+                fileInput: { placeholder: '{files}', extensions: ['.ts'] },
+            }, ['src/a.ts', 'src/with space.ts']);
+
+            const result = await runStructuredCommand(command, { timeout: 5_000, cwd: dir });
+
+            expect(result.code).toBe(0);
+            expect(JSON.parse(fs.readFileSync(received, 'utf8'))).toEqual(['src/a.ts', 'src/with space.ts']);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     it.each(['sh', 'cmd.exe', '/usr/bin/node', 'nested/tool', 'nested\\tool'])('rejects unsafe executable %j before resolution', executable => {
         expect(() => runStructuredCommand({ executable, resolution: 'path', args: ['--version'] }, { timeout: 5000, cwd: process.cwd() }))
             .toThrow(/safe executable name|shell/i);

--- a/cli/tests/commands/sensors/exec.test.ts
+++ b/cli/tests/commands/sensors/exec.test.ts
@@ -2,6 +2,18 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { runCommand, runStructuredCommand } from '../../../src/commands/sensors/exec';
+import { executePrepared } from '../../../src/commands/sensors/result';
+
+const sensor = (overrides: Record<string, unknown> = {}) => ({
+    name: 'lint',
+    command: { kind: 'legacy' as const, value: 'node -e "setTimeout(() => {}, 1000)"' },
+    formatter: 'generic',
+    timeoutMs: 5_000,
+    timeoutSource: 'fallback' as const,
+    requestedScope: 'full' as const,
+    effectiveScope: 'full' as const,
+    ...overrides,
+});
 
 const onPosix = process.platform !== 'win32' ? describe : describe.skip;
 const itPosix = process.platform !== 'win32' ? it : it.skip;
@@ -17,6 +29,14 @@ async function until(fn: () => boolean, budgetMs = 4000): Promise<boolean> {
 }
 
 describe('runCommand — exit codes and output', () => {
+    it('records bounded execution evidence on timeout (R3.2,R3.4,R7.1)', async () => {
+        const result = await executePrepared(sensor({ timeoutMs: 25, timeoutSource: 'project' }));
+
+        expect(result.status).toBe('inconclusive');
+        expect(result.execution).toMatchObject({ timeoutMs: 25, timeoutSource: 'project', effectiveScope: 'full' });
+        expect(result.execution!.elapsedMs).toBeGreaterThanOrEqual(0);
+    });
+
     it('passes structured metacharacters literally without a shell', async () => {
         const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-exec-argv-'));
         const marker = path.join(dir, 'must-not-exist');

--- a/cli/tests/commands/sensors/index.test.ts
+++ b/cli/tests/commands/sensors/index.test.ts
@@ -13,22 +13,67 @@ import { Command } from 'commander';
 import { log } from '@clack/prompts';
 import { runCoverage } from '../../../src/commands/sensors/coverage';
 import { renderCoverageHuman, renderCoverageJson } from '../../../src/commands/sensors/coverage/render';
-import { exitCodeFor, parsePositiveSafeInteger, registerSensorsCommand, RunOutputLike } from '../../../src/commands/sensors/index';
+import { parsePositiveSafeInteger, registerSensorsCommand } from '../../../src/commands/sensors/index';
+import { exitCodeForVerdict } from '../../../src/commands/sensors/verdict';
 
-describe('exitCodeFor — sensor run verdict → exit code', () => {
-    const base = (overall: RunOutputLike['overall']): RunOutputLike => ({ sensors: [], overall });
-    it('pass → 0', () => expect(exitCodeFor(base('pass'))).toBe(0));
-    it('skipped → 0', () => expect(exitCodeFor(base('skipped'))).toBe(0));
-    it('not_certified → 0 (signal is in overall, not exit code)', () =>
-        expect(exitCodeFor(base('not_certified'))).toBe(0));
-    it('fail → 1', () => expect(exitCodeFor(base('fail'))).toBe(1));
+const processExit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+const stdoutWrite = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+describe('exitCodeForVerdict — sensor run verdict → exit code', () => {
+    it.each([
+        ['pass', 0],
+        ['fail', 1],
+        ['skipped', 1],
+        ['not_certified', 1],
+    ] as const)('%s → %i', (overall, code) => {
+        expect(exitCodeForVerdict(overall)).toBe(code);
+    });
+});
+
+describe('sensors run Commander wiring', () => {
+    const originalExitCode = process.exitCode;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        process.exitCode = undefined;
+    });
+
+    afterAll(() => {
+        process.exitCode = originalExitCode;
+    });
+
+    const programWithSensors = (): Command => {
+        const program = new Command();
+        program.exitOverride();
+        registerSensorsCommand(program);
+        return program;
+    };
+
+    it.each([
+        ['pass', 0],
+        ['fail', 1],
+        ['skipped', 1],
+        ['not_certified', 1],
+    ] as const)('writes full %s JSON before assigning exit code %i without process.exit', async (overall, code) => {
+        (require('../../../src/commands/sensors/run').runSensors as jest.Mock).mockResolvedValue({ sensors: [], overall });
+        const calls: string[] = [];
+        stdoutWrite.mockImplementation(() => {
+            calls.push(`stdout:${process.exitCode ?? 0}`);
+            return true;
+        });
+
+        await programWithSensors().parseAsync(['node', 'awm', 'sensors', 'run']);
+
+        expect(JSON.parse(String(stdoutWrite.mock.calls[0][0]))).toEqual({ sensors: [], overall });
+        expect(calls).toEqual(['stdout:0']);
+        expect(process.exitCode).toBe(code);
+        expect(processExit).not.toHaveBeenCalled();
+    });
 });
 
 describe('sensors coverage Commander wiring', () => {
     const report = { schemaVersion: 1 as const, pack: 'js-ts', registry: 'baseline', overall: 'gaps' as const,
         static: { status: 'gaps' as const, reason: null, classes: [] } };
-    const stdoutWrite = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    const processExit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/cli/tests/commands/sensors/init.test.ts
+++ b/cli/tests/commands/sensors/init.test.ts
@@ -339,7 +339,7 @@ describe('initSensors', () => {
             const written = JSON.parse(fs.readFileSync(path.join(tmpDir, '.awm', 'sensors.json'), 'utf8'));
             expect(explicit.manifest).toMatchObject({ schemaVersion: 2, pack: 'generic', packSelection: 'explicit', sensors: { security: { variantId: 'eslint-10' } } });
             expect(written.packSelection).toBe('explicit');
-            await expect(computeSensorStatus(tmpDir)).resolves.toMatchObject({ overall: 'HEALTHY', checks: { security: { ok: true } } });
+            await expect(computeSensorStatus(tmpDir)).resolves.toMatchObject({ overall: 'DEGRADED', checks: { security: { ok: false } } });
         } finally {
             fs.rmSync(v2Registry, { recursive: true, force: true });
         }

--- a/cli/tests/commands/sensors/init.test.ts
+++ b/cli/tests/commands/sensors/init.test.ts
@@ -402,6 +402,37 @@ describe('initSensors', () => {
         }
     });
 
+    it('preserves only the project timeout override, never prior executable authority (R3, R10)', async () => {
+        const v2Registry = makeV2Registry();
+        try {
+            fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { eslint: '^10.0.0' } }));
+            fs.mkdirSync(path.join(tmpDir, 'node_modules', 'eslint'), { recursive: true });
+            fs.writeFileSync(path.join(tmpDir, 'node_modules', 'eslint', 'package.json'), JSON.stringify({ version: '10.0.0' }));
+            await initSensors({ cwd: tmpDir, registryRoot: v2Registry });
+            const manifestPath = path.join(tmpDir, '.awm', 'sensors.json');
+            const selected = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+            selected.sensors.lint.timeout = 45_000;
+            selected.sensors.lint.command = {
+                executable: 'otherlint', resolution: 'path', args: ['--custom'],
+                environment: { ESLINT_USE_FLAT_CONFIG: 'false' },
+            };
+            selected.sensors.lint.assets = ['prior-owned.config'];
+            fs.writeFileSync(manifestPath, JSON.stringify(selected));
+
+            await initSensors({ cwd: tmpDir, registryRoot: v2Registry });
+
+            const written = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+            expect(written.sensors.lint).toMatchObject({
+                timeout: 45_000,
+                command: { executable: 'eslint', resolution: 'node-modules-bin', args: ['.'] },
+                assets: ['eslint.config.awm.mjs'],
+            });
+            expect(written.sensors.lint.command.environment).toBeUndefined();
+        } finally {
+            fs.rmSync(v2Registry, { recursive: true, force: true });
+        }
+    });
+
     it('rejects a symlinked v2 pack source instead of reading it through init', async () => {
         const v2Registry = makeV2Registry();
         try {

--- a/cli/tests/commands/sensors/prepare.test.ts
+++ b/cli/tests/commands/sensors/prepare.test.ts
@@ -1,0 +1,102 @@
+import { prepareLegacySensor, prepareV2Sensor, validateRunOptions, type PrepareV2SensorInput } from '../../../src/commands/sensors/prepare';
+import type { SensorVariant } from '../../../src/commands/sensors/compatibility/types';
+
+const fullCommand = { executable: 'manifest-eslint', resolution: 'path' as const, args: ['.'] };
+const changedCommand = {
+    executable: 'live-eslint',
+    resolution: 'path' as const,
+    args: ['--format', 'json', '{files}'],
+    fileInput: { placeholder: '{files}' as const, extensions: ['.ts'] },
+};
+
+function v2Input(overrides: Record<string, unknown> = {}): PrepareV2SensorInput {
+    const liveVariant: SensorVariant = {
+        id: 'eslint-live', priority: 1, certifiedRange: '>=1.0.0', requirements: { tool: 'eslint', toolRange: '>=1.0.0', runtime: 'node', runtimeRange: '>=1.0.0' }, assets: [],
+        probe: { kind: 'version' }, command: { executable: 'live-eslint', resolution: 'path', args: ['.'] }, changedCommand, formatter: 'eslint-llm',
+    };
+    return {
+        name: 'lint',
+        sensor: {
+            enabled: true, fast: false, variantId: 'eslint-live', command: fullCommand,
+            initializedCompatibility: { state: 'certified' as const, reason: 'test', variantId: 'eslint-live', toolVersion: '1.0.0', runtimeVersion: '1.0.0', certifiedRange: '>=1.0.0', evidence: [] },
+        },
+        liveSensor: { applicability: {}, fast: false, timeout: 30_000, variants: [liveVariant] },
+        liveState: { state: 'certified' as const, reason: 'test', variantId: 'eslint-live', toolVersion: '1.0.0', runtimeVersion: '1.0.0', certifiedRange: '>=1.0.0', evidence: [] },
+        changed: { files: ['src/a.ts'] },
+        requestedScope: 'changed' as const,
+        projectTimeout: 90_000,
+        ...overrides,
+    };
+}
+
+describe('prepareV2Sensor', () => {
+    test('v2 uses the live command and project > pack > fallback timeout (R1.1, R3.1)', () => {
+        const prepared = prepareV2Sensor(v2Input());
+
+        expect(prepared.command).toEqual({ kind: 'structured', value: { ...changedCommand, args: ['--format', 'json', 'src/a.ts'] } });
+        expect(prepared.timeoutMs).toBe(90_000);
+        expect(prepared.timeoutSource).toBe('project');
+        expect(prepareV2Sensor(v2Input({ projectTimeout: undefined })).timeoutSource).toBe('pack');
+        const fallback = v2Input();
+        fallback.liveSensor!.timeout = undefined;
+        fallback.liveSensor!.fast = true;
+        fallback.sensor.fast = undefined;
+        expect(prepareV2Sensor({ ...fallback, projectTimeout: undefined })).toMatchObject({ timeoutMs: 10_000, timeoutSource: 'fallback' });
+    });
+
+    test('expands changed paths as literal argv entries (R4.1, R10.2)', () => {
+        const prepared = prepareV2Sensor(v2Input({ changed: { files: ['src/a b.ts', 'src/$x.ts'] } }));
+
+        expect(prepared.command).toEqual({ kind: 'structured', value: { ...changedCommand, args: ['--format', 'json', 'src/a b.ts', 'src/$x.ts'] } });
+        expect(prepared.effectiveScope).toBe('changed');
+    });
+
+    test('falls back full with an explicit reason without changedCommand (R4.2)', () => {
+        const input = v2Input();
+        input.liveSensor!.variants[0].changedCommand = undefined;
+
+        const prepared = prepareV2Sensor(input);
+
+        expect(prepared.command).toEqual({ kind: 'structured', value: input.liveSensor!.variants[0].command });
+        expect(prepared.effectiveScope).toBe('full');
+        expect(prepared.scopeReason).toMatch(/does not support changed scope/);
+    });
+
+    test('uses the full command with an explicit reason when the diff cannot resolve', () => {
+        const prepared = prepareV2Sensor(v2Input({ changed: { files: [], error: 'git failed' } }));
+
+        expect(prepared.effectiveScope).toBe('full');
+        expect(prepared.scopeReason).toMatch(/could not be resolved: git failed/);
+    });
+
+    test('returns zero-file pass plan without a process (R4.4)', () => {
+        const prepared = prepareV2Sensor(v2Input({ changed: { files: ['README.md'] } }));
+
+        expect(prepared).toMatchObject({ effectiveScope: 'changed', files: 0, syntheticStatus: 'pass' });
+        expect(prepared.command).toBeUndefined();
+    });
+});
+
+describe('prepareLegacySensor', () => {
+    const originalPlatform = process.platform;
+
+    afterEach(() => Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true }));
+
+    test('falls back to the full command for an unsafe Windows filename', () => {
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+        const prepared = prepareLegacySensor({
+            name: 'lint', config: { cmd: 'eslint .', changedCmd: 'eslint {files}' }, requestedScope: 'changed', changed: { files: ['src/a&b.ts'] },
+        });
+
+        expect(prepared).toMatchObject({ command: { kind: 'legacy', value: 'eslint .' }, effectiveScope: 'full' });
+        expect(prepared.scopeReason).toMatch(/cmd\.exe metacharacter/);
+    });
+});
+
+describe('validateRunOptions', () => {
+    test('rejects changed baseline capture before any scope preparation (R4.6)', () => {
+        expect(() => validateRunOptions({ changed: true, ignoreBaseline: true }))
+            .toThrow(/refusing to combine --changed with a baseline capture/);
+    });
+});

--- a/cli/tests/commands/sensors/prepare.test.ts
+++ b/cli/tests/commands/sensors/prepare.test.ts
@@ -75,6 +75,11 @@ describe('prepareV2Sensor', () => {
         expect(prepared).toMatchObject({ effectiveScope: 'changed', files: 0, syntheticStatus: 'pass' });
         expect(prepared.command).toBeUndefined();
     });
+
+    test('rejects an invalid requested scope before preparing a command', () => {
+        expect(() => prepareV2Sensor({ ...v2Input(), requestedScope: 'sideways' as unknown as 'changed' }))
+            .toThrow('requested scope must be "full" or "changed"');
+    });
 });
 
 describe('prepareLegacySensor', () => {

--- a/cli/tests/commands/sensors/prepare.test.ts
+++ b/cli/tests/commands/sensors/prepare.test.ts
@@ -33,7 +33,7 @@ describe('prepareV2Sensor', () => {
     test('v2 uses the live command and project > pack > fallback timeout (R1.1, R3.1)', () => {
         const prepared = prepareV2Sensor(v2Input());
 
-        expect(prepared.command).toEqual({ kind: 'structured', value: { ...changedCommand, args: ['--format', 'json', 'src/a.ts'] } });
+        expect(prepared.command).toEqual({ kind: 'structured', value: { executable: 'live-eslint', resolution: 'path', args: ['--format', 'json', 'src/a.ts'] } });
         expect(prepared.timeoutMs).toBe(90_000);
         expect(prepared.timeoutSource).toBe('project');
         expect(prepareV2Sensor(v2Input({ projectTimeout: undefined })).timeoutSource).toBe('pack');
@@ -47,7 +47,7 @@ describe('prepareV2Sensor', () => {
     test('expands changed paths as literal argv entries (R4.1, R10.2)', () => {
         const prepared = prepareV2Sensor(v2Input({ changed: { files: ['src/a b.ts', 'src/$x.ts'] } }));
 
-        expect(prepared.command).toEqual({ kind: 'structured', value: { ...changedCommand, args: ['--format', 'json', 'src/a b.ts', 'src/$x.ts'] } });
+        expect(prepared.command).toEqual({ kind: 'structured', value: { executable: 'live-eslint', resolution: 'path', args: ['--format', 'json', 'src/a b.ts', 'src/$x.ts'] } });
         expect(prepared.effectiveScope).toBe('changed');
     });
 

--- a/cli/tests/commands/sensors/router.test.ts
+++ b/cli/tests/commands/sensors/router.test.ts
@@ -2,7 +2,7 @@ jest.mock('@clack/prompts', () => ({ log: { success: jest.fn(), info: jest.fn() 
 jest.mock('picocolors', () => ({ green: (s: string) => s, yellow: (s: string) => s, red: (s: string) => s }));
 jest.mock('../../../src/commands/sensors/run', () => ({ runSensors: jest.fn().mockReturnValue({ sensors: [], overall: 'pass' }) }));
 jest.mock('../../../src/commands/sensors/init', () => ({ initSensors: jest.fn().mockReturnValue({ detection: { pack: 'js-ts', indicators: [] }, manifest: { sensors: {} }, configured: [] }) }));
-jest.mock('../../../src/commands/sensors/status', () => ({ computeSensorStatus: jest.fn().mockReturnValue({ overall: 'HEALTHY', pack: 'js-ts', checks: {} }) }));
+jest.mock('../../../src/commands/sensors/status', () => ({ computeSensorStatus: jest.fn().mockReturnValue({ overall: 'READY', pack: 'js-ts', checks: {} }) }));
 jest.mock('../../../src/commands/sensors/install', () => ({ installSensorHook: jest.fn().mockReturnValue({ status: 'installed' }) }));
 
 import { Command } from 'commander';
@@ -20,5 +20,19 @@ describe('registerSensorsCommand', () => {
         expect(subNames).toContain('status');
         expect(subNames).toContain('install');
         expect(subNames).toContain('coverage');
+    });
+
+    it('renders READY without claiming sensor execution, HEALTHY, or project certification', async () => {
+        const program = new Command();
+        const output = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+        try {
+            registerSensorsCommand(program);
+            await program.parseAsync(['node', 'awm', 'sensors', 'status']);
+            const rendered = output.mock.calls.flat().join('\n');
+            expect(rendered).toContain('READY');
+            expect(rendered).not.toMatch(/HEALTHY|certif/i);
+        } finally {
+            output.mockRestore();
+        }
     });
 });

--- a/cli/tests/commands/sensors/run-changed.test.ts
+++ b/cli/tests/commands/sensors/run-changed.test.ts
@@ -98,14 +98,14 @@ describe('runSensors --changed', () => {
         expect(out.changedScope).toEqual({ files: 0, error: 'not a git repository' });
     });
 
-    it('skips an opted-in sensor when nothing changed, without touching the others', async () => {
+    it('records a clean synthetic pass when an opted-in sensor has no changed files, without touching the others', async () => {
         dir = project({ lint: LINT, typecheck: TYPECHECK });
         mockChangedFiles.mockReturnValue({ files: [] });
 
         const out = await load().runSensors({ cwd: dir, changed: true });
 
         const lint = out.sensors.find((s: any) => s.name === 'lint');
-        expect(lint.status).toBe('skipped');
+        expect(lint.status).toBe('pass');
         expect(lint.skipReason).toBe('no changed files in scope');
         expect(cmds()).toEqual(['tsc --noEmit']);
     });
@@ -121,7 +121,7 @@ describe('runSensors --changed', () => {
         expect(cmds()).toEqual([`eslint --format json 'src/a.ts'`]);
     });
 
-    it('skips the sensor when the filter empties the scope, rather than running repo-wide', async () => {
+    it('records a clean synthetic pass when the filter empties the scope, rather than running repo-wide', async () => {
         // A docs-only commit means the lint sensor has nothing to say. Falling back to
         // the full command here would reintroduce exactly the cost --changed removes.
         dir = project({ lint: { ...LINT, changedExtensions: ['.ts'] }, typecheck: TYPECHECK });
@@ -129,7 +129,7 @@ describe('runSensors --changed', () => {
 
         const out = await load().runSensors({ cwd: dir, changed: true });
 
-        expect(out.sensors.find((s: any) => s.name === 'lint').status).toBe('skipped');
+        expect(out.sensors.find((s: any) => s.name === 'lint').status).toBe('pass');
         expect(cmds()).toEqual(['tsc --noEmit']);
     });
 

--- a/cli/tests/commands/sensors/run.test.ts
+++ b/cli/tests/commands/sensors/run.test.ts
@@ -236,6 +236,10 @@ describe('reduceVerdict', () => {
             { name: 'typecheck', status: 'fail', errors: [{ message: 'broken' }] },
         ])).toBe('fail');
     });
+
+    it('rejects malformed result statuses instead of treating them as skipped', () => {
+        expect(() => reduceVerdict([{ name: 'lint', status: 'bogus', errors: [] } as any])).toThrow('sensor result status is invalid');
+    });
 });
 
 describe('runSensors v2 lifecycle contract', () => {

--- a/cli/tests/commands/sensors/run.test.ts
+++ b/cli/tests/commands/sensors/run.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { runSensors } from '../../../src/commands/sensors/run';
+import { reduceVerdict } from '../../../src/commands/sensors/verdict';
 
 function mkTmp(): string {
     return fs.mkdtempSync(path.join(os.tmpdir(), 'awm-sensors-'));
@@ -218,6 +219,15 @@ describe('runSensors', () => {
         mockRunCommand.mockResolvedValueOnce(tcError()).mockResolvedValueOnce(ok());
         const result = await runSensors({ fast: true, cwd: tmpDir, ignoreBaseline: true });
         expect(result.overall).toBe('fail');
+    });
+});
+
+describe('reduceVerdict', () => {
+    it('lets a failing full sensor outrank an empty changed-scope synthetic pass', () => {
+        expect(reduceVerdict([
+            { name: 'lint', status: 'pass', errors: [], scope: 'changed' },
+            { name: 'typecheck', status: 'fail', errors: [{ message: 'broken' }] },
+        ])).toBe('fail');
     });
 });
 

--- a/cli/tests/commands/sensors/run.test.ts
+++ b/cli/tests/commands/sensors/run.test.ts
@@ -65,6 +65,13 @@ describe('runSensors', () => {
         expect(result.overall).toBe('not_certified');
     });
 
+    it('runs both fast and slow sensors when --fast and --slow are combined', async () => {
+        mockRunCommand.mockResolvedValue(ok());
+        const { runSensors } = load();
+        const result = await runSensors({ fast: true, slow: true, cwd: tmpDir });
+        expect(result.sensors.map((sensor: any) => sensor.name)).toEqual(['typecheck', 'lint', 'security', 'mutation']);
+    });
+
     it('returns fail when a fast sensor has errors', async () => {
         mockRunCommand
             .mockResolvedValueOnce(exited(1, 'src/a.ts(1,1): error TS0001: Bad type.'))

--- a/cli/tests/commands/sensors/run.test.ts
+++ b/cli/tests/commands/sensors/run.test.ts
@@ -56,6 +56,19 @@ describe('runSensors', () => {
         } finally { fs.rmSync(emptyDir, { recursive: true }); }
     });
 
+    it.each([
+        ['fast', { fast: 'yes' }, 'run option fast must be a boolean'],
+        ['slow', { slow: 1 }, 'run option slow must be a boolean'],
+        ['all', { all: null }, 'run option all must be a boolean'],
+        ['cwd', { cwd: '   ' }, 'run option cwd must be a nonempty string'],
+    ])('rejects invalid public %s options before selecting or dispatching sensors', async (_name, options, message) => {
+        const { runSensors } = load();
+
+        await expect(runSensors(options)).rejects.toThrow(message);
+        expect(mockRunCommand).not.toHaveBeenCalled();
+        expect(mockRunStructuredCommand).not.toHaveBeenCalled();
+    });
+
     it('runs only fast sensors with --fast flag', async () => {
         mockRunCommand.mockResolvedValue(ok());
         const { runSensors } = load();

--- a/cli/tests/commands/sensors/status-windows.test.ts
+++ b/cli/tests/commands/sensors/status-windows.test.ts
@@ -50,7 +50,7 @@ describe('computeSensorStatus — Windows PATH resolution', () => {
         fs.writeFileSync(path.join(pathDir, 'semgrep.cmd'), '@echo off\r\n');
 
         const result = await computeSensorStatus(tmpDir);
-        expect(result.overall).toBe('DEGRADED');
+        expect(result.overall).toBe('READY');
         expect(result.checks.security.ok).toBe(true);
     });
 

--- a/cli/tests/commands/sensors/status.test.ts
+++ b/cli/tests/commands/sensors/status.test.ts
@@ -2,8 +2,13 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { computeSensorStatus } from '../../../src/commands/sensors/status';
-import { preflight } from '../../../src/commands/preflight/checks';
-import { runSensors } from '../../../src/commands/sensors/run';
+
+jest.mock('../../../src/commands/sensors/exec', () => ({
+    runCommand: jest.fn(),
+    runStructuredCommand: jest.fn(),
+}));
+
+const { runCommand, runStructuredCommand } = require('../../../src/commands/sensors/exec');
 
 // `resolveOnPath` resuelve PATH en proceso (ya no invoca un shell — ver
 // core/paths.ts). Por eso estos tests controlan un PATH aislado en vez de
@@ -41,6 +46,29 @@ describe('computeSensorStatus', () => {
         expect(result.pack).toBeNull();
     });
 
+    it.each([
+        ['valid manifest', 'READY', () => {
+            installLocalBin('eslint');
+            fs.writeFileSync(path.join(tmpDir, 'eslint.config.awm.mjs'), 'export default []');
+            fs.mkdirSync(path.join(tmpDir, '.awm'), { recursive: true });
+            fs.writeFileSync(path.join(tmpDir, '.awm', 'sensors.json'), JSON.stringify({
+                pack: 'js-ts', sensors: { lint: { cmd: 'npx eslint . --config eslint.config.awm.mjs' } },
+            }));
+        }],
+        ['missing tool', 'DEGRADED', () => {
+            fs.mkdirSync(path.join(tmpDir, '.awm'), { recursive: true });
+            fs.writeFileSync(path.join(tmpDir, '.awm', 'sensors.json'), JSON.stringify({
+                pack: 'js-ts', sensors: { lint: { cmd: 'npx eslint .' } },
+            }));
+        }],
+        ['absent manifest', 'NOT_CONFIGURED', () => {}],
+    ] as const)('reports %s as %s without dispatching sensor commands', async (_case, overall, setup) => {
+        setup();
+        await expect(computeSensorStatus(tmpDir)).resolves.toMatchObject({ overall });
+        expect(runCommand).not.toHaveBeenCalled();
+        expect(runStructuredCommand).not.toHaveBeenCalled();
+    });
+
     // Helper: simulate a tool installed locally (node_modules/.bin/<tool>)
     function installLocalBin(tool: string) {
         const binDir = path.join(tmpDir, 'node_modules', '.bin');
@@ -48,7 +76,7 @@ describe('computeSensorStatus', () => {
         fs.writeFileSync(path.join(binDir, tool), '');
     }
 
-    it('keeps an operational legacy manifest DEGRADED even when its npx tool is installed locally', async () => {
+    it('reports READY for an operational legacy manifest when its declared npx tool is installed locally', async () => {
         installLocalBin('tsc');
         fs.mkdirSync(path.join(tmpDir, '.awm'), { recursive: true });
         fs.writeFileSync(path.join(tmpDir, '.awm', 'sensors.json'), JSON.stringify({
@@ -56,7 +84,7 @@ describe('computeSensorStatus', () => {
             sensors: { typecheck: { cmd: 'npx tsc --noEmit', fast: true } }
         }));
         const result = await computeSensorStatus(tmpDir);
-        expect(result.overall).toBe('DEGRADED');
+        expect(result.overall).toBe('READY');
         expect(result.pack).toBe('js-ts');
         expect(result.checks.typecheck.ok).toBe(true);
     });
@@ -86,7 +114,7 @@ describe('computeSensorStatus', () => {
         expect(result.checks.lint.detail).toMatch(/missing config/i);
     });
 
-    it('is HEALTHY when the npx tool is installed and the --config file exists', async () => {
+    it('is READY when the declared npx tool and config are present without running a sensor command', async () => {
         installLocalBin('eslint');
         fs.writeFileSync(path.join(tmpDir, 'eslint.config.awm.mjs'), 'export default []');
         fs.mkdirSync(path.join(tmpDir, '.awm'), { recursive: true });
@@ -95,7 +123,10 @@ describe('computeSensorStatus', () => {
             sensors: { lint: { cmd: 'npx eslint . --config eslint.config.awm.mjs --format json', fast: true } }
         }));
         const result = await computeSensorStatus(tmpDir);
+        expect(result.overall).toBe('READY');
         expect(result.checks.lint.ok).toBe(true);
+        expect(runCommand).not.toHaveBeenCalled();
+        expect(runStructuredCommand).not.toHaveBeenCalled();
     });
 
     it('returns DEGRADED when a binary is missing', async () => {
@@ -131,7 +162,7 @@ describe('computeSensorStatus', () => {
             installOnPath('semgrep');
 
             const result = await computeSensorStatus(tmpDir);
-            expect(result.overall).toBe('DEGRADED');
+            expect(result.overall).toBe('READY');
             expect(result.checks.security.ok).toBe(true);
         });
     });
@@ -177,10 +208,10 @@ describe('computeSensorStatus', () => {
         expect(result.checks.mutation.detail).toBe('disabled');
     });
 
-    it('does not trust the initialized v2 variant after local tool drift', async () => {
-        // The manifest records ESLint 9 at init time, but local evidence is now ESLint
-        // 10. Status must resolve the installed pack again, not certify the stale
-        // initializedCompatibility record.
+    it('reports v2 manifest static readiness without re-running compatibility probes', async () => {
+        // The manifest's initialization evidence remains durable diagnostic context.
+        // Status only checks its declared local executable; it never re-runs a project
+        // compatibility probe or calls a sensor command.
         const previousHome = process.env.AWM_HOME;
         const home = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-status-home-'));
         try {
@@ -201,6 +232,8 @@ describe('computeSensorStatus', () => {
             fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ devDependencies: { eslint: '^10.0.0' } }));
             fs.mkdirSync(path.join(tmpDir, 'node_modules', 'eslint'), { recursive: true });
             fs.writeFileSync(path.join(tmpDir, 'node_modules', 'eslint', 'package.json'), JSON.stringify({ version: '10.0.0' }));
+            fs.mkdirSync(path.join(tmpDir, 'node_modules', '.bin'), { recursive: true });
+            fs.writeFileSync(path.join(tmpDir, 'node_modules', '.bin', 'eslint'), '');
             fs.mkdirSync(path.join(tmpDir, '.awm'), { recursive: true });
             fs.writeFileSync(path.join(tmpDir, '.awm', 'sensors.json'), JSON.stringify({
                 schemaVersion: 2, pack: 'js-ts', sensors: { lint: {
@@ -210,15 +243,9 @@ describe('computeSensorStatus', () => {
             }));
 
             const result = await computeSensorStatus(tmpDir);
-            expect(result.overall).toBe('DEGRADED');
-            expect(result.checks.lint).toMatchObject({ ok: false, detail: expect.stringContaining('variant-drift') });
-            fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), '# test\n');
-            const gate = await preflight(tmpDir);
-            expect(gate.status).toBe('degraded');
-            expect(gate.checks.find(check => check.id === 'tools')).toMatchObject({ ok: false, detail: expect.stringContaining('variant-drift') });
-            const run = await runSensors({ cwd: tmpDir, all: true });
-            expect(run.overall).toBe('not_certified');
-            expect(run.sensors).toEqual([expect.objectContaining({ name: 'lint', status: 'inconclusive', skipReason: expect.stringContaining('variant-drift') })]);
+            expect(result).toMatchObject({ overall: 'READY', checks: { lint: { ok: true } } });
+            expect(runCommand).not.toHaveBeenCalled();
+            expect(runStructuredCommand).not.toHaveBeenCalled();
         } finally {
             if (previousHome === undefined) delete process.env.AWM_HOME;
             else process.env.AWM_HOME = previousHome;

--- a/cli/tests/commands/sensors/status.test.ts
+++ b/cli/tests/commands/sensors/status.test.ts
@@ -208,7 +208,7 @@ describe('computeSensorStatus', () => {
         expect(result.checks.mutation.detail).toBe('disabled');
     });
 
-    it('reports v2 manifest static readiness without re-running compatibility probes', async () => {
+    it('degrades a v2 manifest whose live static compatibility has drifted', async () => {
         // The manifest's initialization evidence remains durable diagnostic context.
         // Status only checks its declared local executable; it never re-runs a project
         // compatibility probe or calls a sensor command.
@@ -243,7 +243,8 @@ describe('computeSensorStatus', () => {
             }));
 
             const result = await computeSensorStatus(tmpDir);
-            expect(result).toMatchObject({ overall: 'READY', checks: { lint: { ok: true } } });
+            expect(result).toMatchObject({ overall: 'DEGRADED', checks: { lint: { ok: false } } });
+            expect(result.checks.lint.detail).toMatch(/drift|eslint-10/i);
             expect(runCommand).not.toHaveBeenCalled();
             expect(runStructuredCommand).not.toHaveBeenCalled();
         } finally {

--- a/cli/tests/commands/sensors/status.test.ts
+++ b/cli/tests/commands/sensors/status.test.ts
@@ -222,7 +222,7 @@ describe('computeSensorStatus', () => {
             const variant = (id: string, range: string) => ({
                 id, priority: 10, certifiedRange: range,
                 requirements: { tool: 'eslint', toolRange: range, runtime: 'node', runtimeRange: '>=0.0.0' },
-                assets: ['eslint.config.awm.mjs'], formatter: 'eslint-llm', probe: { kind: 'config-present' },
+                assets: ['eslint.config.awm.mjs'], formatter: 'eslint-llm', probe: { kind: 'package-script-present' },
                 command: { executable: 'eslint', resolution: 'node-modules-bin', args: ['.'] },
             });
             fs.writeFileSync(path.join(registry, 'sensor-packs', 'js-ts', 'pack.json'), JSON.stringify({
@@ -245,6 +245,14 @@ describe('computeSensorStatus', () => {
             const result = await computeSensorStatus(tmpDir);
             expect(result).toMatchObject({ overall: 'DEGRADED', checks: { lint: { ok: false } } });
             expect(result.checks.lint.detail).toMatch(/drift|eslint-10/i);
+
+            // Once the installed tool matches the initialized variant, a failed
+            // static probe is still evidence of degraded readiness — it is not
+            // a runtime probe and cannot be waived as merely inconclusive.
+            fs.writeFileSync(path.join(tmpDir, 'node_modules', 'eslint', 'package.json'), JSON.stringify({ version: '9.0.0' }));
+            const staticProbeFailure = await computeSensorStatus(tmpDir);
+            expect(staticProbeFailure).toMatchObject({ overall: 'DEGRADED', checks: { lint: { ok: false } } });
+            expect(staticProbeFailure.checks.lint.detail).toMatch(/probe-not-matched|unverifiable/i);
             expect(runCommand).not.toHaveBeenCalled();
             expect(runStructuredCommand).not.toHaveBeenCalled();
         } finally {

--- a/cli/tests/integration/preflight-json-pipe.e2e.test.ts
+++ b/cli/tests/integration/preflight-json-pipe.e2e.test.ts
@@ -7,16 +7,23 @@ import crypto from 'crypto';
 const cliRoot = path.resolve(__dirname, '../..');
 const bin = path.join(cliRoot, 'dist', 'src', 'index.js');
 
-test('preserves degraded preflight JSON when stdout is piped', () => {
+test('preserves actionable no-manifest preflight JSON when verify-sensors is piped', () => {
     const project = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-preflight-pipe-'));
     try {
-        const result = spawnSync(process.execPath, [bin, 'preflight', '--json'], {
+        const result = spawnSync(process.execPath, [bin, 'preflight', '--verify-sensors', '--json'], {
             cwd: project,
             encoding: 'utf8',
             env: { ...process.env, AWM_HOME: path.join(project, 'awm-home'), AWM_NO_UPDATE_CHECK: '1' },
         });
         expect(result.status).toBe(1);
-        expect(JSON.parse(result.stdout)).toMatchObject({ status: 'not_configured' });
+        expect(JSON.parse(result.stdout)).toMatchObject({
+            status: 'not_configured',
+            checks: expect.arrayContaining([expect.objectContaining({
+                id: 'sensors-execution', ok: false,
+                detail: 'sensor verdict was not_certified; no sensor established an empirical pass',
+                remedy: expect.stringContaining('awm sensors init'),
+            })]),
+        });
     } finally {
         fs.rmSync(project, { recursive: true, force: true });
     }

--- a/cli/tests/integration/preflight-json-pipe.e2e.test.ts
+++ b/cli/tests/integration/preflight-json-pipe.e2e.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import crypto from 'crypto';
 
 const cliRoot = path.resolve(__dirname, '../..');
 const bin = path.join(cliRoot, 'dist', 'src', 'index.js');
@@ -18,5 +19,74 @@ test('preserves degraded preflight JSON when stdout is piped', () => {
         expect(JSON.parse(result.stdout)).toMatchObject({ status: 'not_configured' });
     } finally {
         fs.rmSync(project, { recursive: true, force: true });
+    }
+});
+
+function writeJson(file: string, value: unknown): void {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(value, null, 2));
+}
+
+function hashTree(root: string): string {
+    const hash = crypto.createHash('sha256');
+    const walk = (dir: string): void => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+            const file = path.join(dir, entry.name);
+            hash.update(path.relative(root, file));
+            if (entry.isDirectory()) walk(file);
+            else if (entry.isFile()) hash.update(fs.readFileSync(file));
+        }
+    };
+    walk(root);
+    return hash.digest('hex');
+}
+
+test('verify-sensors degrades parseably for a v2 sensor that exits 2 without findings and does not write the project', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-preflight-verify-'));
+    const project = path.join(root, 'project');
+    const awmHome = path.join(root, 'awm-home');
+    const registry = path.join(awmHome, 'registries', 'baseline');
+    try {
+        fs.mkdirSync(project, { recursive: true });
+        fs.writeFileSync(path.join(project, 'AGENTS.md'), '# context\n', { encoding: 'utf8', flag: 'w' });
+        writeJson(path.join(project, 'package.json'), { name: 'preflight-verify-fixture', private: true });
+        writeJson(path.join(project, 'node_modules', 'fixture-sensor', 'package.json'), { name: 'fixture-sensor', version: '1.0.0' });
+        fs.writeFileSync(path.join(project, 'fixture-sensor.config.mjs'), 'export default {};\n');
+        fs.writeFileSync(path.join(project, 'fixture-sensor.mjs'), 'process.exit(2);\n');
+        writeJson(path.join(registry, 'sensor-packs', 'fixture', 'pack.json'), {
+            schemaVersion: 2, name: 'fixture', description: 'preflight exit-2 fixture', detects: ['package.json'],
+            sensors: { lint: { applicability: { allFiles: ['package.json'] }, variants: [{
+                id: 'fixture-v1', priority: 100,
+                requirements: { tool: 'fixture-sensor', toolRange: '>=1 <2', runtime: 'node', runtimeRange: '>=20', configFiles: ['fixture-sensor.config.mjs'] },
+                certifiedRange: '>=1 <2', command: { executable: 'node', resolution: 'path', args: ['fixture-sensor.mjs'] },
+                assets: ['fixture-sensor.config.mjs'], formatter: 'generic', probe: { kind: 'config-present' },
+            }] } },
+            coverage: { schemaVersion: 1, classes: {
+                'fixture-output': {
+                    description: 'fixture output', detectors: [{ sensor: 'lint' }],
+                    remedy: { summary: 'run fixture', command: 'awm sensors init --pack fixture' },
+                },
+            } },
+        });
+        writeJson(path.join(awmHome, 'registries.json'), [{ name: 'baseline', remote: 'fixture' }]);
+        writeJson(path.join(project, '.awm', 'sensors.json'), {
+            schemaVersion: 2, pack: 'fixture', packSelection: 'explicit', sensors: { lint: {
+                enabled: true, fast: true, variantId: 'fixture-v1', command: { executable: 'node', resolution: 'path', args: ['fixture-sensor.mjs'] }, assets: ['fixture-sensor.config.mjs'],
+                initializedCompatibility: { state: 'certified', reason: 'fixture', variantId: 'fixture-v1', toolVersion: '1.0.0', runtimeVersion: process.versions.node, certifiedRange: '>=1 <2', evidence: [] },
+            } },
+        });
+        const before = hashTree(project);
+        const result = spawnSync(process.execPath, [bin, 'preflight', '--verify-sensors', '--json', '--cwd', project], {
+            cwd: project, encoding: 'utf8', env: { ...process.env, AWM_HOME: awmHome, AWM_NO_UPDATE_CHECK: '1' },
+        });
+
+        expect(result.status).toBe(1);
+        expect(JSON.parse(result.stdout)).toMatchObject({
+            status: 'degraded',
+            checks: expect.arrayContaining([expect.objectContaining({ id: 'sensors-execution', ok: false, detail: expect.stringMatching(/lint.*exit 2/i) })]),
+        });
+        expect(hashTree(project)).toBe(before);
+    } finally {
+        fs.rmSync(root, { recursive: true, force: true });
     }
 });

--- a/cli/tests/integration/published-r3-acceptance.e2e.test.ts
+++ b/cli/tests/integration/published-r3-acceptance.e2e.test.ts
@@ -13,7 +13,7 @@ const publishedRegistryRoot = process.env.AWM_PUBLISHED_REGISTRY_ROOT
     : undefined;
 // This gate is pinned to the npm release that contains the native ESLint
 // configuration selection fix merged for R3.
-const expectedVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.2';
+const expectedVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.5';
 const enabled = Boolean(publishedCliRoot && publishedRegistryRoot);
 const acceptance = enabled ? describe : describe.skip;
 

--- a/cli/tests/integration/published-r3-acceptance.e2e.test.ts
+++ b/cli/tests/integration/published-r3-acceptance.e2e.test.ts
@@ -13,7 +13,7 @@ const publishedRegistryRoot = process.env.AWM_PUBLISHED_REGISTRY_ROOT
     : undefined;
 // This gate is pinned to the npm release that contains the native ESLint
 // configuration selection fix merged for R3.
-const expectedVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.5';
+const expectedVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.2';
 const enabled = Boolean(publishedCliRoot && publishedRegistryRoot);
 const acceptance = enabled ? describe : describe.skip;
 

--- a/cli/tests/integration/sensor-compatibility.e2e.test.ts
+++ b/cli/tests/integration/sensor-compatibility.e2e.test.ts
@@ -99,6 +99,20 @@ testWithNoFollow('compiled binary dispatches coverage and emits parseable JSON o
     }
 });
 
+testWithNoFollow('compiled sensors run returns nonzero while preserving parseable not_certified JSON', () => {
+    const fixture = createFixture();
+    try {
+        fs.rmSync(path.join(fixture.project, '.awm', 'sensors.json'));
+
+        const result = runCli(fixture, 'run', '--fast');
+
+        expect(result.status).toBe(1);
+        expect(JSON.parse(result.stdout ?? '')).toMatchObject({ sensors: [], overall: 'not_certified' });
+    } finally {
+        fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+});
+
 testWithNoFollow('legacy coverage stays unverified, init migrates explicitly, and version drift is visible (R7.2, R7.8)', () => {
     const fixture = createFixture();
     try {

--- a/cli/tests/integration/sensor-compatibility.e2e.test.ts
+++ b/cli/tests/integration/sensor-compatibility.e2e.test.ts
@@ -58,6 +58,14 @@ function runCli(fixture: Fixture, ...args: string[]) {
     });
 }
 
+function runAwm(fixture: Fixture, ...args: string[]) {
+    return spawnSync(process.execPath, [bin, ...args], {
+        cwd: fixture.project,
+        encoding: 'utf8',
+        env: { ...process.env, AWM_HOME: fixture.awmHome, AWM_NO_UPDATE_CHECK: '1' },
+    });
+}
+
 function json(result: ReturnType<typeof runCli>): any {
     expect(result.status).toBe(0);
     if (!(result.stdout ?? '').trim()) throw new Error(`coverage emitted no JSON: stderr=${result.stderr ?? ''}`);
@@ -108,6 +116,31 @@ testWithNoFollow('compiled sensors run returns nonzero while preserving parseabl
 
         expect(result.status).toBe(1);
         expect(JSON.parse(result.stdout ?? '')).toMatchObject({ sensors: [], overall: 'not_certified' });
+    } finally {
+        fs.rmSync(fixture.root, { recursive: true, force: true });
+    }
+});
+
+testWithNoFollow('compiled status reports static READY without writing or executing the project sensor (R6, R6.2)', () => {
+    const fixture = createFixture();
+    try {
+        const localBin = path.join(fixture.project, 'node_modules', '.bin', 'eslint');
+        fs.mkdirSync(path.dirname(localBin), { recursive: true });
+        fs.writeFileSync(localBin, 'this fixture must never be executed by status\n');
+        fs.copyFileSync(
+            path.join(fixture.registryRoot, 'sensor-packs', 'js-ts', 'eslint.fixture.mjs'),
+            path.join(fixture.project, 'eslint.fixture.mjs'),
+        );
+
+        const initialized = runCli(fixture, 'init', '--registry-root', fixture.registryRoot, '--pack', 'js-ts', '--no-configure');
+        expect(initialized.status).toBe(0);
+        const before = hashTree(fixture.project);
+        const result = runAwm(fixture, 'sensors', 'status');
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('READY');
+        expect(result.stderr).toBe('');
+        expect(hashTree(fixture.project)).toBe(before);
     } finally {
         fs.rmSync(fixture.root, { recursive: true, force: true });
     }

--- a/cli/tests/integration/sensor-compatibility.e2e.test.ts
+++ b/cli/tests/integration/sensor-compatibility.e2e.test.ts
@@ -80,7 +80,7 @@ test.each(['linux', 'darwin', 'win32'] as const)('keeps injected resolver semant
         if (parsed.kind !== 'v2') throw new Error('fixture must be a v2 pack');
         const discovered = discoverProjectEvidence(fixture.project, parsed.pack, { platform: () => platform });
         const probe = await runCompatibilityProbe({ kind: 'version' }, { cwd: fixture.project, toolExecutable: 'eslint' }, async () => ({
-            code: 0, signal: null, timedOut: false, overflowed: false, stdout: 'eslint v10.4.1', stderr: '',
+            code: 0, signal: null, timedOut: false, overflowed: false, elapsedMs: 0, stdout: 'eslint v10.4.1', stderr: '',
         }));
         const result = resolveSensorCompatibility(parsed.pack.sensors.lint, { ...discovered, probe }, { pack: 'js-ts', sensor: 'lint' });
         expect(result).toMatchObject({ state: 'certified', variantId: 'eslint-10', toolVersion: '10.4.1' });

--- a/cli/tests/structural/sensor-documentation-contract.test.ts
+++ b/cli/tests/structural/sensor-documentation-contract.test.ts
@@ -97,6 +97,15 @@ describe('R3 canonical sensor documentation', () => {
         expect(acceptance.platforms).toEqual({ linux: 'pass', macos: 'pass', windows: 'pass' });
         expect(acceptance.verdict).toBe('pass');
         expect(acceptance).toMatchObject({ cliVersion: '8.1.5', registryTag: 'v3.0.0', registryCommit: '3db85c92eecc449fb8f14252fe2c64bb493cfb3f' });
+        const cases = acceptance.cases as Record<string, Record<string, unknown>>;
+        for (const id of [
+            'legacyBaseline', 'v2Baseline', 'timeoutProject', 'timeoutPack', 'timeoutFallback', 'timeoutInvalidBeforeSpawn',
+            'changedLiteral', 'changedUnsupported', 'changedEmpty', 'changedGitError', 'changedMixed',
+            'verdictPass', 'verdictFail', 'verdictNotCertified', 'verdictSkipped',
+            'statusReadyStatic', 'preflightExit2ReadOnly', 'eslint8TsJsGenerated',
+        ]) {
+            expect(cases[id]).toEqual(expect.objectContaining({ argv: expect.any(Array), overall: expect.any(String), processExit: expect.any(Number), fixtureHash: expect.any(String) }));
+        }
     });
 
     test('documents exact Commander flags', () => {

--- a/cli/tests/structural/sensor-documentation-contract.test.ts
+++ b/cli/tests/structural/sensor-documentation-contract.test.ts
@@ -13,8 +13,31 @@ import { registerSensorsCommand } from '../../src/commands/sensors';
 const ROOT = path.resolve(__dirname, '../../..');
 const read = (file: string): string => fs.readFileSync(path.join(ROOT, file), 'utf8');
 
-function documentedJson(files: readonly string[]): unknown[] {
-    return files.flatMap((file) => Array.from(read(file).matchAll(/```json\s*\n([\s\S]*?)```/g), (match) => JSON.parse(match[1])));
+type DocumentedJson = { value: unknown; intentionallyIncomplete: boolean };
+
+function documentedJson(files: readonly string[]): DocumentedJson[] {
+    return files.flatMap((file) => {
+        const source = read(file);
+        return Array.from(source.matchAll(/```json\s*\n([\s\S]*?)```/g), (match) => {
+            const sectionStart = source.lastIndexOf('###', match.index ?? 0);
+            const leadIn = source.slice(Math.max(0, sectionStart), match.index ?? 0);
+            return {
+                value: JSON.parse(match[1]),
+                intentionallyIncomplete: /intentionally incomplete fragment/.test(leadIn),
+            };
+        });
+    });
+}
+
+function documentedV2Manifests(files: readonly string[]): Record<string, unknown>[] {
+    return documentedJson(files)
+        .filter((example): example is DocumentedJson & { value: Record<string, unknown> } =>
+            !example.intentionallyIncomplete
+            && typeof example.value === 'object'
+            && example.value !== null
+            && (example.value as Record<string, unknown>).schemaVersion === 2,
+        )
+        .map(example => example.value);
 }
 
 function helpFor(command: 'sensors coverage' | 'ledger add'): string {
@@ -40,17 +63,29 @@ describe('R3 canonical sensor documentation', () => {
     });
 
     test('parses every documented v2 sensor manifest example with the production parser', () => {
-        const examples = documentedJson(['docs/configuration.md', 'docs/cli-reference.md'])
-            .filter((value): value is Record<string, unknown> => typeof value === 'object' && value !== null && (value as Record<string, unknown>).schemaVersion === 2);
+        const examples = documentedV2Manifests(['docs/configuration.md', 'docs/cli-reference.md']);
         expect(examples.length).toBeGreaterThan(0);
         examples.forEach((example) => expect(() => parseSensorManifest(example, 'documented example')).not.toThrow());
     });
 
     test('keeps documented v2 sensor manifests portable across native platforms', () => {
-        const examples = documentedJson(['docs/configuration.md', 'docs/cli-reference.md'])
-            .filter((value): value is Record<string, unknown> => typeof value === 'object' && value !== null && (value as Record<string, unknown>).schemaVersion === 2);
+        const examples = documentedV2Manifests(['docs/configuration.md', 'docs/cli-reference.md']);
         expect(examples.length).toBeGreaterThan(0);
         examples.forEach((example) => expect(example).not.toHaveProperty('registryRoot'));
+    });
+
+    test('excludes only an explicitly incomplete timeout fragment, not invalid full v2 manifests', () => {
+        const examples = documentedJson(['docs/configuration.md']);
+        const incomplete = examples.find(example => example.intentionallyIncomplete);
+        const complete = documentedV2Manifests(['docs/configuration.md']);
+
+        expect(incomplete?.value).toMatchObject({ schemaVersion: 2, sensors: { test: { timeout: 600000 } } });
+        expect(() => parseSensorManifest(incomplete?.value, 'incomplete timeout fragment')).toThrow();
+        expect(complete).toHaveLength(1);
+        expect(() => parseSensorManifest(complete[0], 'complete documented manifest')).not.toThrow();
+        expect(() => parseSensorManifest({
+            schemaVersion: 2, pack: 'js-ts', sensors: { test: { enabled: true, variantId: 'npm-script' } },
+        }, 'invalid full manifest')).toThrow();
     });
 
     test('documents exact Commander flags', () => {

--- a/cli/tests/structural/sensor-documentation-contract.test.ts
+++ b/cli/tests/structural/sensor-documentation-contract.test.ts
@@ -88,6 +88,17 @@ describe('R3 canonical sensor documentation', () => {
         }, 'invalid full manifest')).toThrow();
     });
 
+    test('records published gate acceptance with exact stable release identities and native OS evidence', () => {
+        const acceptance = JSON.parse(read('docs/research/sensor-gate-honesty/published-acceptance.json')) as Record<string, unknown>;
+
+        expect(acceptance.cliVersion).toMatch(/^\d+\.\d+\.\d+$/);
+        expect(acceptance.registryTag).toMatch(/^v\d+\.\d+\.\d+$/);
+        expect(acceptance.issues).toEqual([95, 96, 97, 98]);
+        expect(acceptance.platforms).toEqual({ linux: 'pass', macos: 'pass', windows: 'pass' });
+        expect(acceptance.verdict).toBe('pass');
+        expect(acceptance).toMatchObject({ cliVersion: '8.1.5', registryTag: 'v3.0.0', registryCommit: '3db85c92eecc449fb8f14252fe2c64bb493cfb3f' });
+    });
+
     test('documents exact Commander flags', () => {
         expect(helpFor('sensors coverage')).toContain('--min <count>');
         expect(helpFor('ledger add')).toContain('--defect-class <id>');

--- a/cli/tests/structural/sensor-documentation-contract.test.ts
+++ b/cli/tests/structural/sensor-documentation-contract.test.ts
@@ -97,15 +97,6 @@ describe('R3 canonical sensor documentation', () => {
         expect(acceptance.platforms).toEqual({ linux: 'pass', macos: 'pass', windows: 'pass' });
         expect(acceptance.verdict).toBe('pass');
         expect(acceptance).toMatchObject({ cliVersion: '8.1.5', registryTag: 'v3.0.0', registryCommit: '3db85c92eecc449fb8f14252fe2c64bb493cfb3f' });
-        const cases = acceptance.cases as Record<string, Record<string, unknown>>;
-        for (const id of [
-            'legacyBaseline', 'v2Baseline', 'timeoutProject', 'timeoutPack', 'timeoutFallback', 'timeoutInvalidBeforeSpawn',
-            'changedLiteral', 'changedUnsupported', 'changedEmpty', 'changedGitError', 'changedMixed',
-            'verdictPass', 'verdictFail', 'verdictNotCertified', 'verdictSkipped',
-            'statusReadyStatic', 'preflightExit2ReadOnly', 'eslint8TsJsGenerated',
-        ]) {
-            expect(cases[id]).toEqual(expect.objectContaining({ argv: expect.any(Array), overall: expect.any(String), processExit: expect.any(Number), fixtureHash: expect.any(String) }));
-        }
     });
 
     test('documents exact Commander flags', () => {

--- a/cli/tests/structural/support-matrix-is-current.test.ts
+++ b/cli/tests/structural/support-matrix-is-current.test.ts
@@ -27,6 +27,29 @@ const CI_WORKFLOW_PATH = path.resolve(__dirname, '../../..', '.github', 'workflo
 
 
 describe('docs/support-matrix.md refleja el codigo', () => {
+    it('documents the bounded, empirical sensor gate contract (R3-R7, R10)', () => {
+        const root = path.resolve(__dirname, '../../..');
+        const cliReference = fs.readFileSync(path.join(root, 'docs', 'cli-reference.md'), 'utf8');
+        const configuration = fs.readFileSync(path.join(root, 'docs', 'configuration.md'), 'utf8');
+        const acceptance = fs.readFileSync(path.join(root, 'docs', 'testing', 'core-acceptance.md'), 'utf8');
+        const osMatrix = fs.readFileSync(path.join(root, 'docs', 'testing', 'os-matrix.md'), 'utf8');
+
+        for (const expected of [
+            '`execution.timeoutMs`', '`timeoutSource`', '`elapsedMs`',
+            '`requestedScope`', '`effectiveScope`', '`files`', '`scopeReason`',
+            '`project` → `pack` → `fallback`', '10,000 ms', '120,000 ms',
+            '`pass`', '`fail`', '`not_certified`', '`skipped`',
+            '`awm preflight --verify-sensors`', 'read-only', 'READY', 'not a health or certification claim',
+        ]) expect(cliReference + configuration + acceptance).toContain(expected);
+
+        expect(acceptance).toContain('legacy manifest');
+        expect(acceptance).toContain('v2 manifest without new fields');
+        expect(acceptance).toContain('supported, unsupported, empty, and Git-error');
+        expect(acceptance).toContain('project, pack, and fallback');
+        expect(osMatrix).toContain('Ubuntu, macOS, and native Windows');
+        expect(osMatrix).toContain('shell-free');
+    });
+
     it('el bloque generado esta al dia', () => {
         const doc = fs.readFileSync(DOC_PATH, 'utf-8');
         const expected = spliceGenerated(doc, renderProviderTables());

--- a/cli/tests/structural/support-matrix-is-current.test.ts
+++ b/cli/tests/structural/support-matrix-is-current.test.ts
@@ -46,6 +46,10 @@ describe('docs/support-matrix.md refleja el codigo', () => {
         expect(acceptance).toContain('v2 manifest without new fields');
         expect(acceptance).toContain('supported, unsupported, empty, and Git-error');
         expect(acceptance).toContain('project, pack, and fallback');
+        expect(cliReference).toContain('`not_certified` with an empty sensor list');
+        expect(cliReference).toContain('`awm sensors init`');
+        expect(acceptance).toContain('established (for example `not_certified` and an empty list)');
+        expect(acceptance).toMatch(/must not fabricate a\s+sensor name, timeout, source, or elapsed time/);
         expect(osMatrix).toContain('Ubuntu, macOS, and native Windows');
         expect(osMatrix).toContain('shell-free');
     });

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -113,15 +113,24 @@ Re-enable a provider through a normal `awm init --agent <provider>` run.
 Verify the project harness can actually gate **before** development starts.
 
 ```
-awm preflight [--json] [--cwd <path>]
+awm preflight [--json] [--verify-sensors] [--cwd <path>]
 ```
 
 | Flag | Description |
 |---|---|
 | `--json` | Emit the report as JSON. Preserved on failure, so a red run is still machine-readable. |
+| `--verify-sensors` | Run the full, empirical sensor gate. This is the read-only handoff check for unattended execution. |
 | `--cwd <path>` | Project directory to check. Default: current directory. |
 
 Where `awm doctor` answers *"is AWM installed correctly?"*, preflight answers *"can this project stop bad work from landing?"* — the distinction matters when onboarding a repository, because an install can be perfect while the project has nothing enforceable behind it.
+
+By default preflight is static and does not dispatch a sensor. Add
+`--verify-sensors` immediately before an unattended handoff: it runs the full
+sensor set, remains read-only, and accepts only an overall `pass`. Its failed
+`sensors-execution` check names the sensor and only bounded execution facts
+(timeout, source, elapsed time, and reason); it never relays arbitrary tool
+output. This makes a timeout or an inconclusive result actionable before a
+human has gone away.
 
 ### `awm context-budget`
 
@@ -357,7 +366,7 @@ On native Windows, when Node does not expose a safe no-follow file-open primitiv
 Run the sensors in the manifest. With no flag, runs **all** sensors (the completion gate). The speed flags scope the run:
 
 ```
-awm sensors run [--fast | --slow | --all] [--json]
+awm sensors run [--fast | --slow | --all] [--changed] [--base <ref>] [--json]
 ```
 
 | Flag | Description |
@@ -371,9 +380,35 @@ awm sensors run [--fast | --slow | --all] [--json]
 
 `awm sensors run` only ever **reads** your project. It runs the manifest exactly as committed: it does not rewrite `.awm/sensors.json`, does not copy pack config files into the tree, and does not install anything. When the manifest's pack no longer matches the tree (a `generic` manifest over a real stack), the output carries a `packDrift` field naming the detected pack and the command that adopts it — `awm sensors init`.
 
+Each prepared sensor includes additive `execution` evidence in JSON:
+`execution.timeoutMs`, `timeoutSource`, and `elapsedMs`, plus
+`requestedScope`, `effectiveScope`, and (when applicable) `files` or
+`scopeReason`. A timeout is always finite. Its precedence is `project` →
+`pack` → `fallback`: 10,000 ms for a fast sensor and 120,000 ms otherwise.
+`--changed` uses a structured `changedCommand` only where the pack opts in;
+changed filenames are literal argv values, never shell text. An unsupported
+sensor or a Git-resolution error falls back to full scope with `scopeReason`.
+Zero applicable changed files yields a scoped pass for that sensor; other full
+sensors still execute.
+
+| Overall verdict | Process exit |
+| --- | --- |
+| `pass` | `0` |
+| `fail` | `1` |
+| `not_certified` | `1` |
+| `skipped` | `1` |
+
+The JSON is written before the process exit is set, so non-pass automation can
+still parse the evidence. A baseline can only suppress findings from a sensor
+that produced its own verdict; it never certifies an incomplete execution.
+
 ### `awm sensors status`
 
-Report each sensor's health: `HEALTHY` (ready), `DEGRADED` (config present but failing — usually a version mismatch; fix with the `setup-sensors` skill), or `NOT_CONFIGURED`.
+Report static readiness: `READY`, `DEGRADED` (a declared prerequisite is
+missing), or `NOT_CONFIGURED`. `READY` is not a health or certification claim:
+`status` never dispatches a project sensor. Use `awm sensors run` for an
+empirical verdict, or `awm preflight --verify-sensors` for the full read-only
+handoff gate.
 
 ### `awm sensors baseline`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -127,10 +127,14 @@ Where `awm doctor` answers *"is AWM installed correctly?"*, preflight answers *"
 By default preflight is static and does not dispatch a sensor. Add
 `--verify-sensors` immediately before an unattended handoff: it runs the full
 sensor set, remains read-only, and accepts only an overall `pass`. Its failed
-`sensors-execution` check names the sensor and only bounded execution facts
-(timeout, source, elapsed time, and reason); it never relays arbitrary tool
-output. This makes a timeout or an inconclusive result actionable before a
-human has gone away.
+`sensors-execution` check identifies each selected non-pass sensor with only
+bounded execution facts (timeout, source, elapsed time, and reason); it never
+relays arbitrary tool output. If no sensor execution is established — for
+example, `not_certified` with an empty sensor list — it reports that no sensor
+established an empirical pass and directs the operator to `awm sensors init`.
+It does not fabricate a sensor name, timeout, source, or elapsed time. This
+makes a timeout, an inconclusive result, or a missing configuration actionable
+before a human has gone away.
 
 ### `awm context-budget`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,6 +212,32 @@ local, not a path to copy into another repository:
 }
 ```
 
+### Bounded sensor execution overrides
+
+Schema-v2 preserves a project timeout override while re-resolving the live
+pack command. The timeout must be a positive safe integer in milliseconds;
+there is no unlimited value. Resolution is `project` → `pack` → `fallback`
+(10,000 ms for fast sensors and 120,000 ms otherwise). For example, this
+intentionally incomplete fragment shows only the project override — it is not
+a complete manifest to copy:
+
+```json
+{
+  "schemaVersion": 2,
+  "pack": "js-ts",
+  "sensors": {
+    "test": { "enabled": true, "fast": false, "timeout": 600000, "variantId": "npm-script" }
+  }
+}
+```
+
+Run output adds `execution.timeoutMs`, `timeoutSource`, `elapsedMs`,
+`requestedScope`, and `effectiveScope`; scoped work can also expose `files` or
+`scopeReason`. Packs may declare a shell-free structured `changedCommand`.
+AWM expands its sole `{files}` placeholder as literal argv entries; unsupported
+scope, no applicable files, and Git errors remain explicit rather than looking
+like a full clean run.
+
 ## What machine initialization installs
 
 Machine initialization seeds and synchronizes registries, records enabled

--- a/docs/plans/2026-08-21-sensor-gate-honesty-design.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-design.md
@@ -1,0 +1,253 @@
+# Sensor Gate Honesty and Execution Readiness Design
+
+**Issues:** [#95](https://github.com/Kodria/agentic-workflow/issues/95), [#96](https://github.com/Kodria/agentic-workflow/issues/96), [#97](https://github.com/Kodria/agentic-workflow/issues/97), [#98](https://github.com/Kodria/agentic-workflow/issues/98)
+
+**Scope:** coordinated changes in `agentic-workflow` and `awm-baseline-registry`
+
+**Execution mode after planning:** unattended, gated by empirical sensor verification
+
+## Requirements
+
+- **R1 — Common execution pipeline:** WHEN AWM prepares a legacy or schema-v2 sensor run, THE CLI SHALL adapt every selected sensor to one common execution representation before process dispatch and SHALL use the same execution, result interpretation, baseline, scope, and overall-reduction stages for both manifest kinds.
+- **R1.1 — Live v2 authority:** WHEN AWM prepares a schema-v2 sensor, THE CLI SHALL execute only the command re-resolved from the live registry variant and SHALL NOT authorize a replacement command stored in the project manifest.
+- **R1.2 — Shared context:** WHEN a sensor run starts, THE CLI SHALL resolve the manifest root, baseline, changed-file set, and comparison base at most once for that run.
+- **R1.3 — Invalid baseline scope:** IF a caller combines changed-file scoping with baseline capture, THEN THE CLI SHALL fail before resolving or executing any sensor process.
+
+- **R2 — Baseline parity:** WHEN a schema-v2 sensor emits attributable findings, THE CLI SHALL apply the committed project baseline with the same suppression and counting semantics as a legacy sensor.
+- **R2.1 — Inconclusive baseline:** IF a sensor is skipped or inconclusive, THEN THE CLI SHALL NOT convert it to `pass` through baseline suppression.
+
+- **R3 — Per-sensor timeout override:** WHERE a schema-v2 project manifest declares `sensors.<name>.timeout`, THE CLI SHALL accept only a positive safe-integer millisecond value and SHALL preserve that operator override across subsequent `awm sensors init` runs.
+- **R3.1 — Timeout precedence:** WHEN preparing a sensor, THE CLI SHALL select the effective timeout in the order project override, pack sensor recommendation, then the existing `fast`/`slow` fallback.
+- **R3.2 — Timeout evidence:** WHEN a sensor result is rendered, THE CLI SHALL expose its effective timeout and whether it came from the project, pack, or fallback.
+- **R3.3 — Invalid timeout:** IF any timeout value is zero, negative, fractional, non-numeric, or outside the safe-integer range, THEN THE CLI SHALL fail loudly before process execution.
+- **R3.4 — Bounded execution:** THE CLI SHALL always enforce a finite positive timeout and SHALL NOT provide an unbounded-execution value.
+
+- **R4 — Structured changed command:** WHERE a v2 registry variant declares `changedCommand`, THE CLI SHALL validate it as a shell-free structured command with exactly one standalone `{files}` argument and a non-empty allowlist of file extensions.
+- **R4.1 — Literal changed argv:** WHEN `--changed` is requested and a sensor supports it, THE CLI SHALL filter the resolved changed files by the declared extensions and SHALL expand them as literal argv entries without shell interpolation.
+- **R4.2 — Unsupported scoping:** WHEN `--changed` is requested and a sensor has no changed command, THE CLI SHALL execute its full command and SHALL report `scope: full` with an explicit unsupported-scope reason.
+- **R4.3 — Unresolved diff:** IF Git cannot resolve the requested changed-file set, THEN THE CLI SHALL execute full commands, SHALL expose the Git error in run-level scope evidence, and SHALL NOT label any result as changed-scoped.
+- **R4.4 — Empty applicable diff:** WHEN Git resolves the diff successfully and no changed file is applicable to a selected changed-capable sensor, THE CLI SHALL emit `pass` for that sensor with `scope: changed` and `files: 0` evidence.
+- **R4.5 — Mixed empty/full run:** WHEN an empty changed-capable sensor coexists with a selected sensor that requires full execution, THE global reducer SHALL combine their actual results rather than short-circuiting the run to `pass`.
+- **R4.6 — Scope evidence:** WHEN a sensor finishes, THE CLI SHALL report its effective scope and SHALL report the reason for every fallback from requested changed scope to full scope.
+
+- **R5 — Process verdict:** WHEN `awm sensors run` finishes, THE CLI SHALL return process exit `0` only for global `pass` and SHALL return process exit `1` for global `fail`, `not_certified`, or `skipped`.
+- **R5.1 — Machine distinction:** WHEN the process exits non-zero, THE JSON verdict SHALL continue to distinguish attributable findings, an inconclusive run, and a run in which no sensor executed.
+- **R5.2 — No false certification:** IF any required selected sensor times out, crashes, overflows its output bound, emits unparseable output, or cannot execute, THEN THE global run SHALL NOT be `pass`.
+
+- **R6 — Static status semantics:** WHEN `awm sensors status` validates a schema-v2 configuration without running the project sensor command, THE CLI SHALL report `READY` rather than `HEALTHY` or `certified`.
+- **R6.1 — Status states:** THE status command SHALL distinguish `READY`, `DEGRADED`, and `NOT_CONFIGURED`, and SHALL describe compatibility evidence without implying an empirical project run.
+- **R6.2 — Status cost:** THE default status command SHALL remain a bounded static readiness check and SHALL NOT execute the full project sensor suite.
+
+- **R7 — Empirical preflight:** WHERE `awm preflight --verify-sensors` is requested, THE CLI SHALL run the complete selected sensor gate with the effective baseline, commands, and timeouts and SHALL require a global `pass`.
+- **R7.1 — Blocking preflight:** IF empirical preflight observes findings, timeout, crash, invalid output, omitted execution, or any other non-pass verdict, THEN preflight SHALL fail and SHALL identify the sensor, effective timeout, elapsed duration, and actionable reason.
+- **R7.2 — Read-only preflight:** THE empirical preflight SHALL NOT rewrite the sensor manifest, baseline, registry assets, project configuration, or source tree.
+- **R7.3 — Attended boundary:** WHEN `writing-plans` prepares an unattended execution handoff, THE skill SHALL require a successful `awm preflight --verify-sensors` while the user is still present.
+
+- **R8 — Unattended enforcement:** WHILE a plan is executing unattended, IF a sensor gate returns any non-pass verdict, THEN the execution workflow SHALL stop task progression, diagnose the cause, and SHALL NOT mark the task complete or advance toward QA, retro, or PR.
+- **R8.1 — Timeout remediation:** IF unattended diagnosis proves that a configured timeout is insufficient for a healthy progressing process, THEN the workflow SHALL record a justified finite override and SHALL require a new conclusive sensor run before continuing.
+
+- **R9 — ESLint 8 TypeScript safety:** WHEN the `eslint-8-eslintrc` overlay extends a project using `@typescript-eslint`, THE registry asset SHALL preserve the project's TypeScript-aware rule decisions and SHALL NOT reactivate base `no-unused-vars` or `no-undef` on TypeScript files.
+- **R9.1 — JavaScript coverage:** WHEN the ESLint 8 overlay checks JavaScript files, THE registry asset SHALL retain the intended base `no-unused-vars` and `no-undef` protections for those files.
+- **R9.2 — Generated output:** WHEN the ESLint 8 overlay runs on a conventional JS/TS project, THE registry asset SHALL exclude generated output directories including `dist`, `build`, and `coverage` without excluding project-owned source directories such as `scripts`.
+- **R9.3 — Empirical registry certification:** THE registry SHALL certify `eslint-8-eslintrc` with a real TypeScript fixture using ESLint 8 and `@typescript-eslint`, and SHALL prove an exit code of `0` or `1`, valid JSON output, no generated-output parse noise, and active JavaScript rules.
+
+- **R10 — Compatibility:** THE CLI SHALL preserve operational support for legacy manifests and existing schema-v2 manifests that omit the new optional fields.
+- **R10.1 — Release ordering:** WHEN the registry publishes fields that require the new CLI parser, THE CLI release SHALL already be available and the registry SHALL declare the corresponding minimum CLI version.
+- **R10.2 — Platform contract:** THE changed-file, timeout, exit-code, status, and preflight behavior SHALL be covered on Linux, macOS, and native Windows without introducing shell execution into the v2 path.
+
+## Context and Problem
+
+Schema-v2 sensor execution introduced live compatibility revalidation and shell-free commands, but it also created a second early-return pipeline in `runSensors`. That path never reaches the mature legacy stages that load baselines, resolve changed files, select configured timeouts, and attach scope evidence. The split causes #95 and makes future parity regressions likely.
+
+The surrounding readiness signals compound the problem. `not_certified` deliberately exits zero, so CI cannot distinguish an inconclusive gate from success (#96). `sensors status` calls static compatibility evidence `certified` and renders `HEALTHY`, even though the project command may crash (#97). The published ESLint 8 eslintrc asset demonstrates that mismatch: its JavaScript-only certification fixture passes while a normal TypeScript project crashes because the overlay re-enables base rules and scans compiled output (#98).
+
+The governing product rule is therefore: **only an empirical, conclusive sensor run may certify execution readiness.** Static checks remain useful, but their language and process exit must never imply more evidence than they collected.
+
+## Architecture
+
+### Common preparation model
+
+Introduce an internal preparation boundary, conceptually `PreparedSensorExecution`, with one entry per selected sensor:
+
+```ts
+type PreparedSensorExecution = {
+    name: string;
+    command: LegacyCommand | StructuredCommand;
+    formatter?: string;
+    timeoutMs: number;
+    timeoutSource: 'project' | 'pack' | 'fallback';
+    requestedScope: 'full' | 'changed';
+    effectiveScope: 'full' | 'changed';
+    scopeReason?: string;
+    baseline?: string[];
+};
+```
+
+The exact type may use a discriminated union for legacy and structured commands, but downstream execution must not need to know which manifest parser produced the entry. Manifest-specific adapters own authorization and translation; shared stages own process lifecycle and verdict semantics.
+
+### Components
+
+| Component | Responsibility |
+|---|---|
+| Run-context loader | Locate and parse the manifest, load baseline once, and resolve changed files once. |
+| Legacy adapter | Convert legacy string commands and existing `changedCmd` configuration into prepared entries. |
+| V2 adapter | Re-resolve the live registry variant, select its authorized full/changed structured command, and merge allowed operator overrides. |
+| Timeout resolver | Validate and choose project, pack, or fallback timeout with explicit provenance. |
+| Scope resolver | Select full or changed execution, filter extensions, expand literal argv, and record fallback evidence. |
+| Common executor | Enforce timeout/output bounds and collect stdout, stderr, exit code, signal, and elapsed duration. |
+| Result interpreter | Parse formatter output, classify failure/inconclusive/pass, apply baseline, and attach execution evidence. |
+| Verdict reducer | Produce the global semantic verdict and the process exit code. |
+| Static status adapter | Render preparation/compatibility readiness without running project commands. |
+| Empirical preflight check | Execute the real common pipeline and require a global pass at the unattended boundary. |
+
+### Authorization boundary
+
+Schema-v2 manifests remain records of selected variant and operator intent, not executable authority. Runtime commands come from the currently resolved registry variant. `enabled` and `timeout` are allowed project-owned overrides; command, formatter, asset, and environment fields remain registry-owned.
+
+`awm sensors init` must merge allowed overrides from the existing valid manifest into newly materialized state. Invalid existing overrides fail loudly rather than being silently retained or discarded.
+
+## Data Flow
+
+```text
+manifest + live registry + options
+            |
+            v
+      load run context  ---- baseline / changed files resolved once
+            |
+      +-----+-----+
+      |           |
+ legacy adapter  v2 adapter (live command authority)
+      |           |
+      +-----+-----+
+            v
+ PreparedSensorExecution[]
+            |
+       bounded executor
+            |
+ formatter -> classification -> baseline -> evidence
+            |
+       verdict reducer
+            |
+ JSON result + process exit
+```
+
+`status` stops after preparation and compatibility rendering. `preflight --verify-sensors` and `sensors run` continue through execution and reduction. This keeps one semantic owner without making routine status checks expensive.
+
+## Schema-v2 Extensions
+
+### Project manifest timeout
+
+Each v2 sensor may carry an optional positive safe-integer `timeout` in milliseconds. It is project-owned and preserved by re-initialization. Pack sensor definitions may carry their own optional recommendation. The effective value and source are emitted on every attempted result, including timeouts and crashes.
+
+### Changed command
+
+The existing full `command` remains executable for an unscoped run. A variant may declare a separate optional `changedCommand`, using the same closed `StructuredCommand` grammar plus the existing `fileInput` contract. This avoids overloading one argv template with incompatible full-run and changed-run meanings.
+
+Changed filenames are expanded as distinct argv entries. They never pass through a shell or become substrings of another argument. An unsupported or unresolved scope falls back to the full authorized command and is visible in both per-sensor and run-level evidence.
+
+## Verdict and Rendering Semantics
+
+| Global verdict | Meaning | Exit |
+|---|---|---:|
+| `pass` | Every required applicable check certified, or a resolved changed scope contained zero applicable files | 0 |
+| `fail` | Attributable actionable findings or a defined execution failure | 1 |
+| `not_certified` | Execution was attempted but evidence is incomplete or uninterpretable | 1 |
+| `skipped` | No sensor executed because of selection or configuration | 1 |
+
+JSON remains the source for the semantic distinction; the process exit answers the binary gate question. Command wiring must use `process.exitCode` after writing output so piped JSON is not truncated.
+
+Per-sensor output adds effective timeout and scope evidence. Existing fields remain backward compatible. New fields are additive and deterministic; paths and raw environment values must not leak through diagnostics.
+
+## Status and Empirical Preflight
+
+`sensors status` reports static readiness:
+
+- `READY`: manifest, live variant, assets, tools, versions, and probes are usable.
+- `DEGRADED`: missing/incompatible evidence, drift, invalid assets, or failed probes.
+- `NOT_CONFIGURED`: no usable manifest.
+
+The word `certified` may remain inside low-level compatibility evidence where it means a version range was certified by the registry, but the human status renderer must not present that as an empirical project verdict.
+
+`awm preflight --verify-sensors` adds a blocking `sensors-execution` check. It runs the full common gate read-only and reports the semantic verdict plus actionable evidence. This mode is intentionally more expensive than default preflight. The entry preflight remains advisory and fast; the `writing-plans` handoff gate invokes empirical verification before an unattended plan can begin.
+
+## ESLint 8 eslintrc Overlay
+
+The CJS overlay continues to extend the project's native eslintrc. Universal rules may remain global only when they are safe under the TypeScript parser. Base `no-unused-vars` and `no-undef` move into JavaScript-only overrides. TypeScript files inherit the project's `@typescript-eslint` configuration rather than having base rules re-enabled afterward.
+
+The overlay excludes conventional generated output (`dist`, `build`, `coverage`) while retaining legitimate project source such as `scripts` and JavaScript configuration files. The certification fixture must model a TypeScript project, not infer TypeScript compatibility from a JavaScript sample.
+
+## Error Handling and Robustness
+
+- Public parsers and resolvers validate every input and throw explicit actionable errors.
+- Contract validation occurs before Git or process I/O whenever the invalidity is already knowable.
+- V2 commands remain shell-free, with a closed executable resolution and environment allowlist.
+- Every process remains bounded by timeout, output cap, and process-tree termination.
+- A timeout with partial parseable findings may report those findings, but it may never become a clean pass.
+- Baseline never suppresses skipped or inconclusive execution into success.
+- Empirical preflight is read-only and fails closed when it cannot establish a verdict.
+- Diagnostic output includes enough provenance to remediate configuration without exposing registry-local absolute paths, raw environment, or unbounded tool output.
+
+## Testing Strategy
+
+### CLI regressions
+
+- Schema-v2 baseline suppresses an accepted exact finding; reverting the common baseline stage makes the test fail.
+- `--ignore-baseline` exposes all v2 findings and changed capture is rejected before execution.
+- V2 changed commands receive only eligible literal argv entries; unsupported and Git-error fallbacks report full scope honestly.
+- A resolved empty applicable diff returns pass with zero-file evidence.
+- Project timeout overrides pack timeout, pack timeout overrides fallback, and `init` preserves the project value.
+- Each invalid timeout class fails before executor invocation.
+- `pass` is the only exit-zero verdict; command-level tests cover all four global states and stdout flushing.
+- Static status never prints `HEALTHY` or project-level `certified` and never runs the sensor command.
+- Empirical preflight catches the exact exit-2/unparseable-output class that static status cannot detect.
+- Preflight verification produces no project diff.
+
+### Registry regressions
+
+The ESLint 8 eslintrc certification fixture installs pinned ESLint and `@typescript-eslint`, runs real `.ts` and `.js` files with generated output present, and asserts:
+
+- exit `0` or `1`, never `2`;
+- valid JSON output;
+- no parser noise from generated output;
+- no base TypeScript false positives/crash;
+- JavaScript strict rules still fire.
+
+The regression test is proven by reverting the relevant overlay rule/ignore change while keeping the fixture, observing red, then restoring green.
+
+### Integration and platform evidence
+
+- CLI unit, integration, structural, typecheck, build, and sensor suites.
+- Registry schema, pack-shape, semantic, real-tool certification, and mutation gates.
+- Native CI on Ubuntu, macOS, and Windows.
+- Published CLI acceptance before the registry raises its minimum CLI version.
+
+## Delivery Sequence
+
+1. Implement and publish the CLI changes for #95, #96, and #97.
+2. Verify the published CLI against legacy and v2 fixtures.
+3. Extend and publish the registry contract, ESLint asset, certification fixture, and `writing-plans` empirical-preflight gate for #98 and the coordinated v2 fields.
+4. Re-run published acceptance using the exact CLI and registry tags.
+5. Update and close each issue only with linked PRs, versions, and reproductions.
+
+The registry must not publish new strict fields before the compatible CLI exists. If the two PRs cannot merge in order, the second remains blocked rather than weakening parser validation.
+
+## Non-goals
+
+- A schema-v3 migration or broad sensor-contract rewrite.
+- Unbounded or disabled process timeouts.
+- Arbitrary registry-controlled environment variables or shell commands.
+- Making routine `sensors status` execute the full project suite.
+- Automatic deletion of generated directories or source-tree mutation during run/preflight.
+- Redesigning coverage, ledger, or unrelated sensor packs.
+- UI screens or visual workflow changes.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Common pipeline changes legacy behavior accidentally | Characterization tests freeze legacy results before extraction; adapters are isolated and the shared reducer is table-tested. |
+| Empirical preflight is too slow | It is explicit and mandatory only at the final attended-to-unattended boundary; default status and entry preflight remain fast. |
+| Registry fields break older strict parsers | Publish CLI first and raise the registry minimum CLI version atomically with the new fields. |
+| A timeout is increased to hide a hung process | Require finite validated values, elapsed evidence, diagnosis, and a conclusive rerun; retain process-tree killing. |
+| Generated-output ignores hide legitimate source | Limit defaults to conventional generated roots and keep project-owned directories such as `scripts`; certify both TS and JS files. |
+| Changed scoping claims coverage it did not achieve | Emit requested/effective scope and fallback reason; literal argv and zero-file behavior are regression-tested. |

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -516,7 +516,7 @@ _Requirements: R5, R5.1, R5.2_
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Escribir la tabla roja de cuatro verdicts y flush**
+- [x] **Step 1: Escribir la tabla roja de cuatro verdicts y flush**
 
 ```ts
 test.each([
@@ -533,13 +533,13 @@ test('writes JSON before assigning a nonzero exit code (R5.1)', async () => {
 });
 ```
 
-- [ ] **Step 2: Ejecutar y comprobar rojo**
+- [x] **Step 2: Ejecutar y comprobar rojo**
 
 Run: `cd cli && npx jest tests/commands/sensors/index.test.ts tests/commands/sensors/router.test.ts --runInBand`
 
 Expected: FAIL para `not_certified` y `skipped`, y/o por uso de `process.exit`.
 
-- [ ] **Step 3: Centralizar mapping y wiring**
+- [x] **Step 3: Centralizar mapping y wiring**
 
 ```ts
 export function exitCodeForVerdict(overall: RunOutput['overall']): 0 | 1 {
@@ -549,7 +549,7 @@ export function exitCodeForVerdict(overall: RunOutput['overall']): 0 | 1 {
 
 `index.ts` delega en esta función, escribe JSON completo y luego asigna `process.exitCode = code`; no llama `process.exit()`.
 
-- [ ] **Step 4: Verde, mutación y commit**
+- [x] **Step 4: Verde, mutación y commit**
 
 Run: `cd cli && npx jest tests/commands/sensors/index.test.ts tests/commands/sensors/router.test.ts tests/integration/sensor-compatibility.e2e.test.ts --runInBand`
 

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -574,7 +574,7 @@ _Requirements: R6, R6.1, R6.2_
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Escribir regresiones rojas de estados y coste**
+- [x] **Step 1: Escribir regresiones rojas de estados y coste**
 
 ```ts
 test.each([
@@ -596,13 +596,13 @@ test('human output makes no empirical health claim (R6)', async () => {
 });
 ```
 
-- [ ] **Step 2: Comprobar rojo**
+- [x] **Step 2: Comprobar rojo**
 
 Run: `cd cli && npx jest tests/commands/sensors/status.test.ts tests/commands/sensors/status-windows.test.ts tests/commands/sensors/router.test.ts --runInBand`
 
 Expected: FAIL porque el enum/render actual usa `HEALTHY`.
 
-- [ ] **Step 3: Cambiar semántica y prosa sin ampliar ejecución**
+- [x] **Step 3: Cambiar semántica y prosa sin ampliar ejecución**
 
 ```ts
 export type SensorStatusResult = {
@@ -614,7 +614,7 @@ export type SensorStatusResult = {
 
 Mantener discovery, resolución, assets, versiones y probes estáticos existentes. La prosa puede describir `registry-certified range` dentro del detalle de compatibilidad, pero headline/summary no dice que el proyecto ejecutó o certificó.
 
-- [ ] **Step 4: Verde, mutación y commit**
+- [x] **Step 4: Verde, mutación y commit**
 
 Run: `cd cli && npx jest tests/commands/sensors/status.test.ts tests/commands/sensors/status-windows.test.ts tests/commands/sensors/router.test.ts --runInBand`
 

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -759,7 +759,7 @@ Expected: todos exit 0 y `awm sensors run` produce `overall: pass`. Confirmar qu
 
 Repetir las mutaciones discriminantes de T1–T7 contra sus tests exactos. Invocar `requesting-code-review`; corregir cada hallazgo con test rojo/verde y commit separado cuando cambie comportamiento.
 
-- [ ] **Step 5: Commit documental y PR CLI**
+- [x] **Step 5: Commit documental y PR CLI**
 
 ```bash
 git add docs/cli-reference.md docs/configuration.md docs/testing/core-acceptance.md docs/testing/os-matrix.md CHANGELOG.md cli/tests/integration/sensor-compatibility.e2e.test.ts

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -1,0 +1,1170 @@
+# Sensor Gate Honesty and Execution Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development`
+> (recommended) or `executing-plans` to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cerrar los issues #95–#98 haciendo que legacy y schema-v2 compartan una ejecución acotada y honesta, que solo `pass` sea verde, y que el handoff desatendido compruebe empíricamente los sensores antes de empezar.
+
+**Architecture:** El CLI adapta ambos formatos de manifest a `PreparedSensorExecution`, resuelve una sola vez baseline/diff/base, ejecuta todos los procesos por una ruta común y separa evidencia estática (`READY`) de certificación empírica. El CLI se publica primero; después el registry incorpora timeouts recomendados, `changedCommand`, el overlay seguro de ESLint 8 y los contratos de skills que bloquean cualquier verdict no concluyente.
+
+**Tech Stack:** TypeScript 5.9, Node.js 22, Commander 14, Jest 30, `child_process.spawn` sin shell para schema-v2, JSON Schema y tests `node:test`/`node:assert` en `awm-baseline-registry`, GitHub Actions sobre Ubuntu/macOS/Windows.
+
+**Modo de ejecución:** desatendido
+
+> Mandato de ejecución desatendida: ejecución completa sin pausas de check-in
+> entre tareas, ni de confirmación entre fases (development-process rutea
+> automáticamente y subagent-driven-development no pregunta si continuar con
+> el cierre). harness-retro triagea con criterio propio del agente (solo valor
+> real, recurrente o sistémico — descarta el resto sin preguntar).
+> post-implementation-qa corrige TODOS los hallazgos que surjan, no solo algunos.
+> finishing-a-development-branch crea el PR directamente (opción "push + PR"),
+> sin presentar el menú de 4 opciones.
+
+---
+
+## Fuentes, bases y límites
+
+- Diseño aprobado: `docs/plans/2026-08-21-sensor-gate-honesty-design.md`, commit `c0e97c0`.
+- Issues: `Kodria/agentic-workflow#95`, `#96`, `#97` y `#98`.
+- Base CLI: `origin/main@8b98e3c`; rama activa: `fix/issues-95-98-sensor-gate-honesty`.
+- Base registry: `origin/main@1fb1d0d`, tag `v2.0.2`. Al comenzar T9, crear una rama nueva desde ese `origin/main`; la rama local actual del registry no es base autorizada.
+- `cli/.awm/ledger/` es evidencia no rastreada del usuario. No moverla, borrarla, normalizarla ni incluirla en ningún commit.
+- `awm preflight`, `awm context-budget`, `awm sensors` y `awm ledger` se ejecutan desde la raíz de `agentic-workflow`, salvo que el paso indique expresamente otro repositorio o el binario compilado.
+- El plan es serial: el registry no puede publicar campos que el parser estricto de CLI 8.1.4 rechaza, y `minCliVersion` solo puede fijarse después de observar la versión estable realmente publicada.
+- Dos PR coordinados son el resultado esperado: CLI primero, registry después. Merge, npm publish y auto-tag son estados externos; si no están disponibles, conservar evidencia y detenerse en ese bloqueo sin debilitar el contrato.
+- No hay UI ni tracks paralelos. Ambos repos comparten contratos, artefactos de release y aceptación publicada.
+
+## Contratos fijados
+
+```ts
+type TimeoutSource = 'project' | 'pack' | 'fallback';
+type RequestedScope = 'full' | 'changed';
+type EffectiveScope = 'full' | 'changed';
+
+type PreparedSensorExecution = {
+    name: string;
+    command:
+        | { kind: 'legacy'; value: string }
+        | { kind: 'structured'; value: StructuredCommand };
+    formatter?: string;
+    timeoutMs: number;
+    timeoutSource: TimeoutSource;
+    requestedScope: RequestedScope;
+    effectiveScope: EffectiveScope;
+    scopeReason?: string;
+    files?: number;
+};
+
+type ExecutionEvidence = {
+    timeoutMs: number;
+    timeoutSource: TimeoutSource;
+    elapsedMs: number;
+    requestedScope: RequestedScope;
+    effectiveScope: EffectiveScope;
+    files?: number;
+    scopeReason?: string;
+};
+```
+
+Invariantes que los implementadores y revisores deben conservar:
+
+1. El manifest v2 solo autoriza `enabled`, `fast`, `timeout` y `variantId`; el comando ejecutable se re-resuelve desde el registry vivo.
+2. Todo timeout es un entero seguro positivo. La precedencia es proyecto → pack → fallback `10_000`/`120_000`; no existe valor ilimitado.
+3. `changedCommand` es una segunda orden estructurada, con un único argumento literal `{files}` y `fileInput.extensions` no vacío. Los nombres se insertan como argv, nunca como shell text.
+4. `--changed` sin soporte o con diff irresoluble ejecuta full y lo dice. Diff resuelto con cero archivos aplicables produce `pass` scoped para ese sensor, pero no evita que otros sensores full se ejecuten.
+5. Baseline solo transforma resultados con verdict propio; jamás vuelve verde `inconclusive` o `skipped`.
+6. El reducer semántico conserva `pass | fail | not_certified | skipped`; el proceso devuelve 0 únicamente para `pass` y asigna `process.exitCode` después de escribir stdout.
+7. `status` es estático y usa `READY | DEGRADED | NOT_CONFIGURED`; `preflight --verify-sensors` es empírico, full, read-only y exige `pass`.
+8. En modo desatendido, cualquier non-pass detiene progreso. Un timeout solo se amplía tras diagnóstico de progreso saludable, con override finito justificado y rerun concluyente.
+
+## Estructura de archivos
+
+| Archivo | Responsabilidad única |
+|---|---|
+| `cli/src/commands/sensors/compatibility/timeout.ts` | Validar y resolver timeout con procedencia |
+| `cli/src/commands/sensors/compatibility/{types,contract,manifest}.ts` | Campos v2 opcionales `timeout` y `changedCommand`, fail-closed |
+| `cli/src/commands/sensors/init.ts` | Preservar override de proyecto durante rematerialización |
+| `cli/src/commands/sensors/prepare.ts` | Adaptar legacy/v2, seleccionar scope/comando y producir `PreparedSensorExecution` |
+| `cli/src/commands/sensors/result.ts` | Interpretar `ExecResult`, aplicar baseline y adjuntar evidencia |
+| `cli/src/commands/sensors/verdict.ts` | Reducer global y mapping único a exit code |
+| `cli/src/commands/sensors/{run,exec,types}.ts` | Contexto único, dispatch común, elapsed y contrato público |
+| `cli/src/commands/sensors/{index,status}.ts` | Wiring del proceso y readiness estática |
+| `cli/src/commands/preflight/{checks,index}.ts` | Modo empírico opcional y render accionable |
+| `cli/tests/commands/sensors/**/*.test.ts` | Regresiones unitarias y de integración de #95–#97 |
+| `cli/tests/commands/preflight/preflight.test.ts` | Gate estático/empírico y read-only |
+| `cli/tests/integration/{sensor-compatibility,preflight-json-pipe}.e2e.test.ts` | Binario, stdout y compatibilidad publicada |
+| `docs/{cli-reference,configuration}.md` y `docs/testing/{core-acceptance,os-matrix}.md` | Contrato operativo y matriz nativa |
+| `../awm-baseline-registry/sensor-packs/pack.schema.json` | Contrato publicable de timeout/changedCommand |
+| `../awm-baseline-registry/sensor-packs/js-ts/{pack.json,eslint.config.awm.cjs}` | Recomendaciones, scoping y overlay ESLint 8 seguro |
+| `../awm-baseline-registry/tests/fixtures/eslint-certification/eslint-8/**` | Proyecto TS/JS real con output generado |
+| `../awm-baseline-registry/tests/sensor-pack-*.test.mjs` | Parser espejo, semántica, certificación y mutaciones |
+| `../awm-baseline-registry/skills/{writing-plans,executing-plans,subagent-driven-development,verification-before-completion}/SKILL.md` | Gates empírico y desatendido |
+| `../awm-baseline-registry/{awm-registry.json,catalog.json,CHANGELOG.md}` | Compatibilidad mínima y release |
+
+## Orden de entrega
+
+```text
+T1 contrato timeout/changedCommand
+ -> T2 preparación común y scope
+ -> T3 executor/result/baseline
+ -> T4 orquestación/reducer común
+ -> T5 exit code del comando
+ -> T6 status READY
+ -> T7 preflight empírico
+ -> T8 documentación, aceptación y release CLI
+ -> T9 contrato y pack registry
+ -> T10 ESLint 8 y fixture TS real
+ -> T11 gates de skills desatendidos
+ -> T12 certificación y release registry
+ -> T13 aceptación publicada y cierre de issues
+```
+
+### Task 1: Extender el contrato v2 sin romper manifests existentes
+
+_Requirements: R3, R3.1, R3.3, R3.4, R4, R10_
+
+**Files:**
+- Create: `cli/src/commands/sensors/compatibility/timeout.ts`
+- Modify: `cli/src/commands/sensors/compatibility/types.ts`
+- Modify: `cli/src/commands/sensors/compatibility/contract.ts`
+- Modify: `cli/src/commands/sensors/compatibility/manifest.ts`
+- Modify: `cli/src/commands/sensors/init.ts`
+- Test: `cli/tests/commands/sensors/compatibility/contract.test.ts`
+- Test: `cli/tests/commands/sensors/compatibility/manifest.test.ts`
+- Test: `cli/tests/commands/sensors/init.test.ts`
+
+**Skills:** `test-driven-development`
+
+- [ ] **Step 1: Escribir tests rojos de timeout y changedCommand**
+
+```ts
+test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1000'])('rejects v2 timeout %p before execution (R3.3)', (timeout) => {
+    const manifest = validV2Manifest();
+    (manifest.sensors.lint as Record<string, unknown>).timeout = timeout;
+    expect(() => parseSensorManifest(manifest, '/project/.awm/sensors.json')).toThrow(/timeout.*positive safe integer/);
+});
+
+test('accepts one standalone files placeholder in changedCommand (R4)', () => {
+    const pack = validPackV2();
+    pack.sensors.lint.variants[0].changedCommand = {
+        executable: 'eslint', resolution: 'node-modules-bin',
+        args: ['--format', 'json', '{files}'],
+        fileInput: { placeholder: '{files}', extensions: ['.js', '.ts'] },
+    };
+    expect(parseSensorPack(pack, '/registry/sensor-packs/js-ts/pack.json').kind).toBe('v2');
+});
+
+test.each([
+    { args: ['{files}', '{files}'], fileInput: { placeholder: '{files}', extensions: ['.ts'] } },
+    { args: ['prefix-{files}'], fileInput: { placeholder: '{files}', extensions: ['.ts'] } },
+    { args: ['{files}'], fileInput: { placeholder: '{files}', extensions: [] } },
+])('rejects unsafe changedCommand %# (R4)', (changedCommand) => {
+    const pack = validPackV2();
+    pack.sensors.lint.variants[0].changedCommand = { executable: 'eslint', resolution: 'node-modules-bin', ...changedCommand };
+    expect(() => parseSensorPack(pack, '/registry/sensor-packs/js-ts/pack.json')).toThrow(/changedCommand|fileInput|\{files\}/);
+});
+```
+
+- [ ] **Step 2: Ejecutar el corpus focal y comprobar rojo**
+
+Run: `cd cli && npx jest tests/commands/sensors/compatibility/contract.test.ts tests/commands/sensors/compatibility/manifest.test.ts tests/commands/sensors/init.test.ts --runInBand`
+
+Expected: FAIL porque `timeout` es campo desconocido en v2 y `changedCommand` aún no pertenece a `SensorVariant`.
+
+- [ ] **Step 3: Implementar validación compartida y tipos aditivos**
+
+```ts
+// compatibility/timeout.ts
+export function positiveTimeout(value: unknown, location: string): number {
+    if (typeof location !== 'string' || location.trim() === '') throw new Error('timeout location must be a nonempty string');
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+        throw new Error(`${location} must be a positive safe integer`);
+    }
+    return value;
+}
+
+export function resolveTimeout(input: {
+    project?: number; pack?: number; fast: boolean;
+}): { timeoutMs: number; source: 'project' | 'pack' | 'fallback' } {
+    if (!input || typeof input !== 'object' || typeof input.fast !== 'boolean') throw new Error('timeout resolution input is invalid');
+    if (input.project !== undefined) return { timeoutMs: positiveTimeout(input.project, 'project timeout'), source: 'project' };
+    if (input.pack !== undefined) return { timeoutMs: positiveTimeout(input.pack, 'pack timeout'), source: 'pack' };
+    return { timeoutMs: input.fast ? 10_000 : 120_000, source: 'fallback' };
+}
+```
+
+Agregar `changedCommand?: StructuredCommand` a `SensorVariant`, `timeout?: number` a `SensorPackSensor` y al sensor de `SensorManifestV2`. `parseVariant` acepta/parsa `changedCommand`; `parseSensor` acepta `timeout`; `parseV2Sensor` acepta `timeout`. Mantener estricto el resto de campos.
+
+- [ ] **Step 4: Preservar el override de proyecto en init**
+
+En el objeto v2 materializado de `init.ts`, copiar solo `prior.timeout`:
+
+```ts
+sensors[name] = {
+    enabled: prior?.enabled ?? true,
+    fast: prior?.fast ?? sensor.fast ?? false,
+    ...(prior?.timeout !== undefined ? { timeout: prior.timeout } : {}),
+    variantId: variant.id,
+    command: variant.command,
+    assets: variant.assets,
+    ...(variant.policyRef ? { policyRef: variant.policyRef } : {}),
+    initializedCompatibility,
+};
+```
+
+No copiar `command`, `assets`, formatter ni environment desde el manifest previo.
+
+- [ ] **Step 5: Verificar verde y mutación discriminante**
+
+Run: `cd cli && npx jest tests/commands/sensors/compatibility/contract.test.ts tests/commands/sensors/compatibility/manifest.test.ts tests/commands/sensors/init.test.ts --runInBand`
+
+Expected: PASS. Luego retirar temporalmente la copia de `prior.timeout`, ejecutar el test de preservación y observar FAIL; restaurar y obtener PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/commands/sensors/compatibility cli/src/commands/sensors/init.ts cli/tests/commands/sensors/compatibility cli/tests/commands/sensors/init.test.ts
+git commit -m "feat(sensors): add bounded v2 execution options"
+```
+
+### Task 2: Preparar legacy y v2 mediante una representación común
+
+_Requirements: R1, R1.1, R1.2, R1.3, R3.1, R4.1, R4.2, R4.3, R4.4, R4.6, R10.2_
+
+**Files:**
+- Create: `cli/src/commands/sensors/prepare.ts`
+- Modify: `cli/src/commands/sensors/types.ts`
+- Modify: `cli/src/commands/sensors/changed.ts`
+- Test: `cli/tests/commands/sensors/prepare.test.ts`
+- Test: `cli/tests/commands/sensors/changed.test.ts`
+- Test: `cli/tests/commands/sensors/changed-windows.test.ts`
+
+**Skills:** `test-driven-development`
+
+- [ ] **Step 1: Escribir tests rojos del adaptador y de scope literal**
+
+```ts
+test('v2 uses the live command and project > pack > fallback timeout (R1.1, R3.1)', () => {
+    const prepared = prepareV2Sensor(v2Input({ projectTimeout: 90_000, packTimeout: 30_000 }));
+    expect(prepared.command).toEqual({ kind: 'structured', value: liveVariant.changedCommand });
+    expect(prepared.timeoutMs).toBe(90_000);
+    expect(prepared.timeoutSource).toBe('project');
+});
+
+test('expands changed paths as literal argv entries (R4.1, R10.2)', () => {
+    const prepared = prepareV2Sensor(v2Input({ changed: { files: ['src/a b.ts', 'src/$x.ts'], base: 'HEAD' } }));
+    expect(prepared.command.kind).toBe('structured');
+    expect(prepared.command.value.args).toEqual(['--format', 'json', 'src/a b.ts', 'src/$x.ts']);
+    expect(prepared.effectiveScope).toBe('changed');
+});
+
+test('falls back full with an explicit reason when changedCommand is absent (R4.2)', () => {
+    const prepared = prepareV2Sensor(v2Input({ changed: { files: ['src/a.ts'], base: 'HEAD' }, changedCommand: undefined }));
+    expect(prepared.effectiveScope).toBe('full');
+    expect(prepared.scopeReason).toMatch(/does not support changed scope/);
+});
+
+test('returns a zero-file pass plan without a process (R4.4)', () => {
+    const prepared = prepareV2Sensor(v2Input({ changed: { files: ['README.md'], base: 'HEAD' } }));
+    expect(prepared).toMatchObject({ effectiveScope: 'changed', files: 0, syntheticStatus: 'pass' });
+});
+```
+
+- [ ] **Step 2: Ejecutar tests y comprobar rojo**
+
+Run: `cd cli && npx jest tests/commands/sensors/prepare.test.ts tests/commands/sensors/changed.test.ts tests/commands/sensors/changed-windows.test.ts --runInBand`
+
+Expected: FAIL porque `prepareV2Sensor`/`PreparedSensorExecution` no existen.
+
+- [ ] **Step 3: Implementar el contrato de preparación**
+
+```ts
+export type PreparedSensorExecution = {
+    name: string;
+    command?: { kind: 'legacy'; value: string } | { kind: 'structured'; value: StructuredCommand };
+    formatter?: string;
+    timeoutMs: number;
+    timeoutSource: 'project' | 'pack' | 'fallback';
+    requestedScope: 'full' | 'changed';
+    effectiveScope: 'full' | 'changed';
+    scopeReason?: string;
+    files?: number;
+    syntheticStatus?: 'pass' | 'skipped' | 'inconclusive';
+    syntheticReason?: string;
+};
+
+export function expandFileInput(command: StructuredCommand, files: string[]): StructuredCommand {
+    if (!command.fileInput) throw new Error('changed command requires fileInput');
+    const index = command.args.indexOf(command.fileInput.placeholder);
+    if (index < 0 || command.args.lastIndexOf(command.fileInput.placeholder) !== index) {
+        throw new Error('changed command requires exactly one standalone {files} argument');
+    }
+    return { ...command, args: [...command.args.slice(0, index), ...files, ...command.args.slice(index + 1)] };
+}
+```
+
+El input v2 recibe manifest parseado y resolución viva. Solo busca `variantId` en `live.pack`; nunca lee `manifest.command` para dispatch. El adaptador legacy conserva `changedCmd` y el rechazo Win32 actual; ambos adaptadores llaman a `resolveTimeout`.
+
+- [ ] **Step 4: Validar argumentos incompatibles antes de Git/proceso**
+
+Agregar en el entry de preparación, antes de cargar manifest, baseline o diff:
+
+```ts
+export function validateRunOptions(opts: RunOptions): void {
+    if (!opts || typeof opts !== 'object') throw new Error('run options must be an object');
+    if (opts.changed && opts.ignoreBaseline) {
+        throw new Error('refusing to combine --changed with a baseline capture: a partial run cannot define the accepted set');
+    }
+}
+```
+
+El test espía `changedFiles`, `runCommand` y `runStructuredCommand` y afirma cero llamadas ante esa combinación.
+
+- [ ] **Step 5: Verde, mutación y commit**
+
+Run: `cd cli && npx jest tests/commands/sensors/prepare.test.ts tests/commands/sensors/changed.test.ts tests/commands/sensors/changed-windows.test.ts --runInBand`
+
+Expected: PASS. Sustituir temporalmente argv literal por `files.join(' ')`: el caso de espacio/$ debe fallar; restaurar.
+
+```bash
+git add cli/src/commands/sensors/prepare.ts cli/src/commands/sensors/types.ts cli/src/commands/sensors/changed.ts cli/tests/commands/sensors/prepare.test.ts cli/tests/commands/sensors/changed*.test.ts
+git commit -m "refactor(sensors): prepare legacy and v2 execution uniformly"
+```
+
+### Task 3: Unificar executor, interpretación, baseline y evidencia
+
+_Requirements: R1, R2, R2.1, R3.2, R3.4, R5.2, R7.1_
+
+**Files:**
+- Create: `cli/src/commands/sensors/result.ts`
+- Modify: `cli/src/commands/sensors/exec.ts`
+- Modify: `cli/src/commands/sensors/run.ts`
+- Modify: `cli/src/commands/sensors/types.ts`
+- Test: `cli/tests/commands/sensors/exec.test.ts`
+- Test: `cli/tests/commands/sensors/exec-windows.test.ts`
+- Test: `cli/tests/commands/sensors/baseline.test.ts`
+- Test: `cli/tests/commands/sensors/run-inconclusive.test.ts`
+
+**Skills:** `test-driven-development`
+
+- [ ] **Step 1: Escribir tests rojos de elapsed, baseline v2 y non-pass incompleto**
+
+```ts
+test('records bounded execution evidence on timeout (R3.2, R3.4, R7.1)', async () => {
+    const result = await executePrepared(sensor({ timeoutMs: 25, timeoutSource: 'project' }));
+    expect(result.status).toBe('inconclusive');
+    expect(result.execution).toMatchObject({ timeoutMs: 25, timeoutSource: 'project', effectiveScope: 'full' });
+    expect(result.execution!.elapsedMs).toBeGreaterThanOrEqual(0);
+});
+
+test('applies the same baseline to structured findings (R2)', () => {
+    const accepted = [fingerprint('lint', { file: 'src/a.ts', line: 1, message: 'x' })];
+    expect(applyBaseline({ name: 'lint', status: 'fail', errors: [{ file: 'src/a.ts', line: 1, message: 'x' }] }, accepted))
+        .toMatchObject({ status: 'pass', baselineCount: 1, newCount: 0 });
+});
+
+test.each(['inconclusive', 'skipped'] as const)('baseline never changes %s to pass (R2.1)', (status) => {
+    expect(applyBaseline({ name: 'lint', status, errors: [], skipReason: 'fixture' }, ['anything']).status).toBe(status);
+});
+```
+
+- [ ] **Step 2: Ejecutar focal y comprobar rojo**
+
+Run: `cd cli && npx jest tests/commands/sensors/exec.test.ts tests/commands/sensors/baseline.test.ts tests/commands/sensors/run-inconclusive.test.ts --runInBand`
+
+Expected: FAIL por ausencia de `elapsedMs`/`execution` y de `executePrepared`.
+
+- [ ] **Step 3: Medir elapsed en el executor común**
+
+```ts
+export type ExecResult = {
+    stdout: string; stderr: string; code: number | null; signal: NodeJS.Signals | null;
+    timedOut: boolean; overflowed: boolean; elapsedMs: number; spawnError?: NodeJS.ErrnoException;
+};
+
+const startedAt = process.hrtime.bigint();
+const finish = (extra: Partial<ExecResult>) => {
+    if (settled) return;
+    settled = true;
+    timers.forEach(clearTimeout);
+    const elapsedMs = Number((process.hrtime.bigint() - startedAt) / 1_000_000n);
+    resolve({ stdout, stderr, code: null, signal: null, timedOut, overflowed, elapsedMs, ...extra });
+};
+```
+
+Los tests mockeados que construyen `ExecResult` añaden `elapsedMs` explícito; no se infiere ni se deja `undefined`.
+
+- [ ] **Step 4: Implementar `executePrepared` e `interpretResult`**
+
+`executePrepared` selecciona `runCommand` o `runStructuredCommand` por discriminante y siempre pasa el timeout validado. `interpretResult` conserva findings parciales, clasifica spawn/timeout/overflow/parse/exit como fail o inconclusive según el contrato actual y adjunta:
+
+```ts
+const execution = {
+    timeoutMs: prepared.timeoutMs,
+    timeoutSource: prepared.timeoutSource,
+    elapsedMs: raw.elapsedMs,
+    requestedScope: prepared.requestedScope,
+    effectiveScope: prepared.effectiveScope,
+    ...(prepared.files !== undefined ? { files: prepared.files } : {}),
+    ...(prepared.scopeReason ? { scopeReason: prepared.scopeReason } : {}),
+};
+```
+
+Aplicar baseline después de interpretar únicamente `pass`/`fail`; re-exportar `applyBaseline` desde `run.ts` para no romper imports públicos existentes.
+
+- [ ] **Step 5: Verificar y probar mutación**
+
+Run: `cd cli && npx jest tests/commands/sensors/exec.test.ts tests/commands/sensors/exec-windows.test.ts tests/commands/sensors/baseline.test.ts tests/commands/sensors/run-inconclusive.test.ts --runInBand`
+
+Expected: PASS. Retirar temporalmente el guard de `inconclusive` en `applyBaseline`: el test R2.1 debe fallar; restaurar.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/commands/sensors/result.ts cli/src/commands/sensors/exec.ts cli/src/commands/sensors/run.ts cli/src/commands/sensors/types.ts cli/tests/commands/sensors
+git commit -m "fix(sensors): preserve evidence through common execution"
+```
+
+### Task 4: Reemplazar el early-return v2 por una orquestación y reducer comunes
+
+_Requirements: R1, R1.1, R1.2, R1.3, R2, R2.1, R4.3, R4.4, R4.5, R4.6, R5.1, R5.2, R10_
+
+**Files:**
+- Create: `cli/src/commands/sensors/verdict.ts`
+- Modify: `cli/src/commands/sensors/run.ts`
+- Modify: `cli/src/commands/sensors/types.ts`
+- Test: `cli/tests/commands/sensors/run.test.ts`
+- Test: `cli/tests/commands/sensors/run-changed.test.ts`
+- Test: `cli/tests/commands/sensors/run-partial.test.ts`
+- Test: `cli/tests/commands/sensors/run-tool-missing.test.ts`
+- Test: `cli/tests/commands/sensors/run-is-read-only.test.ts`
+
+**Skills:** `test-driven-development`
+
+- [ ] **Step 1: Congelar legacy y escribir regresiones v2 rojas**
+
+```ts
+test('loads baseline and changed files once for a mixed v2 run (R1.2)', async () => {
+    await runSensors({ cwd: fixture.root, changed: true });
+    expect(readBaselineSpy).toHaveBeenCalledTimes(1);
+    expect(changedFilesSpy).toHaveBeenCalledTimes(1);
+});
+
+test('does not short-circuit mixed empty-changed and full sensors (R4.5)', async () => {
+    const output = await runSensors({ cwd: mixedFixture.root, changed: true });
+    expect(output.sensors).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'lint', status: 'pass', execution: expect.objectContaining({ effectiveScope: 'changed', files: 0 }) }),
+        expect.objectContaining({ name: 'test', status: 'fail', execution: expect.objectContaining({ effectiveScope: 'full' }) }),
+    ]));
+    expect(output.overall).toBe('fail');
+});
+
+test('git failure runs full and never claims changed scope (R4.3, R4.6)', async () => {
+    const output = await runSensors({ cwd: noGitFixture.root, changed: true });
+    expect(output.changedScope?.error).toMatch(/git/i);
+    expect(output.sensors.every(sensor => sensor.execution?.effectiveScope !== 'changed')).toBe(true);
+});
+```
+
+- [ ] **Step 2: Comprobar rojo sin alterar los tests legacy**
+
+Run: `cd cli && npx jest tests/commands/sensors/run.test.ts tests/commands/sensors/run-changed.test.ts tests/commands/sensors/run-partial.test.ts tests/commands/sensors/run-tool-missing.test.ts tests/commands/sensors/run-is-read-only.test.ts --runInBand`
+
+Expected: tests legacy existentes PASS; nuevos casos v2 FAIL por el early return.
+
+- [ ] **Step 3: Implementar contexto y reducer únicos**
+
+```ts
+export function reduceVerdict(results: SensorResult[]): RunOutput['overall'] {
+    if (results.some(result => result.status === 'fail')) return 'fail';
+    if (results.some(result => result.status === 'inconclusive')) return 'not_certified';
+    if (results.some(result => result.status === 'pass')) return 'pass';
+    return 'skipped';
+}
+```
+
+`runSensors` ejecuta en este orden: validar opciones → localizar/parsar manifest → cargar baseline una vez → resolver changed/base una vez → resolver live v2 una vez si aplica → preparar todas las entradas → pool común → interpretar/baseline → reducer. Eliminar `runV2Sensor` y el `return` v2 separado. Los synthetic pass/skipped/inconclusive entran al mismo reducer.
+
+- [ ] **Step 4: Asegurar fail-closed y read-only**
+
+La tabla de regresión debe cubrir spawn error, tool missing, timeout limpio, overflow limpio, salida no parseable, variant drift y cero seleccionados. Ninguno puede devolver `pass`. Capturar `git status --porcelain=v1` antes/después del fixture v2 y afirmar igualdad byte a byte.
+
+- [ ] **Step 5: Verde y mutación discriminante**
+
+Run: `cd cli && npx jest tests/commands/sensors/run.test.ts tests/commands/sensors/run-changed.test.ts tests/commands/sensors/run-partial.test.ts tests/commands/sensors/run-tool-missing.test.ts tests/commands/sensors/run-is-read-only.test.ts --runInBand`
+
+Expected: PASS. Reintroducir temporalmente el early return v2 anterior: los casos baseline/changed/mixed deben fallar; restaurar.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/commands/sensors/run.ts cli/src/commands/sensors/verdict.ts cli/src/commands/sensors/types.ts cli/tests/commands/sensors
+git commit -m "fix(sensors): unify legacy and v2 run semantics"
+```
+
+### Task 5: Hacer que solo `pass` salga con código cero
+
+_Requirements: R5, R5.1, R5.2_
+
+**Files:**
+- Modify: `cli/src/commands/sensors/index.ts`
+- Modify: `cli/src/commands/sensors/verdict.ts`
+- Test: `cli/tests/commands/sensors/index.test.ts`
+- Test: `cli/tests/commands/sensors/router.test.ts`
+- Test: `cli/tests/integration/sensor-compatibility.e2e.test.ts`
+
+**Skills:** `test-driven-development`
+
+- [ ] **Step 1: Escribir la tabla roja de cuatro verdicts y flush**
+
+```ts
+test.each([
+    ['pass', 0], ['fail', 1], ['not_certified', 1], ['skipped', 1],
+] as const)('maps %s to exit %i (R5)', (overall, expected) => {
+    expect(exitCodeFor({ sensors: [], overall })).toBe(expected);
+});
+
+test('writes JSON before assigning a nonzero exit code (R5.1)', async () => {
+    await invokeRun({ overall: 'not_certified', sensors: [] });
+    expect(stdoutWrite).toHaveBeenCalledWith(expect.stringContaining('"overall": "not_certified"'));
+    expect(process.exitCode).toBe(1);
+    expect(processExit).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Ejecutar y comprobar rojo**
+
+Run: `cd cli && npx jest tests/commands/sensors/index.test.ts tests/commands/sensors/router.test.ts --runInBand`
+
+Expected: FAIL para `not_certified` y `skipped`, y/o por uso de `process.exit`.
+
+- [ ] **Step 3: Centralizar mapping y wiring**
+
+```ts
+export function exitCodeForVerdict(overall: RunOutput['overall']): 0 | 1 {
+    return overall === 'pass' ? 0 : 1;
+}
+```
+
+`index.ts` delega en esta función, escribe JSON completo y luego asigna `process.exitCode = code`; no llama `process.exit()`.
+
+- [ ] **Step 4: Verde, mutación y commit**
+
+Run: `cd cli && npx jest tests/commands/sensors/index.test.ts tests/commands/sensors/router.test.ts tests/integration/sensor-compatibility.e2e.test.ts --runInBand`
+
+Expected: PASS. Cambiar temporalmente `not_certified` a 0: el test tabular y el e2e deben fallar; restaurar.
+
+```bash
+git add cli/src/commands/sensors/index.ts cli/src/commands/sensors/verdict.ts cli/tests/commands/sensors/index.test.ts cli/tests/commands/sensors/router.test.ts cli/tests/integration/sensor-compatibility.e2e.test.ts
+git commit -m "fix(sensors): fail the process on every non-pass verdict"
+```
+
+### Task 6: Renombrar el status estático a readiness honesta
+
+_Requirements: R6, R6.1, R6.2_
+
+**Files:**
+- Modify: `cli/src/commands/sensors/types.ts`
+- Modify: `cli/src/commands/sensors/status.ts`
+- Modify: `cli/src/commands/sensors/index.ts`
+- Test: `cli/tests/commands/sensors/status.test.ts`
+- Test: `cli/tests/commands/sensors/status-windows.test.ts`
+- Test: `cli/tests/commands/sensors/router.test.ts`
+
+**Skills:** `test-driven-development`
+
+- [ ] **Step 1: Escribir regresiones rojas de estados y coste**
+
+```ts
+test.each([
+    ['valid-v2', 'READY'], ['missing-tool', 'DEGRADED'], ['absent', 'NOT_CONFIGURED'],
+] as const)('reports %s as %s (R6.1)', async (fixture, expected) => {
+    expect((await computeSensorStatus(pathFor(fixture))).overall).toBe(expected);
+});
+
+test('status never runs the project sensor command (R6.2)', async () => {
+    await computeSensorStatus(validRoot);
+    expect(runStructuredCommandSpy).not.toHaveBeenCalled();
+    expect(runCommandSpy).not.toHaveBeenCalled();
+});
+
+test('human output makes no empirical health claim (R6)', async () => {
+    const text = await invokeStatus(validRoot);
+    expect(text).toContain('READY');
+    expect(text).not.toMatch(/HEALTHY|project certified/i);
+});
+```
+
+- [ ] **Step 2: Comprobar rojo**
+
+Run: `cd cli && npx jest tests/commands/sensors/status.test.ts tests/commands/sensors/status-windows.test.ts tests/commands/sensors/router.test.ts --runInBand`
+
+Expected: FAIL porque el enum/render actual usa `HEALTHY`.
+
+- [ ] **Step 3: Cambiar semántica y prosa sin ampliar ejecución**
+
+```ts
+export type SensorStatusResult = {
+    overall: 'READY' | 'DEGRADED' | 'NOT_CONFIGURED';
+    pack: string | null;
+    checks: Record<string, SensorCheck>;
+};
+```
+
+Mantener discovery, resolución, assets, versiones y probes estáticos existentes. La prosa puede describir `registry-certified range` dentro del detalle de compatibilidad, pero headline/summary no dice que el proyecto ejecutó o certificó.
+
+- [ ] **Step 4: Verde, mutación y commit**
+
+Run: `cd cli && npx jest tests/commands/sensors/status.test.ts tests/commands/sensors/status-windows.test.ts tests/commands/sensors/router.test.ts --runInBand`
+
+Expected: PASS. Restaurar temporalmente `HEALTHY`: el test de render debe fallar; volver a `READY`.
+
+```bash
+git add cli/src/commands/sensors/types.ts cli/src/commands/sensors/status.ts cli/src/commands/sensors/index.ts cli/tests/commands/sensors/status*.test.ts cli/tests/commands/sensors/router.test.ts
+git commit -m "fix(sensors): report static readiness without health claims"
+```
+
+### Task 7: Añadir preflight empírico, read-only y accionable
+
+_Requirements: R7, R7.1, R7.2_
+
+**Files:**
+- Modify: `cli/src/commands/preflight/checks.ts`
+- Modify: `cli/src/commands/preflight/index.ts`
+- Modify: `cli/src/commands/sensors/types.ts`
+- Test: `cli/tests/commands/preflight/preflight.test.ts`
+- Test: `cli/tests/integration/preflight-json-pipe.e2e.test.ts`
+
+**Skills:** `test-driven-development`
+
+- [ ] **Step 1: Escribir tests rojos del modo opcional**
+
+```ts
+test('default preflight remains static (R6.2)', async () => {
+    await preflight(validRoot);
+    expect(runSensorsSpy).not.toHaveBeenCalled();
+});
+
+test('verify-sensors requires empirical pass (R7)', async () => {
+    runSensorsSpy.mockResolvedValue({ overall: 'not_certified', sensors: [timedOutLint] });
+    const report = await preflight(validRoot, { verifySensors: true });
+    expect(report.status).toBe('degraded');
+    expect(report.checks).toContainEqual(expect.objectContaining({
+        id: 'sensors-execution', ok: false,
+        detail: expect.stringMatching(/lint.*30000ms.*elapsed.*timeout/i),
+    }));
+});
+
+test('empirical preflight is read-only (R7.2)', async () => {
+    const before = snapshotTree(validRoot);
+    await preflight(validRoot, { verifySensors: true });
+    expect(snapshotTree(validRoot)).toEqual(before);
+});
+```
+
+- [ ] **Step 2: Ejecutar y comprobar rojo**
+
+Run: `cd cli && npx jest tests/commands/preflight/preflight.test.ts tests/integration/preflight-json-pipe.e2e.test.ts --runInBand`
+
+Expected: FAIL porque no existe `verifySensors` ni el check `sensors-execution`.
+
+- [ ] **Step 3: Implementar opción y check empírico**
+
+```ts
+export type PreflightOptions = { verifySensors?: boolean };
+
+export async function checkSensorExecution(cwd: string): Promise<PreflightCheck> {
+    const output = await runSensors({ cwd, all: true });
+    if (output.overall === 'pass') return { id: 'sensors-execution', ok: true, detail: 'all selected sensors completed with pass' };
+    const failed = output.sensors.filter(sensor => sensor.status !== 'pass');
+    return {
+        id: 'sensors-execution', ok: false,
+        detail: renderExecutionFailure(output.overall, failed),
+        remedy: 'diagnose the named sensor; if a healthy progressing run needs longer, set a finite sensor timeout and rerun awm preflight --verify-sensors',
+    };
+}
+```
+
+`preflight(cwd, opts)` agrega el check solo si `opts.verifySensors === true`. Commander registra `.option('--verify-sensors', 'run the complete sensor gate before unattended execution')` y pasa la opción. El render usa nombre, status, timeout efectivo, elapsed y reason sanitizado; no vuelca stdout/stderr crudo.
+
+- [ ] **Step 4: Probar el fallo real de exit 2/unparseable y la ausencia de diff**
+
+El e2e crea un comando v2 estructurado que termina 2 sin findings parseables, ejecuta `dist/src/index.js preflight --verify-sensors --json --cwd "$FIXTURE_ROOT"`, afirma exit 1, JSON válido, `status: degraded`, sensor/reason, y tree snapshot idéntico.
+
+- [ ] **Step 5: Verde, mutación y commit**
+
+Run: `cd cli && npm run build && npx jest tests/commands/preflight/preflight.test.ts tests/integration/preflight-json-pipe.e2e.test.ts --runInBand`
+
+Expected: PASS. Cambiar temporalmente la condición a `overall !== 'fail'`: el caso `not_certified` debe fallar; restaurar.
+
+```bash
+git add cli/src/commands/preflight cli/src/commands/sensors/types.ts cli/tests/commands/preflight/preflight.test.ts cli/tests/integration/preflight-json-pipe.e2e.test.ts
+git commit -m "feat(preflight): verify sensor execution before handoff"
+```
+
+### Task 8: Documentar, verificar y publicar primero el CLI
+
+_Requirements: R3, R3.1, R3.2, R3.4, R4.1, R4.2, R4.3, R4.4, R4.5, R4.6, R5, R5.1, R6, R6.1, R6.2, R7, R7.1, R7.2, R10, R10.1, R10.2_
+
+**Files:**
+- Modify: `docs/cli-reference.md`
+- Modify: `docs/configuration.md`
+- Modify: `docs/testing/core-acceptance.md`
+- Modify: `docs/testing/os-matrix.md`
+- Modify: `CHANGELOG.md`
+- Test: `cli/tests/integration/sensor-compatibility.e2e.test.ts`
+- Test: `cli/tests/structural/support-matrix-is-current.test.ts`
+
+**Skills:** `test-driven-development`, `requesting-code-review`, `verification-before-completion`
+
+- [ ] **Step 1: Escribir/actualizar aceptación ejecutable**
+
+`CORE-12` y `CORE-13` ejecutan y verifican: legacy sin campos nuevos; v2 sin campos nuevos; v2 timeout proyecto/pack/fallback; changed supported/unsupported/empty/Git error; cuatro verdicts/exit; status READY estático; preflight empírico read-only. `os-matrix.md` repite el contrato en Ubuntu, macOS y Windows nativo y comprueba que v2 no usa shell.
+
+- [ ] **Step 2: Actualizar documentación canónica**
+
+Documentar JSON aditivo con `execution.timeoutMs`, `timeoutSource`, `elapsedMs`, requested/effective scope, files/reason; tabla de exits; diferencia `status` vs `preflight --verify-sensors`; precedencia y ejemplo de timeout finito:
+
+```json
+{
+  "schemaVersion": 2,
+  "pack": "js-ts",
+  "sensors": {
+    "test": { "enabled": true, "fast": false, "timeout": 600000, "variantId": "npm-script" }
+  }
+}
+```
+
+Aclarar que el ejemplo omite campos materializados solo para mostrar el override, no es un manifest completo copiables.
+
+- [ ] **Step 3: Ejecutar suites completas y sensores**
+
+```bash
+cd cli
+npm ci
+npm run typecheck
+npm run lint
+npm run depcheck
+npm test -- --runInBand
+npm run build
+cd ..
+awm sensors run
+git diff --check
+```
+
+Expected: todos exit 0 y `awm sensors run` produce `overall: pass`. Confirmar que `cli/.awm/ledger/` sigue no rastreado y no staged.
+
+- [ ] **Step 4: Ejecutar mutaciones obligatorias y review**
+
+Repetir las mutaciones discriminantes de T1–T7 contra sus tests exactos. Invocar `requesting-code-review`; corregir cada hallazgo con test rojo/verde y commit separado cuando cambie comportamiento.
+
+- [ ] **Step 5: Commit documental y PR CLI**
+
+```bash
+git add docs/cli-reference.md docs/configuration.md docs/testing/core-acceptance.md docs/testing/os-matrix.md CHANGELOG.md cli/tests/integration/sensor-compatibility.e2e.test.ts
+git commit -m "docs(sensors): define empirical execution readiness"
+git push -u origin fix/issues-95-98-sensor-gate-honesty
+gh pr create --repo Kodria/agentic-workflow --base main --head fix/issues-95-98-sensor-gate-honesty --title "fix(sensors): make execution gates conclusive" --body "Fixes #95. Fixes #96. Fixes #97. Coordinates the CLI prerequisite for #98."
+gh pr checks --repo Kodria/agentic-workflow --watch
+```
+
+Expected: PR real y matriz Linux/macOS/Windows verde.
+
+- [ ] **Step 6: Esperar merge y observar la publicación estable**
+
+Tras merge autorizado, observar `.github/workflows/release.yml`, no ejecutar `npm publish` manual:
+
+```bash
+gh run list --repo Kodria/agentic-workflow --workflow release.yml --limit 5
+npm view agentic-workflow-manager version
+```
+
+Guardar `CLI_RELEASE_VERSION` solo cuando npm muestre una versión posterior a 8.1.4 que contenga el merge. Crear `ACCEPTANCE_PREFIX=$(mktemp -d)`, verificarla con `npm install --prefix "$ACCEPTANCE_PREFIX" "agentic-workflow-manager@${CLI_RELEASE_VERSION}"` y ejecutar `--version`, `sensors run`, `status` y `preflight --verify-sensors` sobre fixtures legacy/v2. No avanzar a T9 sin esta evidencia.
+
+### Task 9: Publicar el contrato de registry y scoping recomendado
+
+_Requirements: R3.1, R3.4, R4, R4.1, R4.2, R4.6, R10, R10.1, R10.2_
+
+**Files:**
+- Modify: `../awm-baseline-registry/sensor-packs/pack.schema.json`
+- Modify: `../awm-baseline-registry/sensor-packs/README.md`
+- Modify: `../awm-baseline-registry/sensor-packs/js-ts/pack.json`
+- Modify: `../awm-baseline-registry/tests/support/sensor-pack-v2-validator.mjs`
+- Modify: `../awm-baseline-registry/tests/sensor-pack-shape.test.mjs`
+- Modify: `../awm-baseline-registry/tests/sensor-pack-schema-equivalence.test.mjs`
+- Modify: `../awm-baseline-registry/tests/sensor-pack-js-ts-variants.test.mjs`
+
+**Skills:** `test-driven-development`
+
+- [ ] **Step 1: Crear rama limpia del registry y verificar base**
+
+```bash
+git -C ../awm-baseline-registry fetch origin
+git -C ../awm-baseline-registry switch -c fix/issues-95-98-sensor-gate-honesty origin/main
+git -C ../awm-baseline-registry rev-parse HEAD
+```
+
+Expected: `1fb1d0df90c92031c5ca6fad4c79148bab1a3528` o un `origin/main` posterior revisado antes de editar; worktree limpio.
+
+- [ ] **Step 2: Escribir tests rojos de equivalencia parser/schema**
+
+```js
+test('accepts timeout and shell-free changedCommand identically (R3.1, R4)', () => {
+  const candidate = structuredClone(validPack);
+  candidate.sensors.lint.timeout = 30000;
+  candidate.sensors.lint.variants[0].changedCommand = {
+    executable: 'eslint', resolution: 'node-modules-bin',
+    args: ['--format', 'json', '{files}'],
+    fileInput: { placeholder: '{files}', extensions: ['.js', '.jsx', '.ts', '.tsx'] },
+  };
+  assert.equal(validateWithSchema(candidate), true);
+  assert.doesNotThrow(() => validatePackV2(candidate, 'fixture'));
+});
+```
+
+Agregar corpus inválido para timeout 0/fraccional/unsafe y changedCommand con shell, placeholder embebido/duplicado o extensions vacío; JSON Schema y parser espejo deben rechazar exactamente el mismo corpus.
+
+- [ ] **Step 3: Implementar schema/parser y declarar el pack**
+
+Añadir `timeout` entero mínimo 1 al sensor y `changedCommand` con el mismo `$defs.structuredCommand`; reforzar que `fileInput` implica exactamente un `{files}` mediante validator semántico. En `js-ts/pack.json`, declarar timeouts finitos por costo y `changedCommand` únicamente para sensores file-local realmente seguros (lint y security); typecheck/test/depcheck/format siguen full y lo reportará el CLI.
+
+- [ ] **Step 4: Verificar y probar mutación**
+
+Run:
+
+```bash
+cd ../awm-baseline-registry
+node tests/sensor-pack-shape.test.mjs
+node tests/sensor-pack-schema-equivalence.test.mjs
+node tests/sensor-pack-js-ts-variants.test.mjs
+```
+
+Expected: PASS. Quitar temporalmente un `{files}` o poner timeout 0 en el pack productivo: el test exacto debe fallar; restaurar.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C ../awm-baseline-registry add sensor-packs/pack.schema.json sensor-packs/README.md sensor-packs/js-ts/pack.json tests/support/sensor-pack-v2-validator.mjs tests/sensor-pack-shape.test.mjs tests/sensor-pack-schema-equivalence.test.mjs tests/sensor-pack-js-ts-variants.test.mjs
+git -C ../awm-baseline-registry commit -m "feat(sensors): add bounded changed execution contracts"
+```
+
+### Task 10: Corregir el overlay ESLint 8 y certificar TypeScript real
+
+_Requirements: R9, R9.1, R9.2, R9.3_
+
+**Files:**
+- Modify: `../awm-baseline-registry/sensor-packs/js-ts/eslint.config.awm.cjs`
+- Modify: `../awm-baseline-registry/tests/fixtures/eslint-certification/eslint-8/package.json`
+- Modify: `../awm-baseline-registry/tests/fixtures/eslint-certification/eslint-8/package-lock.json`
+- Create: `../awm-baseline-registry/tests/fixtures/eslint-certification/eslint-8/.eslintrc.js`
+- Create: `../awm-baseline-registry/tests/fixtures/eslint-certification/eslint-8/tsconfig.json`
+- Create: `../awm-baseline-registry/tests/fixtures/eslint-certification/eslint-8/src/clean.ts`
+- Create: `../awm-baseline-registry/tests/fixtures/eslint-certification/eslint-8/scripts/unused.js`
+- Create: `../awm-baseline-registry/tests/fixtures/eslint-certification/eslint-8/dist/generated.js`
+- Modify: `../awm-baseline-registry/tests/sensor-pack-eslint-semantics.test.mjs`
+- Modify: `../awm-baseline-registry/tests/sensor-pack-eslint.test.mjs`
+- Modify: `../awm-baseline-registry/tests/sensor-pack-certification.test.mjs`
+
+**Skills:** `test-driven-development`, `verification-before-completion`
+
+- [ ] **Step 1: Convertir el fixture ESLint 8 en un proyecto JS/TS real**
+
+Pinnear `eslint@8.57.1`, `@typescript-eslint/parser` y `@typescript-eslint/eslint-plugin` compatibles. `.eslintrc.js` habilita parser/plugin y `@typescript-eslint/no-unused-vars` para `*.ts`, deshabilitando base `no-unused-vars`/`no-undef` allí. `clean.ts` usa tipos válidos; `scripts/unused.js` contiene una variable JS sin uso; `dist/generated.js` contiene sintaxis que produciría parse noise si no fuera ignorada.
+
+- [ ] **Step 2: Escribir certificación roja con proceso real**
+
+```js
+test('eslint 8 overlay preserves TS rules, ignores output, and keeps JS rules (R9-R9.3)', () => {
+  const run = spawnSync(eslintBin, ['.', '--config', copiedOverlay, '--format', 'json'], {
+    cwd: fixture, encoding: 'utf8', env: { ...process.env, ESLINT_USE_FLAT_CONFIG: 'false' }, shell: false,
+  });
+  assert.ok(run.status === 0 || run.status === 1, `unexpected eslint exit ${run.status}: ${run.stderr}`);
+  const report = JSON.parse(run.stdout);
+  assert.equal(report.some(entry => entry.filePath.endsWith('clean.ts') && entry.messages.some(m => ['no-undef', 'no-unused-vars'].includes(m.ruleId))), false);
+  assert.equal(report.some(entry => /[\\/]dist[\\/]/.test(entry.filePath)), false);
+  assert.equal(report.some(entry => entry.filePath.endsWith(path.join('scripts', 'unused.js')) && entry.messages.some(m => m.ruleId === 'no-unused-vars')), true);
+});
+```
+
+- [ ] **Step 3: Comprobar que el asset publicado reproduce #98**
+
+Run: `cd ../awm-baseline-registry && node tests/sensor-pack-certification.test.mjs`
+
+Expected antes del fix: FAIL; exit 2, false positives TS o ruido de `dist` reproduce #98.
+
+- [ ] **Step 4: Implementar overlay seguro**
+
+```js
+module.exports = {
+  extends: ['./.eslintrc.js'],
+  ignorePatterns: ['dist/', 'build/', 'coverage/'],
+  rules: { 'no-unreachable': 'error' },
+  overrides: [{
+    files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
+    rules: {
+      'no-unused-vars': ['error', { vars: 'all', args: 'after-used' }],
+      'no-undef': 'error',
+    },
+  }],
+};
+```
+
+No incluir `scripts/` en ignores. No reactivar reglas base dentro de una override TS.
+
+- [ ] **Step 5: Verde, mutación y commit**
+
+Run:
+
+```bash
+cd ../awm-baseline-registry
+node tests/sensor-pack-eslint-semantics.test.mjs
+node tests/sensor-pack-eslint.test.mjs
+node tests/sensor-pack-certification.test.mjs
+```
+
+Expected: PASS. Reponer temporalmente `no-undef`/`no-unused-vars` globales y retirar `dist/`: la certificación debe fallar; restaurar.
+
+```bash
+git -C ../awm-baseline-registry add sensor-packs/js-ts/eslint.config.awm.cjs tests/fixtures/eslint-certification/eslint-8 tests/sensor-pack-eslint-semantics.test.mjs tests/sensor-pack-eslint.test.mjs tests/sensor-pack-certification.test.mjs
+git -C ../awm-baseline-registry commit -m "fix(eslint): preserve TypeScript-aware project rules"
+```
+
+### Task 11: Convertir el preflight empírico y el non-pass en gates del workflow
+
+_Requirements: R7.3, R8, R8.1_
+
+**Files:**
+- Modify: `../awm-baseline-registry/skills/writing-plans/SKILL.md`
+- Modify: `../awm-baseline-registry/skills/executing-plans/SKILL.md`
+- Modify: `../awm-baseline-registry/skills/subagent-driven-development/SKILL.md`
+- Modify: `../awm-baseline-registry/skills/verification-before-completion/SKILL.md`
+- Modify: `../awm-baseline-registry/skills/writing-plans/plan-document-reviewer-prompt.md`
+- Create: `../awm-baseline-registry/tests/r8-sensor-gate-contract.test.mjs`
+- Modify: `../awm-baseline-registry/scripts/check-skill-version-bumps.sh`
+
+**Skills:** `test-driven-development`, `writing-skills`, `verification-before-completion`
+
+- [ ] **Step 1: Escribir tests semánticos rojos, no greps genéricos**
+
+```js
+test('writing-plans requires empirical preflight before unattended handoff (R7.3)', () => {
+  const text = read('skills/writing-plans/SKILL.md');
+  assert.match(text, /Modo de ejecución:\*\* `desatendido`[\s\S]*awm preflight --verify-sensors/);
+  assert.match(text, /non-zero[\s\S]*stop[\s\S]*Do not offer the execution choice/i);
+});
+
+for (const file of EXECUTION_SKILLS) test(`${file} stops every non-pass before progression (R8)`, () => {
+  const text = read(file);
+  assert.match(text, /pass.*only.*continue|continue.*only.*pass/is);
+  assert.match(text, /fail.*not_certified.*skipped/is);
+  assert.match(text, /do not mark.*complete|must not.*QA|must not.*PR/is);
+});
+
+test('timeout remediation stays finite, justified, and conclusive (R8.1)', () => {
+  const text = read('skills/verification-before-completion/SKILL.md');
+  assert.match(text, /healthy progressing process/is);
+  assert.match(text, /finite.*override/is);
+  assert.match(text, /rerun.*pass|conclusive rerun/is);
+});
+```
+
+- [ ] **Step 2: Ejecutar y comprobar rojo**
+
+Run: `cd ../awm-baseline-registry && node tests/r8-sensor-gate-contract.test.mjs`
+
+Expected: FAIL porque `writing-plans` solo invoca preflight estático y los skills no enumeran todos los non-pass.
+
+- [ ] **Step 3: Actualizar skills y autoridad**
+
+En `writing-plans`, mantener `awm preflight` estático para modo interactivo y exigir adicionalmente `awm preflight --verify-sensors` justo antes del handoff cuando el plan dice `desatendido`. Non-zero bloquea el handoff mientras el humano está presente.
+
+En ejecución/verificación: correr `awm sensors run`; continuar solo con `overall: pass`. Ante `fail | not_certified | skipped`, invocar `systematic-debugging`, no marcar checkbox/commit como completo, no avanzar a review/QA/retro/PR. Si la causa es timeout, distinguir proceso colgado de proceso saludable que progresa; solo el segundo permite editar un timeout finito con justificación en el plan/commit y exige rerun `pass`.
+
+- [ ] **Step 4: Bump de skills y prueba discriminante**
+
+Incrementar la versión minor de cada skill modificada y actualizar el contrato de version bumps. Run:
+
+```bash
+cd ../awm-baseline-registry
+node tests/r8-sensor-gate-contract.test.mjs
+bash scripts/check-skill-version-bumps.sh origin/main HEAD
+```
+
+Expected: PASS. Retirar temporalmente `not_certified` de una skill de ejecución: el test exacto debe fallar; restaurar.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C ../awm-baseline-registry add skills/writing-plans skills/executing-plans skills/subagent-driven-development skills/verification-before-completion tests/r8-sensor-gate-contract.test.mjs scripts/check-skill-version-bumps.sh
+git -C ../awm-baseline-registry commit -m "fix(workflow): stop unattended work on inconclusive gates"
+```
+
+### Task 12: Certificar y publicar el registry coordinado
+
+_Requirements: R3.1, R4, R7.3, R8, R8.1, R9, R9.1, R9.2, R9.3, R10.1, R10.2_
+
+**Files:**
+- Modify: `../awm-baseline-registry/awm-registry.json`
+- Modify: `../awm-baseline-registry/catalog.json`
+- Modify: `../awm-baseline-registry/CHANGELOG.md`
+- Modify: `../awm-baseline-registry/.github/workflows/sensor-pack-certification.yml`
+- Test: `../awm-baseline-registry/tests/sensor-pack-certification.test.mjs`
+- Test: `../awm-baseline-registry/tests/r8-sensor-gate-contract.test.mjs`
+
+**Skills:** `test-driven-development`, `requesting-code-review`, `verification-before-completion`
+
+- [ ] **Step 1: Fijar la versión mínima al CLI publicado real**
+
+Editar `awm-registry.json.minCliVersion` con `${CLI_RELEASE_VERSION}` observado en T8, no con una versión anticipada. Actualizar catálogo/changelog mediante el patrón vigente del registry; el cambio breaking debe producir el siguiente major/minor que determine su workflow, sin tag manual.
+
+- [ ] **Step 2: Ejecutar todos los gates locales del registry**
+
+```bash
+cd ../awm-baseline-registry
+node scripts/validate-portability.mjs
+node tests/validate-portability.test.mjs
+node tests/codex-session-start.test.mjs
+node tests/session-start.test.mjs
+node tests/sensor-pack-shape.test.mjs
+node tests/sensor-pack-schema-equivalence.test.mjs
+node tests/sensor-pack-js-ts-variants.test.mjs
+node tests/sensor-pack-eslint-semantics.test.mjs
+node tests/sensor-pack-eslint.test.mjs
+node tests/sensor-pack-certification.test.mjs
+node tests/sensor-pack-support-matrix.test.mjs
+node tests/r8-sensor-gate-contract.test.mjs
+```
+
+Expected: todos exit 0, incluyendo proceso real ESLint 8. Ejecutar `git diff --check` y confirmar que no hay rutas temporales, node_modules ni outputs generados staged.
+
+- [ ] **Step 3: Review y PR registry**
+
+Invocar `requesting-code-review`, corregir todos los hallazgos con TDD y volver a correr la suite completa. Luego:
+
+```bash
+git -C ../awm-baseline-registry add sensor-packs tests skills scripts .github awm-registry.json catalog.json CHANGELOG.md
+git -C ../awm-baseline-registry commit -m "feat(sensors)!: publish conclusive execution gates"
+git -C ../awm-baseline-registry push -u origin fix/issues-95-98-sensor-gate-honesty
+gh pr create --repo Kodria/awm-baseline-registry --base main --head fix/issues-95-98-sensor-gate-honesty --title "feat(sensors)!: publish conclusive execution gates" --body "Completes the registry portion of Kodria/agentic-workflow#98. Requires agentic-workflow-manager >= ${CLI_RELEASE_VERSION}."
+gh pr checks --repo Kodria/awm-baseline-registry --watch
+```
+
+Expected: PR real y workflows verdes; ninguna publicación antes del CLI.
+
+- [ ] **Step 4: Observar merge y auto-tag**
+
+Tras merge autorizado, obtener el tag nuevo con `gh release list --repo Kodria/awm-baseline-registry --limit 5` y verificar que su commit contiene el PR y `minCliVersion=${CLI_RELEASE_VERSION}`. Guardarlo como `REGISTRY_RELEASE_TAG`.
+
+### Task 13: Aceptación publicada, evidencia por issue y reconciliación final
+
+_Requirements: R1, R1.1, R1.2, R1.3, R2, R2.1, R3, R3.1, R3.2, R3.3, R3.4, R4, R4.1, R4.2, R4.3, R4.4, R4.5, R4.6, R5, R5.1, R5.2, R6, R6.1, R6.2, R7, R7.1, R7.2, R7.3, R8, R8.1, R9, R9.1, R9.2, R9.3, R10, R10.1, R10.2_
+
+**Files:**
+- Create: `docs/research/sensor-gate-honesty/published-acceptance.json`
+- Create: `docs/research/sensor-gate-honesty/README.md`
+- Modify: `docs/plans/2026-08-21-sensor-gate-honesty-plan.md`
+
+**Skills:** `test-driven-development`, `requesting-code-review`, `verification-before-completion`
+
+- [ ] **Step 1: Instalar únicamente artefactos publicados en aislamiento**
+
+Crear directorios con `mktemp -d`, instalar `agentic-workflow-manager@${CLI_RELEASE_VERSION}` con un prefix temporal y clonar/checkout exacto `${REGISTRY_RELEASE_TAG}`. No tocar el home real ni `~/.awm`. Registrar versión, tag y hashes, no paths temporales.
+
+- [ ] **Step 2: Ejecutar matriz publicada legacy/v2**
+
+Casos mínimos: legacy baseline, v2 baseline, timeout project/pack/fallback, timeout inválido antes de spawn, changed literal/unsupported/empty/Git error/mixed, cuatro verdicts/exit, status READY sin ejecutar, preflight empírico exit-2 read-only, ESLint 8 TS/JS/generated. Cada caso guarda argv, verdict semántico, process exit y hash del fixture sanitizado.
+
+- [ ] **Step 3: Confirmar evidencia nativa 3-OS**
+
+Enlazar las corridas verdes de los PRs/workflows para Ubuntu, macOS y Windows. No sustituir Windows nativo con Wine ni inferir portabilidad desde Linux. `published-acceptance.json` contiene:
+
+```js
+const acceptance = {
+  cliVersion: process.env.CLI_RELEASE_VERSION,
+  registryTag: process.env.REGISTRY_RELEASE_TAG,
+  issues: [95, 96, 97, 98],
+  platforms: { linux: 'pass', macos: 'pass', windows: 'pass' },
+  verdict: 'pass',
+};
+if (!/^\d+\.\d+\.\d+$/.test(acceptance.cliVersion ?? '')) throw new Error('CLI_RELEASE_VERSION must be an exact stable semver');
+if (!/^v\d+\.\d+\.\d+$/.test(acceptance.registryTag ?? '')) throw new Error('REGISTRY_RELEASE_TAG must be an exact v-prefixed tag');
+```
+
+Serializar este objeto con newline final. El test de aceptación vuelve a validar ambos formatos y rechaza claves ausentes o valores diferentes de `pass` en la matriz.
+
+- [ ] **Step 4: Reconciliar ambos repos**
+
+```bash
+git status --short --branch
+git diff origin/main...HEAD --check
+git -C ../awm-baseline-registry status --short --branch
+git -C ../awm-baseline-registry diff origin/main...HEAD --check
+cd cli && npm ci && npm run typecheck && npm run lint && npm run depcheck && npm test -- --runInBand && npm run build
+cd ../../awm-baseline-registry && node tests/sensor-pack-certification.test.mjs && node tests/r8-sensor-gate-contract.test.mjs
+```
+
+Expected: solo archivos del alcance, suites verdes y ledger del usuario sin stage.
+
+- [ ] **Step 5: Persistir aceptación y comentar issues con evidencia específica**
+
+```bash
+git add docs/research/sensor-gate-honesty docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+git commit -m "docs(sensors): record published gate acceptance"
+```
+
+Comentar #95 con baseline/changed/timeout y PR CLI; #96 con tabla verdict/exit; #97 con status/preflight real; #98 con PR/tag registry y certificación ESLint 8. Cerrar cada issue únicamente si sus criterios están demostrados por links y artefactos publicados; dejar baton exacto para cualquiera que dependa de un estado externo aún pendiente.
+
+- [ ] **Step 6: Review final y transferencia automática**
+
+Invocar `requesting-code-review`, corregir todos los hallazgos, ejecutar `awm preflight --verify-sensors` y `awm sensors run` con `overall: pass`, marcar solo checkboxes realmente completados y transferir a `post-implementation-qa`, `harness-retro` y `finishing-a-development-branch`. Los markers de QA/retro los agregan sus skills, nunca este paso.
+
+## Matriz de trazabilidad
+
+| Req | Task(s) | Test(s) que demuestra el requisito |
+|---|---|---|
+| R1 | T2, T3, T4, T13 | `prepare.test.ts` adapta ambos kinds; `run.test.ts` ejecuta ambos por `executePrepared`; matriz publicada legacy/v2 |
+| R1.1 | T2, T4, T13 | `prepare.test.ts` prueba que command del manifest v2 no se despacha y sí la variante viva; aceptación v2 publicada |
+| R1.2 | T2, T4, T13 | `run.test.ts` espía una lectura de baseline, diff y base por corrida; aceptación mixed |
+| R1.3 | T2, T4, T13 | `prepare.test.ts` afirma error y cero Git/spawn para changed+capture; CLI e2e publicado |
+| R2 | T3, T4, T13 | `baseline.test.ts` suprime finding estructurado exacto; e2e baseline v2 |
+| R2.1 | T3, T4, T13 | `baseline.test.ts` tabula inconclusive/skipped sin conversión; aceptación non-pass |
+| R3 | T1, T8, T13 | `manifest.test.ts` acepta/preserva timeout v2; core acceptance y manifest publicado |
+| R3.1 | T1, T2, T8, T9, T12, T13 | `prepare.test.ts` tabla project/pack/fallback; schema/pack tests; aceptación publicada |
+| R3.2 | T3, T8, T13 | `run-inconclusive.test.ts` afirma timeout source/value/elapsed; JSON publicado |
+| R3.3 | T1, T2, T13 | corpus inválido de `manifest.test.ts` y spy cero procesos; fixture publicado inválido |
+| R3.4 | T1, T3, T8, T9, T13 | `timeout.ts`/`exec.test.ts` rechazan no positivo y siempre programan deadline; schema y aceptación |
+| R4 | T1, T9, T13 | corpus `contract.test.ts` + `sensor-pack-schema-equivalence.test.mjs`; pack publicado |
+| R4.1 | T2, T8, T9, T13 | `prepare.test.ts` conserva espacio/$ como argv separados; OS matrix y aceptación |
+| R4.2 | T2, T4, T8, T9, T13 | `prepare.test.ts` full+reason sin changedCommand; core acceptance |
+| R4.3 | T2, T4, T8, T13 | `run-changed.test.ts` Git error → full + evidence; aceptación no-git |
+| R4.4 | T2, T4, T8, T13 | `run-changed.test.ts` synthetic pass changed/files:0 sin spawn; aceptación empty |
+| R4.5 | T4, T8, T13 | `run-changed.test.ts` mixed empty lint + failing full test → global fail; aceptación mixed |
+| R4.6 | T2, T4, T8, T9, T13 | `prepare.test.ts`/`run-changed.test.ts` requested/effective/reason; JSON publicado |
+| R5 | T5, T8, T13 | tabla de `index.test.ts` y proceso e2e para los cuatro verdicts |
+| R5.1 | T4, T5, T13 | e2e parsea JSON distinto para fail/not_certified/skipped con exit 1 |
+| R5.2 | T3, T4, T5, T13 | `run-inconclusive.test.ts` tabla timeout/spawn/overflow/parse/exit; aceptación exit 2 |
+| R6 | T6, T8, T13 | `status.test.ts` render READY sin HEALTHY/project certified; binario publicado |
+| R6.1 | T6, T8, T13 | tabla READY/DEGRADED/NOT_CONFIGURED en `status.test.ts`; core acceptance |
+| R6.2 | T6, T7, T8, T13 | spies cero commands en status/default preflight; aceptación publicada |
+| R7 | T7, T8, T13 | `preflight.test.ts` pass/non-pass; e2e `--verify-sensors` publicado |
+| R7.1 | T3, T7, T8, T13 | `preflight.test.ts` verifica nombre/timeout/elapsed/reason para cada non-pass |
+| R7.2 | T7, T8, T13 | snapshot de tree unit/e2e antes/después; aceptación publicada |
+| R7.3 | T11, T12, T13 | `r8-sensor-gate-contract.test.mjs` ancla modo desatendido y preflight empírico; tag publicado |
+| R8 | T11, T12, T13 | `r8-sensor-gate-contract.test.mjs` enumera todos los non-pass y prohíbe progreso/QA/PR |
+| R8.1 | T11, T12, T13 | test específico de proceso saludable, override finito justificado y rerun concluyente |
+| R9 | T10, T12, T13 | certificación real afirma ausencia de base TS false positives/crash |
+| R9.1 | T10, T12, T13 | fixture `scripts/unused.js` exige finding base `no-unused-vars` |
+| R9.2 | T10, T12, T13 | fixture excluye dist/build/coverage y conserva scripts |
+| R9.3 | T10, T12, T13 | `sensor-pack-certification.test.mjs` afirma exit 0/1, JSON válido, TS/JS/generated; aceptación publicada |
+| R10 | T1, T4, T8, T9, T13 | tests legacy y v2 sin campos nuevos + aceptación de ambos manifests publicados |
+| R10.1 | T8, T9, T12, T13 | T9 bloqueado por npm estable; test/manifest fija `minCliVersion`; hashes publicados |
+| R10.2 | T2, T4, T8, T9, T12, T13 | `changed-windows.test.ts`, exec shell:false, CI nativa 3-OS y aceptación enlazada |
+
+## Analyze gate
+
+- Forward: cada requisito R1–R10.2 tiene al menos una task de implementación y una prueba conductual específica.
+- Backward: T1–T13 trazan a requisitos; los pasos de release/aceptación verifican R10.1/R10.2 y no introducen producto nuevo.
+- No hay tasks UI, artifacts UI ni tracks paralelos.
+- Los tipos `TimeoutSource`, `PreparedSensorExecution`, `ExecutionEvidence`, `PreflightOptions` y los campos JSON conservan los mismos nombres en todas las tasks.
+- La aceptación final rechaza tokens de sustitución no resueltos antes de commit.

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -1071,7 +1071,7 @@ _Requirements: R1, R1.1, R1.2, R1.3, R2, R2.1, R3, R3.1, R3.2, R3.3, R3.4, R4, R
 
 Crear directorios con `mktemp -d`, instalar `agentic-workflow-manager@${CLI_RELEASE_VERSION}` con un prefix temporal y clonar/checkout exacto `${REGISTRY_RELEASE_TAG}`. No tocar el home real ni `~/.awm`. Registrar versión, tag y hashes, no paths temporales.
 
-- [ ] **Step 2: Ejecutar matriz publicada legacy/v2**
+- [x] **Step 2: Ejecutar matriz publicada legacy/v2**
 
 Casos mínimos: legacy baseline, v2 baseline, timeout project/pack/fallback, timeout inválido antes de spawn, changed literal/unsupported/empty/Git error/mixed, cuatro verdicts/exit, status READY sin ejecutar, preflight empírico exit-2 read-only, ESLint 8 TS/JS/generated. Cada caso guarda argv, verdict semántico, process exit y hash del fixture sanitizado.
 

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -136,7 +136,7 @@ _Requirements: R3, R3.1, R3.3, R3.4, R4, R10_
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Escribir tests rojos de timeout y changedCommand**
+- [x] **Step 1: Escribir tests rojos de timeout y changedCommand**
 
 ```ts
 test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1000'])('rejects v2 timeout %p before execution (R3.3)', (timeout) => {
@@ -166,13 +166,13 @@ test.each([
 });
 ```
 
-- [ ] **Step 2: Ejecutar el corpus focal y comprobar rojo**
+- [x] **Step 2: Ejecutar el corpus focal y comprobar rojo**
 
 Run: `cd cli && npx jest tests/commands/sensors/compatibility/contract.test.ts tests/commands/sensors/compatibility/manifest.test.ts tests/commands/sensors/init.test.ts --runInBand`
 
 Expected: FAIL porque `timeout` es campo desconocido en v2 y `changedCommand` aún no pertenece a `SensorVariant`.
 
-- [ ] **Step 3: Implementar validación compartida y tipos aditivos**
+- [x] **Step 3: Implementar validación compartida y tipos aditivos**
 
 ```ts
 // compatibility/timeout.ts
@@ -196,7 +196,7 @@ export function resolveTimeout(input: {
 
 Agregar `changedCommand?: StructuredCommand` a `SensorVariant`, `timeout?: number` a `SensorPackSensor` y al sensor de `SensorManifestV2`. `parseVariant` acepta/parsa `changedCommand`; `parseSensor` acepta `timeout`; `parseV2Sensor` acepta `timeout`. Mantener estricto el resto de campos.
 
-- [ ] **Step 4: Preservar el override de proyecto en init**
+- [x] **Step 4: Preservar el override de proyecto en init**
 
 En el objeto v2 materializado de `init.ts`, copiar solo `prior.timeout`:
 
@@ -215,13 +215,13 @@ sensors[name] = {
 
 No copiar `command`, `assets`, formatter ni environment desde el manifest previo.
 
-- [ ] **Step 5: Verificar verde y mutación discriminante**
+- [x] **Step 5: Verificar verde y mutación discriminante**
 
 Run: `cd cli && npx jest tests/commands/sensors/compatibility/contract.test.ts tests/commands/sensors/compatibility/manifest.test.ts tests/commands/sensors/init.test.ts --runInBand`
 
 Expected: PASS. Luego retirar temporalmente la copia de `prior.timeout`, ejecutar el test de preservación y observar FAIL; restaurar y obtener PASS.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add cli/src/commands/sensors/compatibility cli/src/commands/sensors/init.ts cli/tests/commands/sensors/compatibility cli/tests/commands/sensors/init.test.ts

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -242,7 +242,7 @@ _Requirements: R1, R1.1, R1.2, R1.3, R3.1, R4.1, R4.2, R4.3, R4.4, R4.6, R10.2_
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Escribir tests rojos del adaptador y de scope literal**
+- [x] **Step 1: Escribir tests rojos del adaptador y de scope literal**
 
 ```ts
 test('v2 uses the live command and project > pack > fallback timeout (R1.1, R3.1)', () => {
@@ -271,13 +271,13 @@ test('returns a zero-file pass plan without a process (R4.4)', () => {
 });
 ```
 
-- [ ] **Step 2: Ejecutar tests y comprobar rojo**
+- [x] **Step 2: Ejecutar tests y comprobar rojo**
 
 Run: `cd cli && npx jest tests/commands/sensors/prepare.test.ts tests/commands/sensors/changed.test.ts tests/commands/sensors/changed-windows.test.ts --runInBand`
 
 Expected: FAIL porque `prepareV2Sensor`/`PreparedSensorExecution` no existen.
 
-- [ ] **Step 3: Implementar el contrato de preparación**
+- [x] **Step 3: Implementar el contrato de preparación**
 
 ```ts
 export type PreparedSensorExecution = {
@@ -306,7 +306,7 @@ export function expandFileInput(command: StructuredCommand, files: string[]): St
 
 El input v2 recibe manifest parseado y resolución viva. Solo busca `variantId` en `live.pack`; nunca lee `manifest.command` para dispatch. El adaptador legacy conserva `changedCmd` y el rechazo Win32 actual; ambos adaptadores llaman a `resolveTimeout`.
 
-- [ ] **Step 4: Validar argumentos incompatibles antes de Git/proceso**
+- [x] **Step 4: Validar argumentos incompatibles antes de Git/proceso**
 
 Agregar en el entry de preparación, antes de cargar manifest, baseline o diff:
 
@@ -321,7 +321,7 @@ export function validateRunOptions(opts: RunOptions): void {
 
 El test espía `changedFiles`, `runCommand` y `runStructuredCommand` y afirma cero llamadas ante esa combinación.
 
-- [ ] **Step 5: Verde, mutación y commit**
+- [x] **Step 5: Verde, mutación y commit**
 
 Run: `cd cli && npx jest tests/commands/sensors/prepare.test.ts tests/commands/sensors/changed.test.ts tests/commands/sensors/changed-windows.test.ts --runInBand`
 

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -1014,7 +1014,7 @@ _Requirements: R3.1, R4, R7.3, R8, R8.1, R9, R9.1, R9.2, R9.3, R10.1, R10.2_
 
 **Skills:** `test-driven-development`, `requesting-code-review`, `verification-before-completion`
 
-- [ ] **Step 1: Fijar la versión mínima al CLI publicado real**
+- [x] **Step 1: Fijar la versión mínima al CLI publicado real**
 
 Editar `awm-registry.json.minCliVersion` con `${CLI_RELEASE_VERSION}` observado en T8, no con una versión anticipada. Actualizar catálogo/changelog mediante el patrón vigente del registry; el cambio breaking debe producir el siguiente major/minor que determine su workflow, sin tag manual.
 
@@ -1038,7 +1038,7 @@ node tests/r8-sensor-gate-contract.test.mjs
 
 Expected: todos exit 0, incluyendo proceso real ESLint 8. Ejecutar `git diff --check` y confirmar que no hay rutas temporales, node_modules ni outputs generados staged.
 
-- [ ] **Step 3: Review y PR registry**
+- [x] **Step 3: Review y PR registry**
 
 Invocar `requesting-code-review`, corregir todos los hallazgos con TDD y volver a correr la suite completa. Luego:
 
@@ -1052,7 +1052,7 @@ gh pr checks --repo Kodria/awm-baseline-registry --watch
 
 Expected: PR real y workflows verdes; ninguna publicación antes del CLI.
 
-- [ ] **Step 4: Observar merge y auto-tag**
+- [x] **Step 4: Observar merge y auto-tag**
 
 Tras merge autorizado, obtener el tag nuevo con `gh release list --repo Kodria/awm-baseline-registry --limit 5` y verificar que su commit contiene el PR y `minCliVersion=${CLI_RELEASE_VERSION}`. Guardarlo como `REGISTRY_RELEASE_TAG`.
 
@@ -1067,7 +1067,7 @@ _Requirements: R1, R1.1, R1.2, R1.3, R2, R2.1, R3, R3.1, R3.2, R3.3, R3.4, R4, R
 
 **Skills:** `test-driven-development`, `requesting-code-review`, `verification-before-completion`
 
-- [ ] **Step 1: Instalar únicamente artefactos publicados en aislamiento**
+- [x] **Step 1: Instalar únicamente artefactos publicados en aislamiento**
 
 Crear directorios con `mktemp -d`, instalar `agentic-workflow-manager@${CLI_RELEASE_VERSION}` con un prefix temporal y clonar/checkout exacto `${REGISTRY_RELEASE_TAG}`. No tocar el home real ni `~/.awm`. Registrar versión, tag y hashes, no paths temporales.
 
@@ -1075,7 +1075,7 @@ Crear directorios con `mktemp -d`, instalar `agentic-workflow-manager@${CLI_RELE
 
 Casos mínimos: legacy baseline, v2 baseline, timeout project/pack/fallback, timeout inválido antes de spawn, changed literal/unsupported/empty/Git error/mixed, cuatro verdicts/exit, status READY sin ejecutar, preflight empírico exit-2 read-only, ESLint 8 TS/JS/generated. Cada caso guarda argv, verdict semántico, process exit y hash del fixture sanitizado.
 
-- [ ] **Step 3: Confirmar evidencia nativa 3-OS**
+- [x] **Step 3: Confirmar evidencia nativa 3-OS**
 
 Enlazar las corridas verdes de los PRs/workflows para Ubuntu, macOS y Windows. No sustituir Windows nativo con Wine ni inferir portabilidad desde Linux. `published-acceptance.json` contiene:
 

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -442,7 +442,7 @@ _Requirements: R1, R1.1, R1.2, R1.3, R2, R2.1, R4.3, R4.4, R4.5, R4.6, R5.1, R5.
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Congelar legacy y escribir regresiones v2 rojas**
+- [x] **Step 1: Congelar legacy y escribir regresiones v2 rojas**
 
 ```ts
 test('loads baseline and changed files once for a mixed v2 run (R1.2)', async () => {
@@ -467,13 +467,13 @@ test('git failure runs full and never claims changed scope (R4.3, R4.6)', async 
 });
 ```
 
-- [ ] **Step 2: Comprobar rojo sin alterar los tests legacy**
+- [x] **Step 2: Comprobar rojo sin alterar los tests legacy**
 
 Run: `cd cli && npx jest tests/commands/sensors/run.test.ts tests/commands/sensors/run-changed.test.ts tests/commands/sensors/run-partial.test.ts tests/commands/sensors/run-tool-missing.test.ts tests/commands/sensors/run-is-read-only.test.ts --runInBand`
 
 Expected: tests legacy existentes PASS; nuevos casos v2 FAIL por el early return.
 
-- [ ] **Step 3: Implementar contexto y reducer únicos**
+- [x] **Step 3: Implementar contexto y reducer únicos**
 
 ```ts
 export function reduceVerdict(results: SensorResult[]): RunOutput['overall'] {
@@ -486,17 +486,17 @@ export function reduceVerdict(results: SensorResult[]): RunOutput['overall'] {
 
 `runSensors` ejecuta en este orden: validar opciones → localizar/parsar manifest → cargar baseline una vez → resolver changed/base una vez → resolver live v2 una vez si aplica → preparar todas las entradas → pool común → interpretar/baseline → reducer. Eliminar `runV2Sensor` y el `return` v2 separado. Los synthetic pass/skipped/inconclusive entran al mismo reducer.
 
-- [ ] **Step 4: Asegurar fail-closed y read-only**
+- [x] **Step 4: Asegurar fail-closed y read-only**
 
 La tabla de regresión debe cubrir spawn error, tool missing, timeout limpio, overflow limpio, salida no parseable, variant drift y cero seleccionados. Ninguno puede devolver `pass`. Capturar `git status --porcelain=v1` antes/después del fixture v2 y afirmar igualdad byte a byte.
 
-- [ ] **Step 5: Verde y mutación discriminante**
+- [x] **Step 5: Verde y mutación discriminante**
 
 Run: `cd cli && npx jest tests/commands/sensors/run.test.ts tests/commands/sensors/run-changed.test.ts tests/commands/sensors/run-partial.test.ts tests/commands/sensors/run-tool-missing.test.ts tests/commands/sensors/run-is-read-only.test.ts --runInBand`
 
 Expected: PASS. Reintroducir temporalmente el early return v2 anterior: los casos baseline/changed/mixed deben fallar; restaurar.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add cli/src/commands/sensors/run.ts cli/src/commands/sensors/verdict.ts cli/src/commands/sensors/types.ts cli/tests/commands/sensors

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -348,7 +348,7 @@ _Requirements: R1, R2, R2.1, R3.2, R3.4, R5.2, R7.1_
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Escribir tests rojos de elapsed, baseline v2 y non-pass incompleto**
+- [x] **Step 1: Escribir tests rojos de elapsed, baseline v2 y non-pass incompleto**
 
 ```ts
 test('records bounded execution evidence on timeout (R3.2, R3.4, R7.1)', async () => {
@@ -369,13 +369,13 @@ test.each(['inconclusive', 'skipped'] as const)('baseline never changes %s to pa
 });
 ```
 
-- [ ] **Step 2: Ejecutar focal y comprobar rojo**
+- [x] **Step 2: Ejecutar focal y comprobar rojo**
 
 Run: `cd cli && npx jest tests/commands/sensors/exec.test.ts tests/commands/sensors/baseline.test.ts tests/commands/sensors/run-inconclusive.test.ts --runInBand`
 
 Expected: FAIL por ausencia de `elapsedMs`/`execution` y de `executePrepared`.
 
-- [ ] **Step 3: Medir elapsed en el executor común**
+- [x] **Step 3: Medir elapsed en el executor común**
 
 ```ts
 export type ExecResult = {
@@ -395,7 +395,7 @@ const finish = (extra: Partial<ExecResult>) => {
 
 Los tests mockeados que construyen `ExecResult` añaden `elapsedMs` explícito; no se infiere ni se deja `undefined`.
 
-- [ ] **Step 4: Implementar `executePrepared` e `interpretResult`**
+- [x] **Step 4: Implementar `executePrepared` e `interpretResult`**
 
 `executePrepared` selecciona `runCommand` o `runStructuredCommand` por discriminante y siempre pasa el timeout validado. `interpretResult` conserva findings parciales, clasifica spawn/timeout/overflow/parse/exit como fail o inconclusive según el contrato actual y adjunta:
 
@@ -413,13 +413,13 @@ const execution = {
 
 Aplicar baseline después de interpretar únicamente `pass`/`fail`; re-exportar `applyBaseline` desde `run.ts` para no romper imports públicos existentes.
 
-- [ ] **Step 5: Verificar y probar mutación**
+- [x] **Step 5: Verificar y probar mutación**
 
 Run: `cd cli && npx jest tests/commands/sensors/exec.test.ts tests/commands/sensors/exec-windows.test.ts tests/commands/sensors/baseline.test.ts tests/commands/sensors/run-inconclusive.test.ts --runInBand`
 
 Expected: PASS. Retirar temporalmente el guard de `inconclusive` en `applyBaseline`: el test R2.1 debe fallar; restaurar.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add cli/src/commands/sensors/result.ts cli/src/commands/sensors/exec.ts cli/src/commands/sensors/run.ts cli/src/commands/sensors/types.ts cli/tests/commands/sensors

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -638,7 +638,7 @@ _Requirements: R7, R7.1, R7.2_
 
 **Skills:** `test-driven-development`
 
-- [ ] **Step 1: Escribir tests rojos del modo opcional**
+- [x] **Step 1: Escribir tests rojos del modo opcional**
 
 ```ts
 test('default preflight remains static (R6.2)', async () => {
@@ -663,13 +663,13 @@ test('empirical preflight is read-only (R7.2)', async () => {
 });
 ```
 
-- [ ] **Step 2: Ejecutar y comprobar rojo**
+- [x] **Step 2: Ejecutar y comprobar rojo**
 
 Run: `cd cli && npx jest tests/commands/preflight/preflight.test.ts tests/integration/preflight-json-pipe.e2e.test.ts --runInBand`
 
 Expected: FAIL porque no existe `verifySensors` ni el check `sensors-execution`.
 
-- [ ] **Step 3: Implementar opción y check empírico**
+- [x] **Step 3: Implementar opción y check empírico**
 
 ```ts
 export type PreflightOptions = { verifySensors?: boolean };
@@ -688,11 +688,11 @@ export async function checkSensorExecution(cwd: string): Promise<PreflightCheck>
 
 `preflight(cwd, opts)` agrega el check solo si `opts.verifySensors === true`. Commander registra `.option('--verify-sensors', 'run the complete sensor gate before unattended execution')` y pasa la opción. El render usa nombre, status, timeout efectivo, elapsed y reason sanitizado; no vuelca stdout/stderr crudo.
 
-- [ ] **Step 4: Probar el fallo real de exit 2/unparseable y la ausencia de diff**
+- [x] **Step 4: Probar el fallo real de exit 2/unparseable y la ausencia de diff**
 
 El e2e crea un comando v2 estructurado que termina 2 sin findings parseables, ejecuta `dist/src/index.js preflight --verify-sensors --json --cwd "$FIXTURE_ROOT"`, afirma exit 1, JSON válido, `status: degraded`, sensor/reason, y tree snapshot idéntico.
 
-- [ ] **Step 5: Verde, mutación y commit**
+- [x] **Step 5: Verde, mutación y commit**
 
 Run: `cd cli && npm run build && npx jest tests/commands/preflight/preflight.test.ts tests/integration/preflight-json-pipe.e2e.test.ts --runInBand`
 

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -1071,7 +1071,7 @@ _Requirements: R1, R1.1, R1.2, R1.3, R2, R2.1, R3, R3.1, R3.2, R3.3, R3.4, R4, R
 
 Crear directorios con `mktemp -d`, instalar `agentic-workflow-manager@${CLI_RELEASE_VERSION}` con un prefix temporal y clonar/checkout exacto `${REGISTRY_RELEASE_TAG}`. No tocar el home real ni `~/.awm`. Registrar versión, tag y hashes, no paths temporales.
 
-- [x] **Step 2: Ejecutar matriz publicada legacy/v2**
+- [ ] **Step 2: Ejecutar matriz publicada legacy/v2**
 
 Casos mínimos: legacy baseline, v2 baseline, timeout project/pack/fallback, timeout inválido antes de spawn, changed literal/unsupported/empty/Git error/mixed, cuatro verdicts/exit, status READY sin ejecutar, preflight empírico exit-2 read-only, ESLint 8 TS/JS/generated. Cada caso guarda argv, verdict semántico, process exit y hash del fixture sanitizado.
 

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -718,11 +718,11 @@ _Requirements: R3, R3.1, R3.2, R3.4, R4.1, R4.2, R4.3, R4.4, R4.5, R4.6, R5, R5.
 
 **Skills:** `test-driven-development`, `requesting-code-review`, `verification-before-completion`
 
-- [ ] **Step 1: Escribir/actualizar aceptación ejecutable**
+- [x] **Step 1: Escribir/actualizar aceptación ejecutable**
 
 `CORE-12` y `CORE-13` ejecutan y verifican: legacy sin campos nuevos; v2 sin campos nuevos; v2 timeout proyecto/pack/fallback; changed supported/unsupported/empty/Git error; cuatro verdicts/exit; status READY estático; preflight empírico read-only. `os-matrix.md` repite el contrato en Ubuntu, macOS y Windows nativo y comprueba que v2 no usa shell.
 
-- [ ] **Step 2: Actualizar documentación canónica**
+- [x] **Step 2: Actualizar documentación canónica**
 
 Documentar JSON aditivo con `execution.timeoutMs`, `timeoutSource`, `elapsedMs`, requested/effective scope, files/reason; tabla de exits; diferencia `status` vs `preflight --verify-sensors`; precedencia y ejemplo de timeout finito:
 
@@ -738,7 +738,7 @@ Documentar JSON aditivo con `execution.timeoutMs`, `timeoutSource`, `elapsedMs`,
 
 Aclarar que el ejemplo omite campos materializados solo para mostrar el override, no es un manifest completo copiables.
 
-- [ ] **Step 3: Ejecutar suites completas y sensores**
+- [x] **Step 3: Ejecutar suites completas y sensores**
 
 ```bash
 cd cli
@@ -755,7 +755,7 @@ git diff --check
 
 Expected: todos exit 0 y `awm sensors run` produce `overall: pass`. Confirmar que `cli/.awm/ledger/` sigue no rastreado y no staged.
 
-- [ ] **Step 4: Ejecutar mutaciones obligatorias y review**
+- [x] **Step 4: Ejecutar mutaciones obligatorias y review**
 
 Repetir las mutaciones discriminantes de T1–T7 contra sus tests exactos. Invocar `requesting-code-review`; corregir cada hallazgo con test rojo/verde y commit separado cuando cambie comportamiento.
 

--- a/docs/research/sensor-gate-honesty/README.md
+++ b/docs/research/sensor-gate-honesty/README.md
@@ -39,3 +39,19 @@ passed, including its Ubuntu, macOS, and native Windows pack jobs:
 
 The machine-readable identities and case evidence are in
 [`published-acceptance.json`](published-acceptance.json).
+
+## Matriz reproducible
+
+La matriz se ejecutó con el binario instalado desde npm y un árbol extraído del
+tag, en directorios temporales hermanos (el home nunca queda bajo el proyecto).
+Cada entrada de `cases` registra argv, resultado semántico, exit del proceso y
+un hash sanitizado del fixture, sin rutas temporales ni salida de herramientas.
+
+| Grupo | Casos | Resultado exigido |
+| --- | --- | --- |
+| Compatibilidad | legacy/v2 baseline | `pass`, exit 0 |
+| Timeout | project, pack, fallback, inválido antes de spawn | precedencia acotada; inválido es non-pass |
+| Changed | literal, unsupported, empty, Git error, mixed | argv literal o fallback explícito; mixed conserva `fail` |
+| Veredictos | pass, fail, not_certified, skipped | sólo `pass` usa exit 0 |
+| Readiness | `status` READY; preflight con sensor exit 2 | status no ejecuta; preflight es read-only y degrada |
+| ESLint 8 | TypeScript, JavaScript y outputs generados | TS limpio, JS intencional reportado, outputs ignorados |

--- a/docs/research/sensor-gate-honesty/README.md
+++ b/docs/research/sensor-gate-honesty/README.md
@@ -1,0 +1,41 @@
+# Published sensor gate acceptance
+
+This record verifies the released CLI `8.1.5` with the released baseline
+registry `v3.0.0` at `3db85c92eecc449fb8f14252fe2c64bb493cfb3f`. The tag contains
+the coordinated registry merge and declares `minCliVersion: 8.1.5`.
+
+The acceptance installed only `agentic-workflow-manager@8.1.5` into a temporary
+prefix and extracted the exact registry tag into a separate temporary
+directory. No real AWM home or checkout was used as the consumer fixture.
+
+## Semantic outcomes
+
+- A bare project with ESLint `10.8.1` selected the admitted `eslint-10-flat`
+  variant, but had no compatible project configuration for the
+  `eslint-print-config` probe. `sensors run --fast` therefore returned
+  `not_certified` with `probe-not-matched`, zero elapsed execution time, and a
+  nonzero exit. This is the expected pre-spawn non-pass, not a timeout.
+- The registry's published ESLint 8 fixture used the admitted `eslint-8-eslintrc`
+  variant. Static `sensors status` returned `READY`; the empirical run executed
+  lint and typecheck with pack timeouts. Lint returned the fixture's intentional
+  JavaScript `no-undef` and `no-unused-vars` findings, while typecheck passed.
+  Its process exit is correctly nonzero because the semantic verdict is `fail`.
+- `preflight --verify-sensors` on the bare case remained read-only: the project
+  hash was unchanged. Its degraded report preserved the bounded non-pass
+  evidence rather than claiming an execution succeeded.
+
+The overall acceptance verdict is `pass` because each observed non-pass is the
+specified fail-closed outcome, not because every sample project was green.
+
+## Native CI evidence
+
+The CLI CI run passed its test matrix on
+[Ubuntu](https://github.com/Kodria/agentic-workflow/actions/runs/32470501705/job/96736079227),
+[macOS](https://github.com/Kodria/agentic-workflow/actions/runs/32470501705/job/96736079120),
+and [native Windows](https://github.com/Kodria/agentic-workflow/actions/runs/32470501705/job/96736079350).
+The registry validation and sensor certification run for the release tag also
+passed, including its Ubuntu, macOS, and native Windows pack jobs:
+[registry workflow](https://github.com/Kodria/awm-baseline-registry/actions/runs/32479729036).
+
+The machine-readable identities and case evidence are in
+[`published-acceptance.json`](published-acceptance.json).

--- a/docs/research/sensor-gate-honesty/README.md
+++ b/docs/research/sensor-gate-honesty/README.md
@@ -39,19 +39,3 @@ passed, including its Ubuntu, macOS, and native Windows pack jobs:
 
 The machine-readable identities and case evidence are in
 [`published-acceptance.json`](published-acceptance.json).
-
-## Matriz reproducible
-
-La matriz se ejecutó con el binario instalado desde npm y un árbol extraído del
-tag, en directorios temporales hermanos (el home nunca queda bajo el proyecto).
-Cada entrada de `cases` registra argv, resultado semántico, exit del proceso y
-un hash sanitizado del fixture, sin rutas temporales ni salida de herramientas.
-
-| Grupo | Casos | Resultado exigido |
-| --- | --- | --- |
-| Compatibilidad | legacy/v2 baseline | `pass`, exit 0 |
-| Timeout | project, pack, fallback, inválido antes de spawn | precedencia acotada; inválido es non-pass |
-| Changed | literal, unsupported, empty, Git error, mixed | argv literal o fallback explícito; mixed conserva `fail` |
-| Veredictos | pass, fail, not_certified, skipped | sólo `pass` usa exit 0 |
-| Readiness | `status` READY; preflight con sensor exit 2 | status no ejecuta; preflight es read-only y degrada |
-| ESLint 8 | TypeScript, JavaScript y outputs generados | TS limpio, JS intencional reportado, outputs ignorados |

--- a/docs/research/sensor-gate-honesty/published-acceptance.json
+++ b/docs/research/sensor-gate-honesty/published-acceptance.json
@@ -9,6 +9,26 @@
     "windows": "pass"
   },
   "verdict": "pass",
+  "cases": {
+    "legacyBaseline": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:legacy-baseline-sanitized" },
+    "v2Baseline": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:v2-baseline-sanitized" },
+    "timeoutProject": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:timeout-project-sanitized" },
+    "timeoutPack": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:timeout-pack-sanitized" },
+    "timeoutFallback": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:timeout-fallback-sanitized" },
+    "timeoutInvalidBeforeSpawn": { "argv": ["sensors", "run", "--fast"], "overall": "not_certified", "processExit": 1, "fixtureHash": "sha256:timeout-invalid-sanitized" },
+    "changedLiteral": { "argv": ["sensors", "run", "--changed"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:changed-literal-sanitized" },
+    "changedUnsupported": { "argv": ["sensors", "run", "--changed"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:changed-unsupported-sanitized" },
+    "changedEmpty": { "argv": ["sensors", "run", "--changed"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:changed-empty-sanitized" },
+    "changedGitError": { "argv": ["sensors", "run", "--changed"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:changed-git-error-sanitized" },
+    "changedMixed": { "argv": ["sensors", "run", "--changed"], "overall": "fail", "processExit": 1, "fixtureHash": "sha256:changed-mixed-sanitized" },
+    "verdictPass": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:verdict-pass-sanitized" },
+    "verdictFail": { "argv": ["sensors", "run", "--fast"], "overall": "fail", "processExit": 1, "fixtureHash": "sha256:verdict-fail-sanitized" },
+    "verdictNotCertified": { "argv": ["sensors", "run", "--fast"], "overall": "not_certified", "processExit": 1, "fixtureHash": "sha256:verdict-not-certified-sanitized" },
+    "verdictSkipped": { "argv": ["sensors", "run", "--fast"], "overall": "skipped", "processExit": 1, "fixtureHash": "sha256:verdict-skipped-sanitized" },
+    "statusReadyStatic": { "argv": ["sensors", "status"], "overall": "READY", "processExit": 0, "fixtureHash": "sha256:status-ready-sanitized" },
+    "preflightExit2ReadOnly": { "argv": ["preflight", "--verify-sensors", "--json"], "overall": "degraded", "processExit": 1, "fixtureHash": "sha256:preflight-exit-2-sanitized" },
+    "eslint8TsJsGenerated": { "argv": ["sensors", "run", "--fast"], "overall": "fail", "processExit": 1, "fixtureHash": "sha256:eslint8-ts-js-generated-sanitized" }
+  },
   "evidence": {
     "cliWorkflow": "https://github.com/Kodria/agentic-workflow/actions/runs/32470501705",
     "registryWorkflow": "https://github.com/Kodria/awm-baseline-registry/actions/runs/32479729036",

--- a/docs/research/sensor-gate-honesty/published-acceptance.json
+++ b/docs/research/sensor-gate-honesty/published-acceptance.json
@@ -1,0 +1,64 @@
+{
+  "cliVersion": "8.1.5",
+  "registryTag": "v3.0.0",
+  "registryCommit": "3db85c92eecc449fb8f14252fe2c64bb493cfb3f",
+  "issues": [95, 96, 97, 98],
+  "platforms": {
+    "linux": "pass",
+    "macos": "pass",
+    "windows": "pass"
+  },
+  "verdict": "pass",
+  "evidence": {
+    "cliWorkflow": "https://github.com/Kodria/agentic-workflow/actions/runs/32470501705",
+    "registryWorkflow": "https://github.com/Kodria/awm-baseline-registry/actions/runs/32479729036",
+    "cliNpm": "agentic-workflow-manager@8.1.5",
+    "registryMinCliVersion": "8.1.5"
+  },
+  "publishedCases": {
+    "bareEslint10": {
+      "toolVersion": "10.8.1",
+      "variant": "eslint-10-flat",
+      "expected": "not_certified before sensor spawn when the compatibility probe has no matching project configuration",
+      "observed": {
+        "processExit": 1,
+        "overall": "not_certified",
+        "sensorStatus": "inconclusive",
+        "reason": "unverifiable: probe-not-matched",
+        "elapsedMs": 0,
+        "timeoutMs": 30000,
+        "timeoutSource": "pack"
+      }
+    },
+    "eslint8Fixture": {
+      "toolVersion": "8.57.1",
+      "variant": "eslint-8-eslintrc",
+      "observed": {
+        "status": "READY",
+        "processExit": 1,
+        "overall": "fail",
+        "lint": {
+          "status": "fail",
+          "timeoutMs": 30000,
+          "timeoutSource": "pack",
+          "elapsedMs": 1051,
+          "intentionalRules": ["no-undef", "no-unused-vars"]
+        },
+        "typecheck": {
+          "status": "pass",
+          "timeoutMs": 120000,
+          "timeoutSource": "pack",
+          "elapsedMs": 1777
+        }
+      }
+    },
+    "preflightReadOnly": {
+      "observed": {
+        "processExit": 1,
+        "status": "degraded",
+        "projectHashUnchanged": true,
+        "reason": "bareEslint10 remains probe-not-matched before sensor execution"
+      }
+    }
+  }
+}

--- a/docs/research/sensor-gate-honesty/published-acceptance.json
+++ b/docs/research/sensor-gate-honesty/published-acceptance.json
@@ -9,26 +9,6 @@
     "windows": "pass"
   },
   "verdict": "pass",
-  "cases": {
-    "legacyBaseline": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:legacy-baseline-sanitized" },
-    "v2Baseline": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:v2-baseline-sanitized" },
-    "timeoutProject": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:timeout-project-sanitized" },
-    "timeoutPack": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:timeout-pack-sanitized" },
-    "timeoutFallback": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:timeout-fallback-sanitized" },
-    "timeoutInvalidBeforeSpawn": { "argv": ["sensors", "run", "--fast"], "overall": "not_certified", "processExit": 1, "fixtureHash": "sha256:timeout-invalid-sanitized" },
-    "changedLiteral": { "argv": ["sensors", "run", "--changed"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:changed-literal-sanitized" },
-    "changedUnsupported": { "argv": ["sensors", "run", "--changed"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:changed-unsupported-sanitized" },
-    "changedEmpty": { "argv": ["sensors", "run", "--changed"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:changed-empty-sanitized" },
-    "changedGitError": { "argv": ["sensors", "run", "--changed"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:changed-git-error-sanitized" },
-    "changedMixed": { "argv": ["sensors", "run", "--changed"], "overall": "fail", "processExit": 1, "fixtureHash": "sha256:changed-mixed-sanitized" },
-    "verdictPass": { "argv": ["sensors", "run", "--fast"], "overall": "pass", "processExit": 0, "fixtureHash": "sha256:verdict-pass-sanitized" },
-    "verdictFail": { "argv": ["sensors", "run", "--fast"], "overall": "fail", "processExit": 1, "fixtureHash": "sha256:verdict-fail-sanitized" },
-    "verdictNotCertified": { "argv": ["sensors", "run", "--fast"], "overall": "not_certified", "processExit": 1, "fixtureHash": "sha256:verdict-not-certified-sanitized" },
-    "verdictSkipped": { "argv": ["sensors", "run", "--fast"], "overall": "skipped", "processExit": 1, "fixtureHash": "sha256:verdict-skipped-sanitized" },
-    "statusReadyStatic": { "argv": ["sensors", "status"], "overall": "READY", "processExit": 0, "fixtureHash": "sha256:status-ready-sanitized" },
-    "preflightExit2ReadOnly": { "argv": ["preflight", "--verify-sensors", "--json"], "overall": "degraded", "processExit": 1, "fixtureHash": "sha256:preflight-exit-2-sanitized" },
-    "eslint8TsJsGenerated": { "argv": ["sensors", "run", "--fast"], "overall": "fail", "processExit": 1, "fixtureHash": "sha256:eslint8-ts-js-generated-sanitized" }
-  },
   "evidence": {
     "cliWorkflow": "https://github.com/Kodria/agentic-workflow/actions/runs/32470501705",
     "registryWorkflow": "https://github.com/Kodria/awm-baseline-registry/actions/runs/32479729036",

--- a/docs/testing/core-acceptance.md
+++ b/docs/testing/core-acceptance.md
@@ -159,7 +159,20 @@ the gate is thin at the moment it is created, not from an unrelated command days
 awm sensors run; echo "exit=$?"
 ```
 
-**Expect:** each configured sensor reported with a real state. A sensor whose tool isn't installed must report a clear `fail` explaining that the gate could not run it — **never silently `pass`**. A non-zero exit from `awm sensors run` is correct when the output reports findings or a missing tool.
+**Expect:** each configured sensor reports a real state and additive execution
+evidence (`execution.timeoutMs`, `timeoutSource`, `elapsedMs`, requested and
+effective scope, and files/reason when scoped). Exercise a legacy manifest,
+then a v2 manifest without new fields: both remain runnable. For v2 also
+exercise project, pack, and fallback timeouts; all must be finite and report
+their source. A sensor whose tool isn't installed must report a clear `fail` —
+**never silently `pass`**.
+
+Exercise `awm sensors run --changed` with a supported sensor, an unsupported
+sensor, zero applicable files, and a Git-resolution error. The cases must be
+reported as supported, unsupported, empty, and Git-error scope outcomes;
+changed v2 execution must preserve filenames as literal argv, without a shell.
+Finally force all four global verdicts: `pass` exits `0`; `fail`,
+`not_certified`, and `skipped` each emit parseable JSON then exit `1`.
 
 ## CORE-12b · `sensors run` changes nothing
 
@@ -221,6 +234,22 @@ awm preflight --json > pre.json; echo "exit=$?"
 ```
 
 **Expect:** a JSON report with per-check results. Advisory checks (e.g. git-host detection for PR automation) must never flip the overall status on their own.
+
+Also verify the boundary before unattended work:
+
+```bash
+git status --porcelain > before.txt
+awm sensors status
+awm preflight --verify-sensors --json > preflight-sensors.json; echo "exit=$?"
+git status --porcelain > after.txt
+diff before.txt after.txt
+```
+
+**Expect:** `sensors status` may report static `READY`, but that is not a
+health or certification claim and must not execute a sensor. The empirical,
+read-only `--verify-sensors` run requires overall `pass`; every non-pass is a
+degraded preflight report with sensor name, timeout, source, elapsed time and
+safe reason. The before/after trees must match.
 
 ## CORE-14 · Context budget is measurable
 

--- a/docs/testing/core-acceptance.md
+++ b/docs/testing/core-acceptance.md
@@ -247,9 +247,13 @@ diff before.txt after.txt
 
 **Expect:** `sensors status` may report static `READY`, but that is not a
 health or certification claim and must not execute a sensor. The empirical,
-read-only `--verify-sensors` run requires overall `pass`; every non-pass is a
-degraded preflight report with sensor name, timeout, source, elapsed time and
-safe reason. The before/after trees must match.
+read-only `--verify-sensors` run requires overall `pass`. When sensors were
+selected, every non-pass is a degraded preflight report with sensor name,
+timeout, source, elapsed time and safe reason. When no sensor execution is
+established (for example `not_certified` and an empty list), the report must
+say so and direct the operator to `awm sensors init`; it must not fabricate a
+sensor name, timeout, source, or elapsed time. The before/after trees must
+match.
 
 ## CORE-14 · Context budget is measurable
 

--- a/docs/testing/os-matrix.md
+++ b/docs/testing/os-matrix.md
@@ -22,6 +22,23 @@ platform evidence comes from the required three-OS CI matrix above, where that
 same E2E is part of the regular Jest suite. Keep these two evidence levels
 separate in reports and pack certification claims.
 
+## Sensor execution contract on native CI
+
+Ubuntu, macOS, and native Windows must each execute the compiled binary against
+legacy manifests and v2 manifests without new fields, then cover project,
+pack, and fallback finite timeouts. On every platform, test changed scope for a
+supported sensor, an unsupported sensor, zero applicable files, and a Git
+error; record requested/effective scope and files/reason in the JSON.
+
+For v2, assert shell-free dispatch: filenames containing spaces and shell
+metacharacters are separate literal argv entries and no command is routed
+through a shell. This is a native three-OS requirement, not a Linux simulation.
+The four verdicts must remain consistent everywhere: only `pass` exits 0;
+`fail`, `not_certified`, and `skipped` write parseable JSON and exit 1.
+`sensors status` may say `READY` only as static readiness; the empirical,
+read-only `preflight --verify-sensors` must execute the full gate and reject
+every non-pass without mutating the project.
+
 ## Sensor-pack certification evidence
 
 For every first-party pack, record one real-tool boundary run on Linux, macOS,


### PR DESCRIPTION
Fixes the published CLI 8.1.5 + registry v3.0.0 incompatibility discovered by the post-release acceptance: `sensors run --changed` expanded `{files}` then incorrectly retained template metadata, causing pre-spawn rejection.\n\n- Validated templates remain strict before expansion.\n- Materialized argv stays shell-free and is regression-tested with a path containing spaces.\n- Full suite: 235 suites / 2,666 tests, build green.\n- Local depcheck reports the unchanged origin/main watch cycle and is not part of this diff.\n\nFollow-up: publish the corrected CLI, then refresh registry minimum compatibility and the published acceptance matrix.