### PR TITLE
test(sensors): record published gate acceptance

### DIFF
--- a/cli/tests/integration/published-sensor-gate-matrix.e2e.test.ts
+++ b/cli/tests/integration/published-sensor-gate-matrix.e2e.test.ts
@@ -155,10 +155,11 @@ acceptance('published sensor gate matrix', () => {
             assertProcess(initialized, 'v2 init');
             const status = runCli(cliRoot, v2, 'sensors', 'status');
             record(records, 'v2-status', ['sensors', 'status'], status);
-            expect([0, 1]).toContain(status.status);
+            expect(status.status).toBe(0);
             const preflight = runJson(records, 'v2-preflight', cliRoot, v2, 'preflight', '--verify-sensors', '--json');
             expect(['ready', 'degraded', 'not_configured']).toContain(preflight.output.status);
-            expect([0, 1]).toContain(preflight.result.status);
+            expect(preflight.output.status).toBe('degraded');
+            expect(preflight.result.status).toBe(1);
 
             const clean = runJson(records, 'v2-clean-fast', cliRoot, v2, 'sensors', 'run', '--fast');
             assertExitMatchesVerdict(clean.result, clean.output);
@@ -207,11 +208,13 @@ acceptance('published sensor gate matrix', () => {
             fs.writeFileSync(path.join(v2.project, 'failure.js'), 'missingPublishedSensorGateValue;\n');
             const failing = runJson(records, 'v2-failing-fast', cliRoot, v2, 'sensors', 'run', '--fast');
             assertExitMatchesVerdict(failing.result, failing.output);
+            expect(failing.output.overall).toBe('fail');
             const baseline = runCli(cliRoot, v2, 'sensors', 'baseline');
             record(records, 'v2-baseline', ['sensors', 'baseline'], baseline);
             assertProcess(baseline, 'v2 baseline');
             const baselined = runJson(records, 'v2-baselined-fast', cliRoot, v2, 'sensors', 'run', '--fast');
             assertExitMatchesVerdict(baselined.result, baselined.output);
+            expect(baselined.output.overall).toBe('pass');
 
             assertProcess(command(v2.project, 'git', ['init']), 'git init changed fixture');
             assertProcess(command(v2.project, 'git', ['config', 'user.email', 'acceptance@example.invalid']), 'git user email');
@@ -221,7 +224,7 @@ acceptance('published sensor gate matrix', () => {
             fs.writeFileSync(path.join(v2.project, 'clean.js'), 'const changed = 1;\nconsole.log(changed);\n');
             const changed = runJson(records, 'v2-changed-fast', cliRoot, v2, 'sensors', 'run', '--fast', '--changed');
             assertExitMatchesVerdict(changed.result, changed.output);
-            expect(changed.output).toHaveProperty('changedScope');
+            expect(changed.output).toMatchObject({ overall: 'pass', changedScope: { files: 1 } });
 
             const legacy = createFixture(root, registryRoot, 'legacy');
             fs.mkdirSync(path.join(legacy.project, '.awm'), { recursive: true });
@@ -229,8 +232,9 @@ acceptance('published sensor gate matrix', () => {
             const legacyRun = runJson(records, 'legacy-fast', cliRoot, legacy, 'sensors', 'run', '--fast');
             assertExitMatchesVerdict(legacyRun.result, legacyRun.output);
             expect(legacyRun.output.sensors).toEqual(expect.arrayContaining([
-                expect.objectContaining({ execution: expect.objectContaining({ timeoutSource: 'fallback' }) }),
+                expect.objectContaining({ status: 'pass', execution: expect.objectContaining({ timeoutSource: 'fallback' }) }),
             ]));
+            expect(legacyRun.output.overall).toBe('not_certified');
 
             const outcomes = new Map(records.flatMap(record => record.output?.overall ? [[String(record.output.overall), record.exit] as const] : []));
             // This is an explicit observation table for the immutable release:

--- a/cli/tests/integration/published-sensor-gate-matrix.e2e.test.ts
+++ b/cli/tests/integration/published-sensor-gate-matrix.e2e.test.ts
@@ -14,7 +14,7 @@ import path from 'path';
  */
 const enabled = process.env.AWM_RUN_PUBLISHED_SENSOR_GATE_MATRIX === '1';
 const acceptance = enabled ? describe : describe.skip;
-const cliVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.5';
+const cliVersion = process.env.AWM_PUBLISHED_CLI_VERSION ?? '8.1.6';
 const registryTag = process.env.AWM_PUBLISHED_REGISTRY_TAG ?? 'v3.0.0';
 const registryRemote = process.env.AWM_PUBLISHED_REGISTRY_REMOTE ?? 'https://github.com/Kodria/awm-baseline-registry.git';
 // Keep the shorter name used by the release orchestrator, while accepting the
@@ -126,7 +126,11 @@ function writeReport(root: string, cliRoot: string, registryRoot: string, record
         schemaVersion: 1,
         generatedAt: new Date().toISOString(),
         cli: { version: cliVersion, packageHash: hash(fs.readFileSync(path.join(cliRoot, 'package.json'), 'utf8')) },
-        registry: { tag: registryTag, packHash: hash(fs.readFileSync(path.join(registryRoot, 'sensor-packs', 'js-ts', 'pack.json'), 'utf8')) },
+        registry: {
+            tag: registryTag,
+            commit: command(registryRoot, 'git', ['rev-parse', 'HEAD']).stdout.trim(),
+            packHash: hash(fs.readFileSync(path.join(registryRoot, 'sensor-packs', 'js-ts', 'pack.json'), 'utf8')),
+        },
         commands: records,
     });
     process.stdout.write(`published sensor gate matrix: ${target}\n`);
@@ -147,7 +151,7 @@ acceptance('published sensor gate matrix', () => {
 
             const v2 = createFixture(root, registryRoot, 'v2');
             const initialized = runCli(cliRoot, v2, 'sensors', 'init', '--registry-root', registryRoot, '--pack', 'js-ts');
-            record(records, 'v2-init', ['sensors', 'init', '--registry-root', registryRoot, '--pack', 'js-ts'], initialized);
+            record(records, 'v2-init', ['sensors', 'init', '--registry-root', '<registry-root>', '--pack', 'js-ts'], initialized);
             assertProcess(initialized, 'v2 init');
             const status = runCli(cliRoot, v2, 'sensors', 'status');
             record(records, 'v2-status', ['sensors', 'status'], status);
@@ -158,11 +162,24 @@ acceptance('published sensor gate matrix', () => {
 
             const clean = runJson(records, 'v2-clean-fast', cliRoot, v2, 'sensors', 'run', '--fast');
             assertExitMatchesVerdict(clean.result, clean.output);
+            expect(clean.output.sensors).toEqual(expect.arrayContaining([
+                expect.objectContaining({ execution: expect.objectContaining({ timeoutSource: 'pack' }) }),
+            ]));
+            const v2ManifestPath = path.join(v2.project, '.awm', 'sensors.json');
+            const projectTimeoutManifest = JSON.parse(fs.readFileSync(v2ManifestPath, 'utf8')) as { sensors: Record<string, { timeout?: number }> };
+            projectTimeoutManifest.sensors.lint.timeout = 30_000;
+            writeJson(v2ManifestPath, projectTimeoutManifest);
+            const projectTimeout = runJson(records, 'v2-project-timeout-fast', cliRoot, v2, 'sensors', 'run', '--fast');
+            assertExitMatchesVerdict(projectTimeout.result, projectTimeout.output);
+            expect(projectTimeout.output.sensors).toEqual(expect.arrayContaining([
+                expect.objectContaining({ execution: expect.objectContaining({ timeoutMs: 30_000, timeoutSource: 'project' }) }),
+            ]));
+            delete projectTimeoutManifest.sensors.lint.timeout;
+            writeJson(v2ManifestPath, projectTimeoutManifest);
             // A v2 manifest can deliberately disable an otherwise applicable
             // sensor. Exercise the published skip verdict before any failing
             // fixture source is introduced, so this is a real all-skipped run
             // rather than a filtered pass or a baseline side effect.
-            const v2ManifestPath = path.join(v2.project, '.awm', 'sensors.json');
             const disabledManifest = JSON.parse(fs.readFileSync(v2ManifestPath, 'utf8')) as { sensors: Record<string, { enabled?: boolean; fast?: boolean }> };
             const fastSensor = Object.entries(disabledManifest.sensors).find(([, sensor]) => sensor.fast === true);
             expect(fastSensor).toBeDefined();
@@ -174,6 +191,19 @@ acceptance('published sensor gate matrix', () => {
             expect(skipped.output.overall).toBe('skipped');
             disabledManifest.sensors[fastSensor[0]].enabled = true;
             writeJson(v2ManifestPath, disabledManifest);
+            const invalidTimeoutManifest = JSON.parse(fs.readFileSync(v2ManifestPath, 'utf8')) as { sensors: Record<string, { timeout?: number }> };
+            invalidTimeoutManifest.sensors.lint.timeout = 0;
+            writeJson(v2ManifestPath, invalidTimeoutManifest);
+            const invalidTimeout = runCli(cliRoot, v2, 'sensors', 'run', '--fast');
+            expect(invalidTimeout.status).toBe(1);
+            // Release 8.1.6 does not surface the parser rejection required by
+            // the target contract. Record its actual fallback rather than
+            // inventing a pre-spawn guarantee the artifact does not provide.
+            const invalidTimeoutOutput = parseJson(invalidTimeout, 'v2 invalid timeout');
+            record(records, 'v2-invalid-timeout-fast', ['sensors', 'run', '--fast'], invalidTimeout, invalidTimeoutOutput);
+            expect(invalidTimeoutOutput.overall).toBe('not_certified');
+            delete invalidTimeoutManifest.sensors.lint.timeout;
+            writeJson(v2ManifestPath, invalidTimeoutManifest);
             fs.writeFileSync(path.join(v2.project, 'failure.js'), 'missingPublishedSensorGateValue;\n');
             const failing = runJson(records, 'v2-failing-fast', cliRoot, v2, 'sensors', 'run', '--fast');
             assertExitMatchesVerdict(failing.result, failing.output);
@@ -198,12 +228,16 @@ acceptance('published sensor gate matrix', () => {
             writeJson(path.join(legacy.project, '.awm', 'sensors.json'), { pack: 'js-ts', sensors: { lint: { fast: true, cmd: 'npx eslint . --format json' } } });
             const legacyRun = runJson(records, 'legacy-fast', cliRoot, legacy, 'sensors', 'run', '--fast');
             assertExitMatchesVerdict(legacyRun.result, legacyRun.output);
+            expect(legacyRun.output.sensors).toEqual(expect.arrayContaining([
+                expect.objectContaining({ execution: expect.objectContaining({ timeoutSource: 'fallback' }) }),
+            ]));
 
-            const outcomes = new Set(records.flatMap(record => record.output?.overall ? [`${String(record.output.overall)}:${String(record.exit)}`] : []));
-            // The matrix's purpose is to make distinct real outcome/exit pairs
-            // visible. Do not prescribe their values here: those are the release
-            // artifact's evidence, recorded above for review.
-            expect(outcomes.size).toBeGreaterThanOrEqual(4);
+            const outcomes = new Map(records.flatMap(record => record.output?.overall ? [[String(record.output.overall), record.exit] as const] : []));
+            // This is an explicit observation table for the immutable release:
+            // only pass is process-success; every non-pass is process-failure.
+            expect([...outcomes.entries()].sort()).toEqual([
+                ['fail', 1], ['not_certified', 1], ['pass', 0], ['skipped', 1],
+            ]);
             writeReport(root, cliRoot, registryRoot, records);
         } catch (error) {
             // Do not turn a release mismatch into a synthetic success. When an

--- a/cli/tests/structural/published-sensor-gate-acceptance.test.ts
+++ b/cli/tests/structural/published-sensor-gate-acceptance.test.ts
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+
+type Acceptance = {
+    schemaVersion: number;
+    cli: { version: string };
+    registry: { tag: string; commit: string };
+    platforms: Record<string, { status: string; evidence: string }>;
+    matrix: { report: string; commandCount: number };
+};
+
+const acceptancePath = path.resolve(__dirname, '../../../docs/research/sensor-gate-honesty/published-acceptance.json');
+
+describe('published sensor gate acceptance artifact', () => {
+    it('contains only complete, portable publication identities and evidence references', () => {
+        const artifact = JSON.parse(fs.readFileSync(acceptancePath, 'utf8')) as Acceptance;
+
+        expect(artifact.schemaVersion).toBe(1);
+        expect(artifact.cli.version).toMatch(/^\d+\.\d+\.\d+$/);
+        expect(artifact.registry.tag).toMatch(/^v\d+\.\d+\.\d+$/);
+        expect(artifact.registry.commit).toMatch(/^[0-9a-f]{40}$/);
+        expect(artifact.matrix.report).toBe('published-sensor-gate-matrix.json');
+        expect(artifact.matrix.commandCount).toBeGreaterThan(0);
+        expect(Object.keys(artifact.platforms).sort()).toEqual(['linux', 'macos', 'windows']);
+        for (const platform of Object.values(artifact.platforms)) {
+            expect(platform.status).toBe('pass');
+            expect(platform.evidence).toMatch(/^https:\/\//);
+        }
+        expect(fs.readFileSync(acceptancePath, 'utf8').endsWith('\n')).toBe(true);
+    });
+});

--- a/cli/tests/structural/published-sensor-gate-acceptance.test.ts
+++ b/cli/tests/structural/published-sensor-gate-acceptance.test.ts
@@ -3,24 +3,36 @@ import path from 'path';
 
 type Acceptance = {
     schemaVersion: number;
-    cli: { version: string };
-    registry: { tag: string; commit: string };
+    issues: number[];
+    verdict: string;
+    cli: { version: string; packageHash: string };
+    registry: { tag: string; commit: string; packHash: string };
     platforms: Record<string, { status: string; evidence: string }>;
     matrix: { report: string; commandCount: number };
 };
 
 const acceptancePath = path.resolve(__dirname, '../../../docs/research/sensor-gate-honesty/published-acceptance.json');
+const reportPath = path.resolve(__dirname, '../../../docs/research/sensor-gate-honesty/published-sensor-gate-matrix.json');
 
 describe('published sensor gate acceptance artifact', () => {
     it('contains only complete, portable publication identities and evidence references', () => {
         const artifact = JSON.parse(fs.readFileSync(acceptancePath, 'utf8')) as Acceptance;
+        const report = JSON.parse(fs.readFileSync(reportPath, 'utf8')) as { cli: { version: string }; registry: { tag: string; commit: string }; commands: unknown[] };
 
         expect(artifact.schemaVersion).toBe(1);
+        expect(artifact.issues).toEqual([95, 96, 97, 98]);
+        expect(artifact.verdict).toBe('partial');
         expect(artifact.cli.version).toMatch(/^\d+\.\d+\.\d+$/);
+        expect(artifact.cli.packageHash).toMatch(/^[0-9a-f]{64}$/);
         expect(artifact.registry.tag).toMatch(/^v\d+\.\d+\.\d+$/);
         expect(artifact.registry.commit).toMatch(/^[0-9a-f]{40}$/);
+        expect(artifact.registry.packHash).toMatch(/^[0-9a-f]{64}$/);
         expect(artifact.matrix.report).toBe('published-sensor-gate-matrix.json');
-        expect(artifact.matrix.commandCount).toBeGreaterThan(0);
+        expect(artifact.matrix.commandCount).toBe(12);
+        expect(report.commands).toHaveLength(artifact.matrix.commandCount);
+        expect(report.cli.version).toBe(artifact.cli.version);
+        expect(report.registry).toMatchObject(artifact.registry);
+        expect(JSON.stringify(report)).not.toMatch(/\/(tmp|srv)\//);
         expect(Object.keys(artifact.platforms).sort()).toEqual(['linux', 'macos', 'windows']);
         for (const platform of Object.values(artifact.platforms)) {
             expect(platform.status).toBe('pass');

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -1075,7 +1075,7 @@ Crear directorios con `mktemp -d`, instalar `agentic-workflow-manager@${CLI_RELE
 
 Casos mínimos: legacy baseline, v2 baseline, timeout project/pack/fallback, timeout inválido antes de spawn, changed literal/unsupported/empty/Git error/mixed, cuatro verdicts/exit, status READY sin ejecutar, preflight empírico read-only (la release publicada devuelve exit 1 para non-ready; no inventar exit 2), ESLint 8 TS/JS/generated. Cada caso guarda argv, verdict semántico, process exit y hash del fixture sanitizado.
 
-- [x] **Step 3: Confirmar evidencia nativa 3-OS**
+- [ ] **Step 3: Confirmar evidencia nativa 3-OS**
 
 Enlazar las corridas verdes de los PRs/workflows para Ubuntu, macOS y Windows. No sustituir Windows nativo con Wine ni inferir portabilidad desde Linux. `published-acceptance.json` contiene:
 

--- a/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
+++ b/docs/plans/2026-08-21-sensor-gate-honesty-plan.md
@@ -1067,15 +1067,15 @@ _Requirements: R1, R1.1, R1.2, R1.3, R2, R2.1, R3, R3.1, R3.2, R3.3, R3.4, R4, R
 
 **Skills:** `test-driven-development`, `requesting-code-review`, `verification-before-completion`
 
-- [ ] **Step 1: Instalar únicamente artefactos publicados en aislamiento**
+- [x] **Step 1: Instalar únicamente artefactos publicados en aislamiento**
 
 Crear directorios con `mktemp -d`, instalar `agentic-workflow-manager@${CLI_RELEASE_VERSION}` con un prefix temporal y clonar/checkout exacto `${REGISTRY_RELEASE_TAG}`. No tocar el home real ni `~/.awm`. Registrar versión, tag y hashes, no paths temporales.
 
 - [ ] **Step 2: Ejecutar matriz publicada legacy/v2**
 
-Casos mínimos: legacy baseline, v2 baseline, timeout project/pack/fallback, timeout inválido antes de spawn, changed literal/unsupported/empty/Git error/mixed, cuatro verdicts/exit, status READY sin ejecutar, preflight empírico exit-2 read-only, ESLint 8 TS/JS/generated. Cada caso guarda argv, verdict semántico, process exit y hash del fixture sanitizado.
+Casos mínimos: legacy baseline, v2 baseline, timeout project/pack/fallback, timeout inválido antes de spawn, changed literal/unsupported/empty/Git error/mixed, cuatro verdicts/exit, status READY sin ejecutar, preflight empírico read-only (la release publicada devuelve exit 1 para non-ready; no inventar exit 2), ESLint 8 TS/JS/generated. Cada caso guarda argv, verdict semántico, process exit y hash del fixture sanitizado.
 
-- [ ] **Step 3: Confirmar evidencia nativa 3-OS**
+- [x] **Step 3: Confirmar evidencia nativa 3-OS**
 
 Enlazar las corridas verdes de los PRs/workflows para Ubuntu, macOS y Windows. No sustituir Windows nativo con Wine ni inferir portabilidad desde Linux. `published-acceptance.json` contiene:
 

--- a/docs/research/sensor-gate-honesty/README.md
+++ b/docs/research/sensor-gate-honesty/README.md
@@ -37,8 +37,12 @@ does not upgrade them to published evidence. The registry's ESLint 8
 TS/JS/generated certification is evidenced by its native CI run, while the
 local published harness exercised the JavaScript ESLint fixture only.
 
-Native CI evidence for the CLI acceptance commit is recorded in
-[`published-acceptance.json`](published-acceptance.json): Ubuntu, macOS, and
-native Windows jobs all passed. The registry's v3.0.0 validation/certification
-run is [also published](https://github.com/Kodria/awm-baseline-registry/actions/runs/32479729036),
+The persisted, sanitized report is
+[`published-sensor-gate-matrix.json`](published-sensor-gate-matrix.json). It is
+the Linux execution above; this is the only platform on which this opt-in
+matrix was run. Native CI evidence for the CLI acceptance commit is recorded
+in [`published-acceptance.json`](published-acceptance.json): Ubuntu, macOS,
+and native Windows jobs all passed the general CI suite, but those jobs did not
+run this opt-in matrix. The registry's v3.0.0 validation/certification run is
+[also published](https://github.com/Kodria/awm-baseline-registry/actions/runs/32479729036),
 including Ubuntu, macOS, and Windows certification jobs.

--- a/docs/research/sensor-gate-honesty/README.md
+++ b/docs/research/sensor-gate-honesty/README.md
@@ -1,0 +1,44 @@
+# Published sensor-gate acceptance
+
+This record is evidence from an isolated execution on 2026-08-21, not a claim
+that every target-contract scenario was covered. The harness installed npm
+`agentic-workflow-manager@8.1.6`, cloned `awm-baseline-registry` tag `v3.0.0`
+at `3db85c92eecc449fb8f14252fe2c64bb493cfb3f`, set a fresh `AWM_HOME`, and
+ran `cli/tests/integration/published-sensor-gate-matrix.e2e.test.ts` with
+`AWM_RUN_PUBLISHED_SENSOR_GATE_MATRIX=1` and `AWM_PUBLISHED_MATRIX_REPORT`.
+The JSON report retained the command argv (with `<registry-root>` substituted),
+process exit, semantic output when available, and SHA-256 hashes of stdout and
+stderr; it contains no temporary fixture paths.
+
+Observed from the report:
+
+| Case | Observable result |
+| --- | --- |
+| v2 clean / project timeout / pack timeout | `pass`, exit 0; sources `project` and `pack` were observed |
+| legacy | sensor `pass` with fallback timeout, overall `not_certified`, exit 1 |
+| disabled v2 sensor | `skipped`, exit 1 |
+| ESLint finding | `fail`, exit 1 |
+| v2 baseline | finding became baseline debt and the next run was `pass`, exit 0 |
+| changed JavaScript file | changed scope with one file, `pass`, exit 0 |
+| status | exit 0; its output was deliberately not treated as empirical certification |
+| `preflight --verify-sensors --json` | `degraded`, exit 1; the sensor execution check itself was `pass` but project context was absent |
+| v2 `timeout: 0` | `not_certified` with zero sensors, exit 1 — this is recorded as release fallback, not as an invalid-timeout rejection or pre-spawn proof |
+
+The report did establish the published verdict-to-exit table: `pass → 0`, and
+`fail`, `not_certified`, and `skipped` each → 1. It did **not** establish exit
+2; the published preflight result was exit 1.
+
+Coverage boundaries are intentional. The release harness currently has no
+empirical case for changed unsupported, changed empty, changed Git-error,
+mixed full/scoped sensors, timeout termination, or a parser-level
+invalid-timeout-before-spawn assertion. Those requirements remain covered only
+by their focused source tests or remain a release gap; this acceptance record
+does not upgrade them to published evidence. The registry's ESLint 8
+TS/JS/generated certification is evidenced by its native CI run, while the
+local published harness exercised the JavaScript ESLint fixture only.
+
+Native CI evidence for the CLI acceptance commit is recorded in
+[`published-acceptance.json`](published-acceptance.json): Ubuntu, macOS, and
+native Windows jobs all passed. The registry's v3.0.0 validation/certification
+run is [also published](https://github.com/Kodria/awm-baseline-registry/actions/runs/32479729036),
+including Ubuntu, macOS, and Windows certification jobs.

--- a/docs/research/sensor-gate-honesty/published-acceptance.json
+++ b/docs/research/sensor-gate-honesty/published-acceptance.json
@@ -1,0 +1,30 @@
+{
+  "schemaVersion": 1,
+  "cli": {
+    "version": "8.1.6",
+    "packageHash": "7a4e0e3b9fa8a1a32e1ae9604780f306d218c3d9b290e6a1f842b808307c2fa2"
+  },
+  "registry": {
+    "tag": "v3.0.0",
+    "commit": "3db85c92eecc449fb8f14252fe2c64bb493cfb3f",
+    "packHash": "0be244deaece90ad8671de0ca517abd7f0fce5567d0e688c8b76b8ee4f490348"
+  },
+  "platforms": {
+    "linux": {
+      "status": "pass",
+      "evidence": "https://github.com/Kodria/agentic-workflow/actions/runs/32494284592/job/96808918456"
+    },
+    "macos": {
+      "status": "pass",
+      "evidence": "https://github.com/Kodria/agentic-workflow/actions/runs/32494284592/job/96808918234"
+    },
+    "windows": {
+      "status": "pass",
+      "evidence": "https://github.com/Kodria/agentic-workflow/actions/runs/32494284592/job/96808917901"
+    }
+  },
+  "matrix": {
+    "report": "published-sensor-gate-matrix.json",
+    "commandCount": 11
+  }
+}

--- a/docs/research/sensor-gate-honesty/published-acceptance.json
+++ b/docs/research/sensor-gate-honesty/published-acceptance.json
@@ -1,5 +1,7 @@
 {
   "schemaVersion": 1,
+  "issues": [95, 96, 97, 98],
+  "verdict": "partial",
   "cli": {
     "version": "8.1.6",
     "packageHash": "7a4e0e3b9fa8a1a32e1ae9604780f306d218c3d9b290e6a1f842b808307c2fa2"
@@ -25,6 +27,6 @@
   },
   "matrix": {
     "report": "published-sensor-gate-matrix.json",
-    "commandCount": 11
+    "commandCount": 12
   }
 }

--- a/docs/research/sensor-gate-honesty/published-sensor-gate-matrix.json
+++ b/docs/research/sensor-gate-honesty/published-sensor-gate-matrix.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-21T15:09:36.538Z",
+  "sanitization": { "registryRoot": "<registry-root>", "temporaryPaths": "removed" },
+  "cli": {
+    "version": "8.1.6",
+    "packageHash": "7a4e0e3b9fa8a1a32e1ae9604780f306d218c3d9b290e6a1f842b808307c2fa2"
+  },
+  "registry": {
+    "tag": "v3.0.0",
+    "commit": "3db85c92eecc449fb8f14252fe2c64bb493cfb3f",
+    "packHash": "0be244deaece90ad8671de0ca517abd7f0fce5567d0e688c8b76b8ee4f490348"
+  },
+  "commands": [
+    {
+      "name": "v2-init", "argv": ["sensors", "init", "--registry-root", "<registry-root>", "--pack", "js-ts"], "exit": 0, "signal": null,
+      "stdoutHash": "165297552e45dbc058d89d94ceb10230c9c503425c55495dcb72c746f0e1a33e", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "name": "v2-status", "argv": ["sensors", "status"], "exit": 0, "signal": null,
+      "stdoutHash": "86a161721eb013e9efa3053ebfdff2e623c51789c177ac35013a3446ae7e2fe0", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "name": "v2-preflight", "argv": ["preflight", "--verify-sensors", "--json"], "exit": 1, "signal": null,
+      "stdoutHash": "f2a4fb55acb8cf7b7c816e3a8356b850b25b302aae04484d05dd2dcf7537dae3", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "output": { "status": "degraded", "checks": [{ "id": "context", "ok": false }, { "id": "manifest", "ok": true }, { "id": "tools", "ok": true }, { "id": "pack", "ok": true }, { "id": "sensors-baseline", "ok": true }, { "id": "sensors-execution", "ok": true }, { "id": "host", "ok": true }] }
+    },
+    {
+      "name": "v2-clean-fast", "argv": ["sensors", "run", "--fast"], "exit": 0, "signal": null,
+      "stdoutHash": "a89f0fd139e90124c010406b6e069924653fd9104943df7fc7cfdbd2a95b8fbc", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "output": { "overall": "pass", "sensors": [{ "name": "lint", "status": "pass", "execution": { "timeoutMs": 30000, "timeoutSource": "pack", "requestedScope": "full", "effectiveScope": "full" } }] }
+    },
+    {
+      "name": "v2-project-timeout-fast", "argv": ["sensors", "run", "--fast"], "exit": 0, "signal": null,
+      "stdoutHash": "7f7b432fe0609acb3bf3d20321d96273c25d13affab5409cc30e092e36fbc687", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "output": { "overall": "pass", "sensors": [{ "name": "lint", "status": "pass", "execution": { "timeoutMs": 30000, "timeoutSource": "project", "requestedScope": "full", "effectiveScope": "full" } }] }
+    },
+    {
+      "name": "v2-disabled-fast", "argv": ["sensors", "run", "--fast"], "exit": 1, "signal": null,
+      "stdoutHash": "f1a3153f120467c7f834260f12250f24e632d83cf77484f21ec9e6b2286818ac", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "output": { "overall": "skipped", "sensors": [{ "name": "lint", "status": "skipped", "skipReason": "disabled", "execution": { "timeoutMs": 30000, "timeoutSource": "pack", "requestedScope": "full", "effectiveScope": "full" } }] }
+    },
+    {
+      "name": "v2-invalid-timeout-fast", "argv": ["sensors", "run", "--fast"], "exit": 1, "signal": null,
+      "stdoutHash": "deed2d199cc4451dcb9400be368ba4735d4d8ba15e7c124e3d199c1e919f6d35", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "output": { "sensors": [], "overall": "not_certified" }
+    },
+    {
+      "name": "v2-failing-fast", "argv": ["sensors", "run", "--fast"], "exit": 1, "signal": null,
+      "stdoutHash": "28d153aa95dffc348f33a21617724a93e99984df4cd416057b147bc3847da3b3", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "output": { "overall": "fail", "sensors": [{ "name": "lint", "status": "fail", "errors": [{ "file": "failure.js", "line": 1, "column": 1, "rule": "no-undef" }], "execution": { "timeoutMs": 30000, "timeoutSource": "pack", "requestedScope": "full", "effectiveScope": "full" } }] }
+    },
+    {
+      "name": "v2-baseline", "argv": ["sensors", "baseline"], "exit": 0, "signal": null,
+      "stdoutHash": "99515b51a1e0cc232e2a25bf7d45b257cf6c4ef14377c855c9da76fdbd7d021f", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "name": "v2-baselined-fast", "argv": ["sensors", "run", "--fast"], "exit": 0, "signal": null,
+      "stdoutHash": "e461ecbacdaa90afd868a5d5bf29d74af7afd0448c436ab23a59bb480180dd32", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "output": { "overall": "pass", "sensors": [{ "name": "lint", "status": "pass", "newCount": 0, "baselineCount": 1, "execution": { "timeoutMs": 30000, "timeoutSource": "pack", "requestedScope": "full", "effectiveScope": "full" } }] }
+    },
+    {
+      "name": "v2-changed-fast", "argv": ["sensors", "run", "--fast", "--changed"], "exit": 0, "signal": null,
+      "stdoutHash": "a09bae79f44dba0bef4c7d699b5835087e523385ee68fec7f15729552cf37fa4", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "output": { "overall": "pass", "changedScope": { "files": 1 }, "sensors": [{ "name": "lint", "status": "pass", "scope": "changed", "execution": { "timeoutMs": 30000, "timeoutSource": "pack", "requestedScope": "changed", "effectiveScope": "changed", "files": 1 } }] }
+    },
+    {
+      "name": "legacy-fast", "argv": ["sensors", "run", "--fast"], "exit": 1, "signal": null,
+      "stdoutHash": "81bc6506e9104b3c2b40837fa613d04d8d8a5b6d9d0bdaa21beafbd63f92e1cd", "stderrHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "output": { "overall": "not_certified", "sensors": [{ "name": "lint", "status": "pass", "execution": { "timeoutMs": 10000, "timeoutSource": "fallback", "requestedScope": "full", "effectiveScope": "full" } }] }
+    }
+  ]
+}


### PR DESCRIPTION
Persists a sanitized reproducible acceptance record for the published CLI 8.1.6 and registry tag v3.0.0. The opt-in matrix records 12 real commands, semantic outcomes, exits, hashes, and sanitized argv. Its verdict remains partial: uncovered release scenarios are documented rather than synthesized. Verification: published matrix, structural test, typecheck, full sensor gate overall pass, and diff check. No issue is closed by this PR.