### PR TITLE
fix(sensors): execute materialized changed commands

### DIFF
--- a/cli/src/commands/sensors/prepare.ts
+++ b/cli/src/commands/sensors/prepare.ts
@@ -62,7 +62,11 @@ export function expandFileInput(command: StructuredCommand, files: string[]): St
     if (index < 0 || command.args.lastIndexOf(command.fileInput.placeholder) !== index) {
         throw new Error('changed command requires exactly one standalone {files} argument');
     }
-    return { ...command, args: [...command.args.slice(0, index), ...files, ...command.args.slice(index + 1)] };
+    // `fileInput` describes the unexpanded registry template. Leaving it on the
+    // materialized command makes the execution boundary (correctly) demand a
+    // placeholder that has already been replaced with literal argv entries.
+    const { fileInput: _templateInput, ...materialized } = command;
+    return { ...materialized, args: [...command.args.slice(0, index), ...files, ...command.args.slice(index + 1)] };
 }
 
 function timeout(project: number | undefined, pack: number | undefined, fast: boolean): Pick<PreparedSensorExecution, 'timeoutMs' | 'timeoutSource'> {

--- a/cli/tests/commands/sensors/exec.test.ts
+++ b/cli/tests/commands/sensors/exec.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { runCommand, runStructuredCommand } from '../../../src/commands/sensors/exec';
 import { executePrepared } from '../../../src/commands/sensors/result';
+import { expandFileInput } from '../../../src/commands/sensors/prepare';
 
 const sensor = (overrides: Record<string, unknown> = {}) => ({
     name: 'lint',
@@ -156,6 +157,26 @@ describe('runCommand — spawn failure', () => {
 });
 
 describe('runStructuredCommand — public boundary validation', () => {
+    it('dispatches argv materialized from a validated changed-command template without requiring its placeholder again', async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-exec-changed-argv-'));
+        const received = path.join(dir, 'received.json');
+        try {
+            const command = expandFileInput({
+                executable: 'node',
+                resolution: 'path',
+                args: ['-e', "require('fs').writeFileSync(process.argv[1], JSON.stringify(process.argv.slice(2)))", received, '{files}'],
+                fileInput: { placeholder: '{files}', extensions: ['.ts'] },
+            }, ['src/a.ts', 'src/with space.ts']);
+
+            const result = await runStructuredCommand(command, { timeout: 5_000, cwd: dir });
+
+            expect(result.code).toBe(0);
+            expect(JSON.parse(fs.readFileSync(received, 'utf8'))).toEqual(['src/a.ts', 'src/with space.ts']);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
     it.each(['sh', 'cmd.exe', '/usr/bin/node', 'nested/tool', 'nested\\tool'])('rejects unsafe executable %j before resolution', executable => {
         expect(() => runStructuredCommand({ executable, resolution: 'path', args: ['--version'] }, { timeout: 5000, cwd: process.cwd() }))
             .toThrow(/safe executable name|shell/i);

--- a/cli/tests/commands/sensors/prepare.test.ts
+++ b/cli/tests/commands/sensors/prepare.test.ts
@@ -33,7 +33,7 @@ describe('prepareV2Sensor', () => {
     test('v2 uses the live command and project > pack > fallback timeout (R1.1, R3.1)', () => {
         const prepared = prepareV2Sensor(v2Input());
 
-        expect(prepared.command).toEqual({ kind: 'structured', value: { ...changedCommand, args: ['--format', 'json', 'src/a.ts'] } });
+        expect(prepared.command).toEqual({ kind: 'structured', value: { executable: 'live-eslint', resolution: 'path', args: ['--format', 'json', 'src/a.ts'] } });
         expect(prepared.timeoutMs).toBe(90_000);
         expect(prepared.timeoutSource).toBe('project');
         expect(prepareV2Sensor(v2Input({ projectTimeout: undefined })).timeoutSource).toBe('pack');
@@ -47,7 +47,7 @@ describe('prepareV2Sensor', () => {
     test('expands changed paths as literal argv entries (R4.1, R10.2)', () => {
         const prepared = prepareV2Sensor(v2Input({ changed: { files: ['src/a b.ts', 'src/$x.ts'] } }));
 
-        expect(prepared.command).toEqual({ kind: 'structured', value: { ...changedCommand, args: ['--format', 'json', 'src/a b.ts', 'src/$x.ts'] } });
+        expect(prepared.command).toEqual({ kind: 'structured', value: { executable: 'live-eslint', resolution: 'path', args: ['--format', 'json', 'src/a b.ts', 'src/$x.ts'] } });
         expect(prepared.effectiveScope).toBe('changed');
     });
 


### PR DESCRIPTION
Clean rebase of the post-release regression fix for `sensors run --changed`.\n\nFixes the CLI 8.1.5 + registry v3.0.0 incompatibility: the materialized argv no longer carries the template-only `fileInput` metadata after `{files}` expansion. Template validation remains strict and execution stays shell-free.\n\nFocal tests, typecheck and lint pass.