### PR TITLE
feat(sensors): soporte packageRoot para monorepos + brief y planes de orquestadores declarados

### DIFF
--- a/cli/src/commands/sensors/compatibility/manifest.ts
+++ b/cli/src/commands/sensors/compatibility/manifest.ts
@@ -13,6 +13,13 @@ export type SensorManifestV2 = {
     /** Durable operator intent. Absent means detected/fallback, never explicit. */
     packSelection?: 'explicit';
     registryRoot?: string;
+    /** Contained relative path from this manifest's directory to the actual
+     *  project root (package.json/tsconfig/etc) sensors should detect against
+     *  and execute in. Absent means the manifest's own directory — unchanged
+     *  behavior for a single-package repo. Exists for a monorepo where the
+     *  manifest lives at the repo root but the real package lives in a
+     *  subdirectory (e.g. "cli"). */
+    packageRoot?: string;
     sensors: Record<string, { enabled: boolean; fast?: boolean; timeout?: number; variantId: string; command: StructuredCommand; assets?: string[]; policyRef?: 'shared/semgrep-policy.json'; initializedCompatibility: CompatibilityEvidence }>;
     concurrency?: number;
 };
@@ -176,7 +183,7 @@ function provenanceRoot(value: unknown, source: unknown): string {
 }
 
 function parseV2Manifest(value: UnknownRecord, source: unknown): SensorManifestV2 {
-    fields(value, ['schemaVersion', 'pack', 'packSelection', 'registryRoot', 'sensors', 'concurrency'], source, 'root');
+    fields(value, ['schemaVersion', 'pack', 'packSelection', 'registryRoot', 'packageRoot', 'sensors', 'concurrency'], source, 'root');
     if (value.schemaVersion !== 2) invalid(source, `unsupported manifest schemaVersion ${String(value.schemaVersion)}; supported: legacy, 2; upgrade or migrate the manifest`);
     const pack = id(value.pack, source, 'pack');
     const sensorsInput = record(value.sensors, source, 'sensors');
@@ -188,6 +195,7 @@ function parseV2Manifest(value: UnknownRecord, source: unknown): SensorManifestV
         manifest.packSelection = 'explicit';
     }
     if ('registryRoot' in value) manifest.registryRoot = provenanceRoot(value.registryRoot, source);
+    if ('packageRoot' in value) manifest.packageRoot = asset(value.packageRoot, source, 'packageRoot');
     if ('concurrency' in value) {
         if (typeof value.concurrency !== 'number' || !Number.isSafeInteger(value.concurrency) || value.concurrency <= 0) invalid(source, 'concurrency must be a positive safe integer');
         manifest.concurrency = value.concurrency;

--- a/cli/src/commands/sensors/compatibility/materialize.ts
+++ b/cli/src/commands/sensors/compatibility/materialize.ts
@@ -10,6 +10,12 @@ export type MaterializeInput = {
     pack: string;
     packSelection?: 'explicit';
     registryRoot?: string;
+    /** Contained relative path from projectRoot to where sensors actually detect
+     *  and execute (monorepo support). When set, configured assets are copied
+     *  here instead of projectRoot — a config-relative tool invocation only
+     *  finds its asset if it sits where the tool's cwd actually is. The
+     *  manifest file itself always stays at projectRoot regardless. */
+    packageRoot?: string;
     sensors: Record<string, V2Sensor>;
     configure?: boolean;
 };
@@ -77,7 +83,11 @@ export function materializeResolvedSensors(input: MaterializeInput): Materialize
         if (parsed.kind !== 'v2') throw new Error('materialized sensor must be v2');
         sensors[name] = parsed.pack.sensors[name];
     }
-    const manifest: SensorManifestV2 = { schemaVersion: 2, pack, sensors, ...(input.packSelection === 'explicit' ? { packSelection: 'explicit' } : {}), ...(input.registryRoot ? { registryRoot: input.registryRoot } : {}) };
+    const manifest: SensorManifestV2 = { schemaVersion: 2, pack, sensors, ...(input.packSelection === 'explicit' ? { packSelection: 'explicit' } : {}), ...(input.registryRoot ? { registryRoot: input.registryRoot } : {}), ...(input.packageRoot ? { packageRoot: containedAsset(input.packageRoot, 'packageRoot') } : {}) };
+    // Assets land where sensors will actually run — projectRoot by default, or
+    // packageRoot underneath it for a monorepo. The manifest write below stays
+    // pinned to projectRoot either way (see atomicWrite call at the end).
+    const configRoot = manifest.packageRoot ? root(path.join(projectRoot, manifest.packageRoot), 'packageRoot') : projectRoot;
     // A policy reference is deliberately not a materialized asset. Resolve it here
     // from the registry-owned sibling only, so a manifest cannot turn arbitrary
     // registry content into a project write through a cosmetic policy field.
@@ -93,7 +103,7 @@ export function materializeResolvedSensors(input: MaterializeInput): Materialize
         if (input.configure !== false) {
             for (const asset of selected) {
                 const source = path.join(packRoot, ...asset.split('/'));
-                const destination = path.join(projectRoot, ...asset.split('/'));
+                const destination = path.join(configRoot, ...asset.split('/'));
                 let stat: fs.Stats;
                 try { stat = fs.lstatSync(source); } catch { throw new Error(`selected asset is missing from pack: ${asset}`); }
                 if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`selected asset must be a regular file: ${asset}`);

--- a/cli/src/commands/sensors/index.ts
+++ b/cli/src/commands/sensors/index.ts
@@ -63,10 +63,11 @@ export function registerSensorsCommand(program: Command): void {
         .option('--no-configure', 'skip copying sensor pack config files into the project')
         .option('--registry-root <path>', 'path to AWM registry root')
         .option('--pack <name>', 'skip auto-detection, use this pack explicitly')
+        .option('--package-root <dir>', 'run detection/execution from this subdirectory (monorepo support) — the manifest still writes at the current directory')
         .action(async (opts) => {
             const registryRoot = opts.registryRoot ?? capabilityRoot('sensor-packs') ?? undefined;
             try {
-                const result = await initSensors({ configure: opts.configure, registryRoot, pack: opts.pack });
+                const result = await initSensors({ configure: opts.configure, registryRoot, pack: opts.pack, packageRoot: opts.packageRoot });
                 log.success(`Detected: ${result.detection.pack} (${result.detection.indicators.join(', ') || 'fallback'})`);
                 // Said BEFORE "Wrote .awm/sensors.json": the manifest about to be
                 // reported as written is not the one the detection implied.

--- a/cli/src/commands/sensors/init.ts
+++ b/cli/src/commands/sensors/init.ts
@@ -13,6 +13,10 @@ export type InitOptions = {
     cwd?: string;
     registryRoot?: string;
     pack?: string;
+    /** Contained relative path from cwd to the real project (package.json/tsconfig/
+     *  etc). Monorepo support: the manifest is still written under cwd/.awm, but
+     *  detection and materialized assets both resolve against cwd/packageRoot. */
+    packageRoot?: string;
 };
 
 type ResolvedV2Pack = { pack: SensorPackV2; packRoot: string };
@@ -243,6 +247,10 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
     const cwd = opts.cwd ?? process.cwd();
     const configure = opts.configure ?? true; // configure (copy pack config files) by default
     const manifestPath = path.join(cwd, '.awm', 'sensors.json');
+    // Monorepo support: detection and evidence both need to see the real project,
+    // not the (possibly unrelated) directory the manifest lives in. The manifest
+    // write itself stays pinned to cwd regardless — see manifestPath above.
+    const detectionCwd = opts.packageRoot ? path.resolve(cwd, opts.packageRoot) : cwd;
 
     // --pack skips the heuristic entirely. Only validate against the registry when a
     // registryRoot was actually given — same tolerance pattern as readPackDefaults /
@@ -253,7 +261,7 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
         if (opts.registryRoot) assertPackExists(opts.pack, opts.registryRoot);
         detection = { pack: opts.pack, indicators: ['--pack override'] };
     } else {
-        detection = detectStack(cwd);
+        detection = detectStack(detectionCwd);
     }
 
     let existing: SensorManifest | undefined;
@@ -280,7 +288,7 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
         const resolvedV2 = readV2Pack(resolvedPack, opts.registryRoot);
         if (resolvedV2) {
             const packSelection = opts.pack ? 'explicit' as const : undefined;
-            const live = await resolveParsedPackCompatibility(cwd, resolvedV2.pack, { packSelection });
+            const live = await resolveParsedPackCompatibility(detectionCwd, resolvedV2.pack, { packSelection });
             const compatibility = live.sensors;
             const sensors: Record<string, any> = {};
             for (const [name, sensor] of Object.entries(live.pack.sensors)) {
@@ -311,7 +319,8 @@ export async function initSensors(opts: InitOptions = {}): Promise<{
             }
             const materialized = materializeResolvedSensors({
                 projectRoot: cwd, packRoot: resolvedV2.packRoot,
-                pack: resolvedPack, ...(packSelection ? { packSelection } : {}), registryRoot: opts.registryRoot, sensors, configure,
+                pack: resolvedPack, ...(packSelection ? { packSelection } : {}), registryRoot: opts.registryRoot,
+                ...(opts.packageRoot ? { packageRoot: opts.packageRoot } : {}), sensors, configure,
             });
             return { detection, ...materialized,
                 compatibility, ...(unavailablePack ? { unavailablePack } : {}) };

--- a/cli/src/commands/sensors/run.ts
+++ b/cli/src/commands/sensors/run.ts
@@ -173,7 +173,15 @@ export async function runSensors(opts: RunOptions = {}): Promise<RunOutput> {
         const scopeError = changedScopeError(changed);
         if (scopeError) changed.error = scopeError;
     }
-    const live = parsed.kind === 'v2' ? await resolveLiveV2(manifestDir, parsed) : null;
+    // Monorepo support: a v2 manifest may declare packageRoot so detection and
+    // execution both happen against the real package (e.g. "cli"), while the
+    // manifest itself stays discoverable at the repo root via findManifestDir.
+    // Legacy manifests never carry this field — manifestDir is always correct
+    // for them, unchanged.
+    const projectCwd = parsed.kind === 'v2' && parsed.pack.packageRoot
+        ? path.resolve(manifestDir, parsed.pack.packageRoot)
+        : manifestDir;
+    const live = parsed.kind === 'v2' ? await resolveLiveV2(projectCwd, parsed) : null;
     const drift = parsed.kind === 'legacy' ? detectPackDrift(manifestDir, parsed.pack) : undefined;
     const requestedScope = opts.changed ? 'changed' as const : 'full' as const;
     const prepared: PreparedSensorExecution[] = [];
@@ -194,7 +202,7 @@ export async function runSensors(opts: RunOptions = {}): Promise<RunOutput> {
     }
 
     const results = await pooled(prepared.map(entry => async () => {
-        const result = await executePrepared(entry, manifestDir);
+        const result = await executePrepared(entry, projectCwd);
         return baseline ? applyBaseline(result, baseline[entry.name]) : result;
     }), resolveConcurrency(parsed.pack, prepared.length));
 

--- a/cli/tests/commands/sensors/compatibility/manifest.test.ts
+++ b/cli/tests/commands/sensors/compatibility/manifest.test.ts
@@ -90,6 +90,21 @@ describe('sensor manifest contract', () => {
         expect(() => parseSensorManifest({ schemaVersion: 2, pack: 'js-ts', sensors: { lint: sensor } }, 'source')).toThrow('certifiedRange');
     });
 
+    it('accepts a v2 packageRoot for monorepo-scoped sensor detection/execution', () => {
+        const manifest = { ...validV2Manifest(), packageRoot: 'cli' };
+        expect(parseSensorManifest(manifest, 'source')).toMatchObject({ kind: 'v2', pack: { packageRoot: 'cli' } });
+    });
+
+    it('rejects a packageRoot that escapes the manifest directory', () => {
+        const manifest = { ...validV2Manifest(), packageRoot: '../outside' };
+        expect(() => parseSensorManifest(manifest, 'source')).toThrow('packageRoot');
+    });
+
+    it('rejects an absolute packageRoot', () => {
+        const manifest = { ...validV2Manifest(), packageRoot: '/etc' };
+        expect(() => parseSensorManifest(manifest, 'source')).toThrow('packageRoot');
+    });
+
     test.each([
         [null, 'object'],
         [{}, 'pack'],

--- a/cli/tests/commands/sensors/init.test.ts
+++ b/cli/tests/commands/sensors/init.test.ts
@@ -469,6 +469,66 @@ describe('initSensors', () => {
     });
 });
 
+describe('initSensors — packageRoot (monorepo)', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-init-monorepo-'));
+    });
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('detects the real package under packageRoot, not the manifest directory', async () => {
+        const v2Registry = makeV2Registry();
+        try {
+            // The manifest will live at tmpDir/.awm/sensors.json (repo root), but the
+            // real package — package.json, node_modules — lives under tmpDir/cli.
+            const packageDir = path.join(tmpDir, 'cli');
+            fs.mkdirSync(packageDir, { recursive: true });
+            fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ devDependencies: { eslint: '^10.0.0' } }));
+            fs.mkdirSync(path.join(packageDir, 'node_modules', 'eslint'), { recursive: true });
+            fs.writeFileSync(path.join(packageDir, 'node_modules', 'eslint', 'package.json'), JSON.stringify({ version: '10.0.0' }));
+
+            const result = await initSensors({ cwd: tmpDir, registryRoot: v2Registry, packageRoot: 'cli' });
+
+            // Real detection succeeded — a manifest built against tmpDir root (with no
+            // package.json there) would leave lint unresolved/absent.
+            expect(result.manifest).toMatchObject({ packageRoot: 'cli', sensors: { lint: { variantId: 'eslint-10' } } });
+
+            // The manifest itself stays discoverable at the repo root (findManifestDir
+            // walks up from cwd, never down into subdirectories).
+            expect(fs.existsSync(path.join(tmpDir, '.awm', 'sensors.json'))).toBe(true);
+            expect(fs.existsSync(path.join(packageDir, '.awm', 'sensors.json'))).toBe(false);
+            const written = JSON.parse(fs.readFileSync(path.join(tmpDir, '.awm', 'sensors.json'), 'utf8'));
+            expect(written.packageRoot).toBe('cli');
+        } finally {
+            fs.rmSync(v2Registry, { recursive: true, force: true });
+        }
+    });
+
+    it('copies configured assets into packageRoot, not the manifest directory', async () => {
+        const v2Registry = makeV2Registry();
+        try {
+            const packageDir = path.join(tmpDir, 'cli');
+            fs.mkdirSync(packageDir, { recursive: true });
+            fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ devDependencies: { eslint: '^10.0.0' } }));
+            fs.mkdirSync(path.join(packageDir, 'node_modules', 'eslint'), { recursive: true });
+            fs.writeFileSync(path.join(packageDir, 'node_modules', 'eslint', 'package.json'), JSON.stringify({ version: '10.0.0' }));
+
+            await initSensors({ cwd: tmpDir, registryRoot: v2Registry, packageRoot: 'cli' });
+
+            // The asset must land where the lint sensor will actually execute (cwd=cli),
+            // not at the manifest's own directory (repo root) — otherwise a config-relative
+            // tool invocation can never find it.
+            expect(fs.existsSync(path.join(packageDir, 'eslint.config.awm.mjs'))).toBe(true);
+            expect(fs.existsSync(path.join(tmpDir, 'eslint.config.awm.mjs'))).toBe(false);
+        } finally {
+            fs.rmSync(v2Registry, { recursive: true, force: true });
+        }
+    });
+});
+
 describe('initSensors — --pack override', () => {
     let tmpDir: string;
     let registryRoot: string;

--- a/cli/tests/commands/sensors/run.test.ts
+++ b/cli/tests/commands/sensors/run.test.ts
@@ -308,6 +308,43 @@ describe('runSensors v2 lifecycle contract', () => {
         expect(mockRunStructuredCommand).toHaveBeenCalledWith(expect.objectContaining({ executable: 'live-eslint' }), expect.any(Object));
     });
 
+    it('scopes applicability detection and execution to packageRoot for a monorepo manifest', async () => {
+        // Move the fixture project into a subdirectory ("cli") and point the
+        // manifest at it via packageRoot — mirrors a monorepo where the
+        // manifest lives at the repo root but the real package lives deeper.
+        const packageDir = path.join(project, 'cli');
+        fs.mkdirSync(packageDir, { recursive: true });
+        fs.renameSync(path.join(project, 'package.json'), path.join(packageDir, 'package.json'));
+        fs.renameSync(path.join(project, 'node_modules'), path.join(packageDir, 'node_modules'));
+
+        const manifestPath = path.join(project, '.awm', 'sensors.json');
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        manifest.packageRoot = 'cli';
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+        const { runSensors } = require('../../../src/commands/sensors/run');
+        const result = await runSensors({ cwd: project, fast: true });
+
+        expect(result).toEqual(expect.objectContaining({ overall: 'pass' }));
+        expect(mockRunStructuredCommand).toHaveBeenCalledWith(
+            expect.objectContaining({ executable: 'live-eslint' }),
+            expect.objectContaining({ cwd: packageDir }),
+        );
+    });
+
+    it('degrades to not_certified (never a false pass, never a crash) when packageRoot points nowhere', async () => {
+        const manifestPath = path.join(project, '.awm', 'sensors.json');
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        manifest.packageRoot = 'does-not-exist';
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+        const { runSensors } = require('../../../src/commands/sensors/run');
+        const result = await runSensors({ cwd: project, fast: true });
+
+        expect(result.overall).toBe('not_certified');
+        expect(mockRunStructuredCommand).not.toHaveBeenCalled();
+    });
+
     it('honors disabled v2 sensors before dispatching them', async () => {
         const manifest = JSON.parse(fs.readFileSync(path.join(project, '.awm', 'sensors.json'), 'utf8'));
         manifest.sensors.lint.enabled = false;

--- a/docs/plans/2026-08-21-registry-declared-orchestrators-brief.md
+++ b/docs/plans/2026-08-21-registry-declared-orchestrators-brief.md
@@ -6,7 +6,7 @@ mode: brief
 readiness: ready
 created: 2026-08-21
 updated: 2026-08-21
-open_decisions: [DA-1, DA-2, DA-3, DA-4]
+open_decisions: [DA-4]
 project: agentic-workflow
 ---
 
@@ -188,12 +188,14 @@ flowchart TD
 
 ## Open Decisions
 
-| ID | Decisión | Bloquea | Posiciones conocidas |
+Resueltas durante la fase de diseño (`brainstorming`, Brief Preload Mode); se conservan en la tabla por trazabilidad, con su resolución registrada. Solo `DA-4` sigue abierta, y no bloquea ningún release.
+
+| ID | Decisión | Bloquea | Estado y resolución |
 |---|---|---|---|
-| DA-1 | Cómo se garantiza que un orquestador de un registry personal sea invisible para otra persona con acceso a la misma máquina o al mismo repositorio | Release 1 | Depende de lo que R0 encuentre sobre el modelo de instalación y symlinks. Posiciones a evaluar: aislamiento por directorio de usuario del sistema operativo / registry marcado como privado en su manifiesto / instalación fuera del alcance compartido. No se elige sin el hallazgo de R0. |
-| DA-2 | Si la precedencia entre orquestadores la declara cada registry o si es fija y la define el framework | Release 2 | Declarada por el registry: más flexible, permite que un autor exprese "voy antes que el flujo de desarrollo". Fija en el framework: más predecible, evita que dos autores se declaren ambos primeros. |
-| DA-3 | Qué ocurre cuando dos orquestadores declarados resultan aplicables a la vez y la precedencia no los desempata | Release 2 | Posición registrada en RF-2.3 como comportamiento por defecto seguro (no aplicar ninguno). Alternativas a evaluar: preguntar al usuario / desempatar por orden de instalación / rechazar la instalación que introduce el solapamiento. |
-| DA-4 | Si se incorpora, y bajo qué disparador, la capa aditiva O1 (predicado determinista evaluado por el framework sobre un espacio de hechos de sesión) | ninguna | Se difiere deliberadamente. Se incorpora solo si el uso real demuestra que el juicio del agente sobre el disparador en prosa activa de más o de menos con frecuencia intolerable. Es aditiva por diseño: no rompe registries existentes. |
+| DA-1 | Cómo se garantiza que un orquestador de un registry personal sea invisible para quien no lo instaló | ninguna (resuelta) | **Resuelta.** El dueño acotó el modelo de amenaza: el vector real es el repositorio compartido — compañeros en sus propias máquinas, sin cuentas ni equipos comunes. La garantía exigible es por tanto "nada del registry personal toca el árbol versionado del repositorio", que el modelo de instalación por `HOME` ya satisface (skills bajo `~/.claude/skills`, hooks bajo `~/.awm/hooks`). Escenarios de cuenta compartida, contenedor con `HOME` común y sesiones de CI quedan fuera del modelo de amenaza y por tanto fuera de alcance. `RNF-T.3` se verifica con `CA-T.3`, cuya parte de árbol limpio es la que ahora manda. |
+| DA-2 | Si la precedencia entre orquestadores la declara cada registry o si es fija y la define el framework | ninguna (resuelta) | **Resuelta: ninguna de las dos.** La precedencia deja de ser un concepto del framework. AWM fija una sola regla agnóstica — los orquestadores declarados se consideran antes que `development-process` y `product-process` — y el orden **entre** declarados emerge del contrato de terminación (`PR-2`): cada orquestador nombra a quién cede el control, igual que hoy `product-process` cede a `development-process`. Descartada la precedencia declarada por ser un namespace compartido sin coordinador (dos equipos declarándose primeros colisionan sin árbitro posible bajo O2b) y por agregar la fricción de autoría que `RF-4.1` busca eliminar. Consecuencia aceptada: el acoplamiento pasa a estar entre procesos, que es donde corresponde, y no en el framework. |
+| DA-3 | Qué ocurre cuando dos orquestadores declarados resultan aplicables a la vez | ninguna (reducida) | **Reducida por la resolución de DA-2.** Dos declarados aplicables ya no compiten: uno se ejecuta y nombra al siguiente en su terminación. El caso residual —dos aplicables y ninguno nombra al otro— queda cubierto por el comportamiento por defecto seguro que `RF-2.3` ya especifica: no aplicar ninguno y continuar con el ruteo actual. No requiere mecanismo adicional. |
+| DA-4 | Si se incorpora, y bajo qué disparador, la capa aditiva O1 (predicado determinista evaluado por el framework sobre un espacio de hechos de sesión) | ninguna | **Abierta, diferida deliberadamente.** Se incorpora solo si el uso real demuestra que el juicio del agente sobre el disparador en prosa activa de más o de menos con frecuencia intolerable. Es aditiva por diseño: no rompe registries existentes. |
 
 ## Out of Scope
 
@@ -218,14 +220,14 @@ Orden por valor de negocio, no por dependencia técnica. Release 1 va primero po
 
 - **Valor productivo independiente:** el proceso propio deja de ser un skill suelto y pasa a estar versionado, aislado y distribuible con el contrato de registry que ya existe y funciona, sin tocar el CLI. Elimina la deuda de N2 y satisface la frontera personal↔corporativo, aun si Release 2 nunca se hiciera.
 - **Alcance:** RF-4.1, RF-4.2, RNF-T.3, RNF-T.5. Método de autoría documentado (PR-3) y un registry propio real construido con ese método.
-- **Bloqueado por:** DA-1.
+- **Bloqueado por:** nada (DA-1 resuelta en fase de diseño).
 - **Aceptación:** CA-4.1, CA-4.2, CA-T.3, CA-T.5.
 
 ### Release 2 — Punto de extensión en `use-awm`
 
 - **Valor productivo independiente:** cualquier equipo declara su orquestador y AWM lo considera y lo rutea. Es lo que convierte a AWM de herramienta con dos procesos fijos en plataforma extensible, y es lo comprometido con los líderes.
 - **Alcance:** RF-1.1, RF-1.2, RF-1.3, RF-2.1, RF-2.2, RF-2.3, RF-3.1, RF-3.2, RNF-T.1, RNF-T.2, RNF-T.4. Implementa PR-1 y PR-2.
-- **Bloqueado por:** DA-2, DA-3.
+- **Bloqueado por:** nada (DA-2 resuelta, DA-3 reducida a un caso ya especificado por RF-2.3).
 - **Aceptación:** CA-1.1, CA-1.2, CA-1.3, CA-2.1, CA-2.2, CA-2.3, CA-3.1, CA-3.2, CA-T.1, CA-T.2, CA-T.4.
 
 ## Risks

--- a/docs/plans/2026-08-21-registry-declared-orchestrators-brief.md
+++ b/docs/plans/2026-08-21-registry-declared-orchestrators-brief.md
@@ -1,0 +1,240 @@
+---
+awm: product-brief
+schema: 1
+title: Orquestadores de proceso declarados por registry
+mode: brief
+readiness: ready
+created: 2026-08-21
+updated: 2026-08-21
+open_decisions: [DA-1, DA-2, DA-3, DA-4]
+project: agentic-workflow
+---
+
+# Orquestadores de proceso declarados por registry — Product Brief
+
+Audiencia: agente implementador (neutral respecto de proveedor) · Metodología: brief-spec (AWM `product-brief`) · Origen: sesión de `product-discovery` (fases 1–5) + decisión de `architecture-advisor` en modo contextual.
+
+## Business Need
+
+- **N1** — El autor de AWM y los líderes de equipo que ya solicitaron incorporar su propio proceso no tienen forma de hacerlo: `use-awm` conoce exclusivamente `development-process` y `product-process`, de modo que toda sesión se rutea a uno de esos dos aunque el trabajo real corresponda a otro proceso. El costo se paga por sesión, todos los días, en dos monedas: tiempo de re-encauce conversacional del agente, y adopción — un líder que comprueba que AWM no habla su idioma vuelve a usar el agente sin AWM, y recuperarlo cuesta más que haberlo retenido.
+
+- **N2** — Al no existir un método estandarizado para crear un registry que aporte un proceso, los procesos propios se instalan hoy como skills sueltos fuera del contrato de registry: sin versionado, sin `awm update`, sin entrada en `catalog.json`. Cada skill suelto agrega deuda y riesgo de colisión de nombres; la trayectoria declarada por el dueño es de empeoramiento progresivo hasta que una actualización rompa una instalación.
+
+## Business Cases
+
+Catálogo confirmado como completo por el dueño durante `product-discovery` (fase 3). Se enumera como casos observables, no como requisitos.
+
+**Ejecución y ciclo de vida**
+
+- **Sesión ordinaria con dos procesos activos.** El usuario abre sesión en un repositorio de la compañía, siendo una de varias sesiones en paralelo. Aplican dos procesos: uno que sigue a la persona (su proceso de productividad) y otro que sigue al proyecto (infraestructura, formas de compilar y probar). El primero se resuelve, luego el segundo aporta lo suyo, y recién después entra el flujo de desarrollo o producto. Durante el trabajo, el primero sigue activo y actualiza sus registros. Al cerrar, cierra lo que abrió.
+- **Solo proceso de proyecto.** Un integrante del equipo abre sesión en el mismo repositorio. Le aplica únicamente el proceso del producto; el proceso personal del dueño no se le menciona, no se le ofrece y no le corre.
+- **Solo proceso personal.** El repositorio no tiene proceso de proyecto declarado (o es un repositorio personal). Aplica solamente el proceso que sigue a la persona.
+- **Ningún proceso propio.** Ni la persona ni el repositorio tienen procesos declarados. La sesión se comporta exactamente como hoy: `use-awm` rutea a `development-process` o `product-process`.
+- **N sesiones en paralelo sobre tareas distintas.** El usuario mantiene varias sesiones abiertas simultáneamente sobre trabajos diferentes. Cada una lleva su propio hilo de registro sin pisar el de las otras: si dos sesiones compiten por el mismo registro, el sistema externo termina mintiendo sobre en qué se trabajó.
+- **Eventos durante el trabajo.** El usuario pausa, se distrae, cambia de tarea o cierra. El proceso que lo requiera actualiza su sistema externo sin que el usuario tenga que pedirlo.
+- **Captura suelta.** Llega algo por un canal externo (mensajería, correo) que todavía no es una tarea. Se guarda sin convertirse en tarea, y se procesa más tarde en un momento distinto.
+
+**Autoría y distribución**
+
+- **Un equipo construye su proceso desde cero.** Hoy no existe método: se copia del registry base a mano, sin contrato ni validación.
+- **Un proceso se actualiza y debe propagarse.** El autor edita, versiona con tag, y las máquinas y personas que usan ese registry reciben el cambio con `awm update`.
+- **Aislamiento.** El proceso personal de una persona no queda registrado, visible ni ejecutable dentro del repositorio de la compañía.
+
+**Conflicto y degradación**
+
+- **Falla o conflicto.** El sistema externo con el que habla un proceso no responde o carece de credenciales; o bien dos procesos declarados quieren tomar el control simultáneamente. En ninguno de los dos escenarios el usuario puede quedar bloqueado sin poder trabajar.
+
+## Users & Context
+
+- **Autor de AWM (dueño de este brief).** Mantiene varias sesiones abiertas en paralelo, sobre trabajos personales y corporativos indistintamente, en repositorios de la compañía y propios. Encuentra el problema al inicio de cada sesión y durante el trabajo. Su proceso de productividad personal es un sistema propio que usa solamente él.
+- **Líderes de equipo con proceso propio pendiente.** Ya solicitaron explícitamente incorporar su proceso (demanda concreta, no hipotética). Lo encuentran cuando intentan adoptar AWM y comprueban que solo conoce procesos de desarrollo y de producto.
+- **Integrantes de equipo.** Trabajan en repositorios donde otra persona tiene procesos personales instalados. Su contexto exige que esos procesos les sean invisibles: no deben verlos, ejecutarlos ni enterarse de que existen.
+
+## Constraints
+
+**Frontera personal ↔ corporativo (confirmadas como duras por el dueño)**
+
+- Nada personal puede quedar commiteado en un repositorio de la compañía: ni configuración, ni identificadores, ni referencias al sistema personal.
+- El proceso personal no debe ser visible ni ejecutable por otras personas con acceso al mismo repositorio. La exigencia es invisibilidad, no meramente inactividad.
+- Credenciales y tokens nunca en el repositorio ni en el registry publicado.
+- **No es restricción:** que datos del repositorio corporativo (títulos de tarea, nombres de rama) fluyan hacia el sistema personal del dueño. Es su propia bitácora de trabajo. Se deja asentado explícitamente para que no se lo trate como omisión.
+
+**Sistema existente (intocable)**
+
+- El contrato de registry actual — layout validado, `awm-registry.json`, `catalog.json`, `awm registry add` — no se reemplaza ni pierde compatibilidad con quien ya lo usa.
+- `~/.awm` es territorio exclusivo del instalador: solo `awm init` y `awm update` escriben ahí. Aplica también a cualquier estado que un proceso necesite persistir.
+- `use-awm`, `development-process` y `product-process` no pueden sufrir regresión: quien no tenga procesos propios declarados debe obtener el comportamiento actual, idéntico.
+- El gate de CI en las tres plataformas (`ubuntu-latest`, `windows-latest`, `macos-latest`) precede a toda publicación (D-005 en `docs/decisions.md`).
+
+**Costo y recursos**
+
+- Sin presupuesto asignado. El único recurso es el tiempo del propio dueño; no hay equipo disponible para tomar parte del trabajo.
+- La solución no puede introducir suscripciones, servicios cloud ni dependencias pagas: debe funcionar íntegramente sobre lo que ya existe en la instalación actual de AWM y en el entorno de trabajo del usuario.
+- Corolario de alcance: toda alternativa que exija infraestructura propia (un servicio corriendo, un almacén externo, un broker) queda descartada de plano, no diferida.
+
+**Tiempo**
+
+- Urgente. La productividad del dueño está mermando de forma activa y existen compromisos de entrega de funcionalidad con los equipos para la semana siguiente a la fecha de este brief. Esto condiciona el corte de alcance entre Release 1 y Release 2, no la calidad de ninguno de los dos.
+
+## Non-Assumption Mandate
+
+Este brief se construyó a partir de una conversación con el dueño más una lectura parcial y acotada del código durante esa misma sesión. La distinción entre lo uno y lo otro es normativa: lo que sigue como *verificado* fue leído en el árbol real; **todo lo demás no está verificado y debe confirmarse en R0 (descubrimiento de solo lectura) antes de cualquier compromiso técnico.**
+
+**Verificado en sesión (con referencia):**
+
+- `awm registry add` clona el remoto, valida el layout con `validateRegistryLayout` y detecta colisiones de contenido contra los registries ya conocidos *antes* de escribir la configuración, revirtiendo el clon si algo falla — `cli/src/commands/registry/add.ts:38-80`.
+- El manifiesto de registry se llama `awm-registry.json` y los metadatos incluyen además `catalog.json`; los directorios de contenido válidos se enumeran en `REGISTRY_DIR_NAMES` — `cli/src/core/registries.ts:27-29`.
+- El registry base declara sus bundles en `catalog.json` con un campo `scope` de valores `baseline` y `project`; cada `bundle.json` declara `name`, `version`, `description`, `scope`, `dependsOn`, `skills`, `workflows` y `agents`, y admite entradas de skill de la forma `{ "name": ..., "onSignal": true }`.
+- El hook de arranque de sesión inyecta el contenido de `using-awm.md` leído desde `${AWM_HOOKS_ROOT}` y, por separado, el contenido de `$PWD/CONSTITUTION.md` si existe y no está vacío — `hooks/session-start:28,56` en `awm-baseline-registry`. La inyección de constitución está atada al directorio de trabajo actual.
+- Los subsistemas `track` y `job` del CLI operan sobre un journal **por rama de git** y fallan si HEAD está desacoplado — `cli/src/commands/track/index.ts:20`. Implementan requests inmutables con `idempotencyKey`, un supervisor de escritor único, `heartbeat` y un `reap` que confirma identidad de proceso antes de emitir señal alguna.
+
+**NO verificado — confirmar en R0:**
+
+- Cómo trata `awm update` a un registry que declare un orquestador: si el flujo actual basta o requiere cambios.
+- Si el mecanismo de instalación de skills (symlinks hacia `~/.awm/registries/<name>/skills/`) permite aislamiento por usuario en una misma máquina, y qué ocurre con dos usuarios del sistema operativo sobre el mismo repositorio. **Esta es la incógnita que más condiciona la restricción de invisibilidad.**
+- Si los caminos de OpenCode y Codex tienen puntos de inyección equivalentes al de Claude Code, y si el contrato propuesto se expresa igual en los tres.
+- Si `registries.json` es por usuario, por máquina o por instalación, y qué implica eso para un registry personal instalado en una máquina compartida.
+- El contenido y forma reales del archivo `using-awm.md` tal como queda instalado, y qué parte de su texto es el punto de extensión a modificar.
+- El mecanismo por el cual un registry podría declarar servidores MCP o dependencias externas, si es que existe.
+- Convenciones de nomenclatura y de testing vigentes para código nuevo en `cli/src/`, más allá de lo observado incidentalmente.
+
+Toda contradicción entre este brief y el sistema real hallada durante R0 se reporta al dueño y **nunca** se resuelve asumiendo: decide el dueño y la resolución se registra como actualización de este brief o como nueva `DA-#`. Toda definición de esquema, ruta, firma de función, formato de manifiesto y biblioteca queda delegada al implementador, y solo después de R0.
+
+## Glossary
+
+| Término | Definición |
+|---|---|
+| Orquestador declarado | Proceso aportado por un registry que se ofrece como punto de entrada de una sesión, del mismo modo que hoy lo son `development-process` y `product-process`. |
+| Disparador | Texto en prosa con el que un orquestador declarado expresa cuándo aplica. Es lo que el agente lee para decidir. AWM no interpreta su semántica. |
+| Precedencia | Regla que determina en qué orden se consideran los orquestadores declarados entre sí y frente a los dos existentes. |
+| Contrato de terminación | Obligación de un orquestador declarado de ceder el control explícitamente y de nombrar a quién se lo cede. |
+| Fail-safe | Garantía de que un orquestador declarado que no puede ejecutarse no impide que la sesión continúe. |
+| Registry | Repositorio de contenido instalable con `awm registry add`, con layout validado y metadatos propios. |
+| Bundle | Agrupación versionada de skills, workflows y agents dentro de un registry, declarada en `catalog.json`. |
+| Proceso que sigue a la persona | Orquestador cuyo disparador se cumple según quién trabaja, con independencia del repositorio. |
+| Proceso que sigue al proyecto | Orquestador cuyo disparador se cumple según dónde se trabaja, con independencia de quién. |
+
+## Processes
+
+- **PR-1 — Resolución de orquestadores al inicio de sesión.** Al comenzar una sesión, se enumeran los orquestadores declarados por los registries instalados, junto con los dos existentes. El agente lee el disparador de cada uno y selecciona el que corresponde al trabajo que la sesión inicia. Si ninguno declarado aplica, el comportamiento es el actual. Si uno declarado aplica, se ejecuta y luego cede el control según PR-2.
+  - Si R0 confirma que el punto de inyección de `using-awm.md` admite una lista construida en tiempo de instalación, la enumeración se materializa ahí; en caso contrario, el implementador propone el punto de extensión equivalente y lo somete al dueño antes de comprometerlo.
+  - Ante duda o empate entre dos orquestadores declarados, el comportamiento por defecto es **no aplicar ninguno** y continuar como hoy. La resolución definitiva del empate es `DA-3`.
+
+```mermaid
+flowchart TD
+    A[Inicio de sesión] --> B[Enumerar orquestadores declarados<br/>+ development-process + product-process]
+    B --> C{¿Algún declarado<br/>aplica según su disparador?}
+    C -->|Ninguno| D[Comportamiento actual:<br/>ruteo entre los dos existentes]
+    C -->|Empate o duda| D
+    C -->|Exactamente uno| E{¿Puede ejecutarse?}
+    E -->|No| F[Fail-safe: avisar y continuar<br/>sin bloquear la sesión]
+    F --> D
+    E -->|Sí| G[Ejecutar orquestador declarado]
+    G --> H[PR-2: cesión de control]
+    H --> D
+```
+
+- **PR-2 — Cesión de control.** Un orquestador declarado termina en un estado terminal explícito y nombra a quién cede el control: a otro orquestador declarado, a `development-process`, a `product-process`, o a nadie (la sesión termina ahí). No existe la co-existencia de dos orquestadores activos, del mismo modo que hoy `product-process` y `development-process` no co-existen. Lo que el orquestador declarado haya hecho internamente no viaja por ningún canal lateral: lo que no quede en el estado que él mismo produzca, no cruzó.
+
+- **PR-3 — Autoría y publicación de un registry con orquestador.** Un autor parte de un método documentado y reproducible: crea el repositorio con el layout que el contrato exige, declara el orquestador y su disparador, valida localmente que el layout y la ausencia de colisiones se cumplen, publica con tag de versión, y las instalaciones lo reciben con `awm update`. El método no exige copiar del registry base a mano ni conocer detalles internos del CLI.
+  - Si R0 confirma que existe validación local invocable antes de publicar, PR-3 la usa; en caso contrario, el implementador propone cómo el autor verifica su registry sin instalarlo en una máquina real.
+
+## Requirements
+
+**RF-1 — Declaración y descubrimiento**
+
+- **RF-1.1** — CUANDO un registry instalado declare que aporta un orquestador, EL sistema DEBERÁ incluirlo en el conjunto de orquestadores considerados al inicio de la sesión.
+  - **CA-1.1** — Con un registry de prueba que declara un orquestador instalado mediante `awm registry add`, iniciar una sesión real y comprobar que el orquestador declarado aparece entre las opciones consideradas. Verificable contra una instalación real, no contra mocks.
+- **RF-1.2** — SI un registry declara un orquestador con una declaración malformada o incompleta, ENTONCES EL sistema DEBERÁ rechazar esa declaración e informarla, sin impedir que el resto de los orquestadores del mismo registry o de otros se consideren.
+  - **CA-1.2** — Instalar un registry con una declaración inválida y comprobar que la sesión inicia, que el error se reporta de forma legible, y que los demás orquestadores siguen disponibles.
+- **RF-1.3** — EL sistema NO DEBERÁ requerir conocimiento del dominio de un orquestador declarado para descubrirlo: la declaración se limita a identidad, disparador, precedencia y destino de terminación.
+  - **CA-1.3** — Revisión del contrato publicado: ningún campo del manifiesto admite ni exige vocabulario específico de un proceso concreto. Se verifica declarando dos orquestadores de dominios ajenos entre sí y comprobando que ambos se expresan sin campos ad hoc.
+
+**RF-2 — Selección y precedencia**
+
+- **RF-2.1** — CUANDO existan uno o más orquestadores declarados aplicables, EL sistema DEBERÁ seleccionar exactamente uno para ejecutar, según su disparador y la regla de precedencia vigente.
+  - **CA-2.1** — Con dos orquestadores declarados de disparadores disjuntos instalados, iniciar sesiones que correspondan a cada uno y comprobar que se selecciona el correcto en cada caso.
+- **RF-2.2** — SI ningún orquestador declarado aplica, ENTONCES EL sistema DEBERÁ continuar con el ruteo actual entre `development-process` y `product-process`, sin mención alguna a los orquestadores declarados.
+  - **CA-2.2** — Con orquestadores declarados instalados pero cuyos disparadores no aplican, comprobar que la sesión se comporta de forma indistinguible de una sesión sin ellos.
+- **RF-2.3** — SI dos o más orquestadores declarados resultan aplicables simultáneamente y la precedencia no los desempata, ENTONCES EL sistema DEBERÁ no aplicar ninguno y continuar con el ruteo actual.
+  - **CA-2.3** — Instalar dos orquestadores con disparadores deliberadamente solapados y comprobar que la sesión continúa con el comportamiento actual en lugar de elegir arbitrariamente.
+
+**RF-3 — Terminación**
+
+- **RF-3.1** — CUANDO un orquestador declarado concluya, EL sistema DEBERÁ requerir que haya nombrado explícitamente su destino de terminación.
+  - **CA-3.1** — Ejecutar un orquestador declarado de prueba hasta su conclusión y comprobar que el destino queda registrado y es observable.
+- **RF-3.2** — EL sistema NO DEBERÁ permitir que dos orquestadores estén activos simultáneamente.
+  - **CA-3.2** — Provocar que un orquestador declarado intente invocar a otro sin haber concluido, y comprobar que se impide.
+
+**RF-4 — Autoría y distribución**
+
+- **RF-4.1** — EL sistema DEBERÁ proveer un método documentado y reproducible para crear un registry que aporte un orquestador, sin requerir copiar contenido del registry base a mano.
+  - **CA-4.1** — Una persona ajena al desarrollo del CLI sigue el método documentado y produce un registry instalable que supera la validación de layout y de colisiones. Verificable con una persona real, no con una simulación.
+- **RF-4.2** — CUANDO el autor de un registry publique una versión nueva con tag, EL sistema DEBERÁ entregar ese cambio a las instalaciones mediante `awm update`, sin pasos manuales adicionales.
+  - **CA-4.2** — Publicar una versión nueva de un registry de prueba y comprobar en una instalación distinta que `awm update` la trae.
+
+**RNF-T — Transversales**
+
+- **RNF-T.1 (fail-safe)** — SI un orquestador declarado no puede ejecutarse por cualquier causa —incluida la indisponibilidad de un sistema externo del que dependa—, ENTONCES EL sistema DEBERÁ informarlo y continuar la sesión sin bloquear al usuario.
+  - **CA-T.1** — Con un orquestador declarado cuya dependencia externa está deliberadamente caída, iniciar sesión y comprobar que el usuario puede trabajar, y que el fallo se reporta sin interrumpir.
+- **RNF-T.2 (sin regresión)** — EL sistema DEBERÁ producir, en ausencia de orquestadores declarados, un comportamiento idéntico al vigente antes de este cambio.
+  - **CA-T.2** — La suite de tests existente pasa sin modificaciones de expectativas, y una sesión sin registries adicionales se comporta igual que en la versión previa.
+- **RNF-T.3 (aislamiento)** — EL sistema NO DEBERÁ hacer visible ni ejecutable, para una persona distinta de quien lo instaló, un orquestador aportado por un registry personal; ni DEBERÁ dejar rastro de ese registry en el árbol versionado del repositorio de trabajo.
+  - **CA-T.3** — Con un registry personal instalado, comprobar que `git status` en el repositorio de trabajo no reporta archivo alguno atribuible a él, y que una sesión iniciada por otra identidad no enumera ni menciona ese orquestador. La forma concreta de esta garantía depende de `DA-1`.
+- **RNF-T.4 (plataformas)** — EL sistema DEBERÁ comportarse de forma equivalente en `ubuntu-latest`, `windows-latest` y `macos-latest`.
+  - **CA-T.4** — El job de CI existente pasa en las tres plataformas con los tests nuevos incluidos, como precondición de publicación (D-005).
+- **RNF-T.5 (aislamiento de tests)** — Los tests de esta funcionalidad NO DEBERÁN tocar el `~/.awm` real, usando tmpdirs con `HOME` y `AWM_HOME` sobreescritos.
+  - **CA-T.5** — Ejecutar la suite con un `~/.awm` poblado y comprobar que queda inalterado.
+
+## Open Decisions
+
+| ID | Decisión | Bloquea | Posiciones conocidas |
+|---|---|---|---|
+| DA-1 | Cómo se garantiza que un orquestador de un registry personal sea invisible para otra persona con acceso a la misma máquina o al mismo repositorio | Release 1 | Depende de lo que R0 encuentre sobre el modelo de instalación y symlinks. Posiciones a evaluar: aislamiento por directorio de usuario del sistema operativo / registry marcado como privado en su manifiesto / instalación fuera del alcance compartido. No se elige sin el hallazgo de R0. |
+| DA-2 | Si la precedencia entre orquestadores la declara cada registry o si es fija y la define el framework | Release 2 | Declarada por el registry: más flexible, permite que un autor exprese "voy antes que el flujo de desarrollo". Fija en el framework: más predecible, evita que dos autores se declaren ambos primeros. |
+| DA-3 | Qué ocurre cuando dos orquestadores declarados resultan aplicables a la vez y la precedencia no los desempata | Release 2 | Posición registrada en RF-2.3 como comportamiento por defecto seguro (no aplicar ninguno). Alternativas a evaluar: preguntar al usuario / desempatar por orden de instalación / rechazar la instalación que introduce el solapamiento. |
+| DA-4 | Si se incorpora, y bajo qué disparador, la capa aditiva O1 (predicado determinista evaluado por el framework sobre un espacio de hechos de sesión) | ninguna | Se difiere deliberadamente. Se incorpora solo si el uso real demuestra que el juicio del agente sobre el disparador en prosa activa de más o de menos con frecuencia intolerable. Es aditiva por diseño: no rompe registries existentes. |
+
+## Out of Scope
+
+- **Runtime de sesión con estado y eventos (alternativa D).** Detección de inactividad, coordinación entre sesiones concurrentes y actualización automática de sistemas externos durante el trabajo. Queda para un brief propio. Motivo: no entra en la ventana de tiempo comprometida, y su ausencia no invalida el valor de los dos releases de este brief.
+- **Concurrencia entre sesiones y detección de inactividad como garantía del framework.** Corresponden al proceso que las necesite, no a AWM. El framework solo debe no impedirlas. Esta exclusión es deliberada y es la consecuencia directa del requisito de agnosticismo: incorporarlas obligaría a AWM a conocer qué es un bloque de tiempo y qué es inactividad.
+- **La bandeja de captura de ítems sueltos.** Es una capacidad del proceso de productividad del dueño, no del framework.
+- **La implementación del proceso de productividad del dueño y su integración con su sistema personal.** Este brief entrega el mecanismo por el que ese proceso puede existir y distribuirse; el proceso en sí es contenido de un registry, y se desarrolla en su propio repositorio de registry.
+- **Modificaciones a `development-process` y `product-process`.** No se tocan. Solo cambia quién los invoca y cuándo.
+
+## Releases
+
+Orden por valor de negocio, no por dependencia técnica. Release 1 va primero porque ataca directamente el costo que motivó el proyecto —la deuda de skills sueltos y la falta de aislamiento— y porque no depende de Release 2 para ser útil.
+
+### R0 — Descubrimiento (solo lectura)
+
+- **Valor:** ninguna decisión técnica se compromete sobre supuestos. Su entregable es el informe de estado real, el mapeo conceptual→real, las contradicciones halladas y el plan técnico conforme a las convenciones descubiertas.
+- **Alcance:** las siete incógnitas listadas en el mandato de no asunción, con prioridad en la del modelo de instalación y symlinks, por ser la que condiciona `DA-1` y por tanto Release 1.
+- **Bloqueado por:** nada.
+- **Aceptación:** el dueño valida el informe antes de que comience Release 1. R0 no modifica código ni datos.
+
+### Release 1 — Registry propio sobre el contrato existente
+
+- **Valor productivo independiente:** el proceso propio deja de ser un skill suelto y pasa a estar versionado, aislado y distribuible con el contrato de registry que ya existe y funciona, sin tocar el CLI. Elimina la deuda de N2 y satisface la frontera personal↔corporativo, aun si Release 2 nunca se hiciera.
+- **Alcance:** RF-4.1, RF-4.2, RNF-T.3, RNF-T.5. Método de autoría documentado (PR-3) y un registry propio real construido con ese método.
+- **Bloqueado por:** DA-1.
+- **Aceptación:** CA-4.1, CA-4.2, CA-T.3, CA-T.5.
+
+### Release 2 — Punto de extensión en `use-awm`
+
+- **Valor productivo independiente:** cualquier equipo declara su orquestador y AWM lo considera y lo rutea. Es lo que convierte a AWM de herramienta con dos procesos fijos en plataforma extensible, y es lo comprometido con los líderes.
+- **Alcance:** RF-1.1, RF-1.2, RF-1.3, RF-2.1, RF-2.2, RF-2.3, RF-3.1, RF-3.2, RNF-T.1, RNF-T.2, RNF-T.4. Implementa PR-1 y PR-2.
+- **Bloqueado por:** DA-2, DA-3.
+- **Aceptación:** CA-1.1, CA-1.2, CA-1.3, CA-2.1, CA-2.2, CA-2.3, CA-3.1, CA-3.2, CA-T.1, CA-T.2, CA-T.4.
+
+## Risks
+
+| Riesgo | Impacto | Mitigación |
+|---|---|---|
+| Contradicciones entre este brief y el sistema real | Retrabajo, implementación incorrecta | Mandato de no asunción + R0 de solo lectura antes de todo compromiso |
+| La activación depende del juicio del agente sobre prosa, no de un predicado verificable | Un orquestador se activa de más (ruido) o de menos (no aparece cuando debía), sin test que lo detecte | Precedencia explícita; comportamiento por defecto "no aplicar ninguno" ante duda o empate (RF-2.3); `DA-4` registrada como capa aditiva de escape si el uso real lo exige |
+| Filtración de vocabulario de un proceso concreto al contrato del framework | AWM deja de ser agnóstico y hereda las particularidades del primer proceso que lo usa, repitiendo a otro nivel el antipatrón que la doctrina de sensor-packs ya prohíbe | RF-1.3 y su CA lo verifican declarando dos orquestadores de dominios ajenos; revisión explícita del contrato en code review con este criterio |
+| La urgencia empuja a fusionar Release 1 y Release 2 | Se entrega un punto de extensión sin validar y sin aislamiento resuelto, y se rompe la restricción de invisibilidad | Release 1 no depende de Release 2; su valor está justificado de forma independiente y su aceptación es verificable por separado |
+| `DA-1` se resuelve mal por presión de tiempo | El proceso personal termina siendo visible para compañeros, violando una restricción declarada dura | `DA-1` bloquea Release 1 de forma explícita; R0 prioriza la incógnita del modelo de instalación por encima de las demás |
+| El aislamiento por usuario resulta imposible con el modelo de instalación actual | Release 1 no puede cumplir RNF-T.3 tal como está escrito | R0 lo detecta antes de comprometer trabajo; si ocurre, la contradicción se reporta al dueño y no se resuelve asumiendo — puede derivar en una `DA-#` nueva o en un cambio de alcance decidido por él |

--- a/docs/plans/2026-08-21-registry-declared-orchestrators-design.md
+++ b/docs/plans/2026-08-21-registry-declared-orchestrators-design.md
@@ -1,0 +1,154 @@
+# Orquestadores de proceso declarados por registry — Design
+
+Origen: [brief certificado `ready`](2026-08-21-registry-declared-orchestrators-brief.md) (`awm: product-brief`, `mode: brief`), vía `brainstorming` en Brief Preload Mode.
+
+Decisión de activación tomada en `architecture-advisor` (modo contextual): **O2b** — el proceso declara su disparador en prosa y el agente juzga, consistente con el ruteo que `use-awm` ya hace hoy. El predicado determinista evaluado por el framework (O1) queda como capa aditiva futura, registrada en `DA-4` del brief.
+
+## Requirements
+
+Trazabilidad: cada `R#` referencia el `RF/RNF` del brief que lo origina.
+
+**R1 — Declaración y descubrimiento**
+
+- **R1.1** — CUANDO un registry instalado declare que aporta un orquestador, EL sistema SHALL incluirlo entre los orquestadores considerados al inicio de la sesión. *(brief RF-1.1)*
+- **R1.2** — SI la declaración de un orquestador está malformada o incompleta, ENTONCES EL sistema SHALL rechazar esa declaración e informarla, sin invalidar los demás orquestadores del mismo registry ni de otros. *(brief RF-1.2 — reasignada a Release 2)*
+- **R1.3** — EL contrato de declaración SHALL limitarse a identidad, disparador y destino de terminación, sin admitir ni exigir vocabulario de dominio de ningún proceso concreto. *(brief RF-1.3)*
+- **R1.4** — SI un registry no declara ningún orquestador, ENTONCES EL sistema SHALL instalarlo y tratarlo exactamente como hoy. *(nuevo — deriva de RNF-T.2)*
+
+**R2 — Selección y precedencia**
+
+- **R2.1** — CUANDO uno o más orquestadores declarados resulten aplicables, EL sistema SHALL considerarlos antes que `development-process` y `product-process`. *(brief RF-2.1; DA-2 resuelta)*
+- **R2.2** — EL orden entre orquestadores declarados SHALL derivarse del contrato de terminación de cada uno, y NO de ningún campo de precedencia del framework. *(DA-2 resuelta)*
+- **R2.3** — SI ningún orquestador declarado aplica, ENTONCES EL sistema SHALL continuar con el ruteo actual entre `development-process` y `product-process`, sin mencionar los orquestadores declarados. *(brief RF-2.2)*
+- **R2.4** — SI dos o más orquestadores declarados resultan aplicables y ninguno nombra al otro en su terminación, ENTONCES EL sistema SHALL no aplicar ninguno y continuar con el ruteo actual. *(brief RF-2.3; DA-3 reducida)*
+
+**R3 — Terminación**
+
+- **R3.1** — CUANDO un orquestador declarado concluya, EL sistema SHALL exigir que haya nombrado explícitamente su destino de terminación: otro orquestador declarado, `development-process`, `product-process`, o ninguno. *(brief RF-3.1)*
+- **R3.2** — EL sistema SHALL mantener como máximo un orquestador activo a la vez. *(brief RF-3.2)*
+- **R3.3** — SI un orquestador declarado nombra como destino a otro que no está instalado, ENTONCES EL sistema SHALL continuar con el ruteo actual e informarlo, sin abortar la sesión. *(nuevo — deriva del acoplamiento entre procesos aceptado al resolver DA-2)*
+
+**R4 — Autoría y distribución**
+
+- **R4.1** — EL sistema SHALL proveer un método documentado y reproducible para crear un registry que aporte un orquestador, sin requerir copiar contenido del registry base a mano. *(brief RF-4.1)*
+- **R4.2** — CUANDO el autor publique una versión nueva con tag, EL sistema SHALL entregar ese cambio a las instalaciones mediante `awm update`, sin pasos manuales adicionales. *(brief RF-4.2)*
+
+**R5 — Robustez y frontera**
+
+- **R5.1** — SI un orquestador declarado no puede ejecutarse por cualquier causa, incluida la indisponibilidad de un sistema externo del que dependa, ENTONCES EL sistema SHALL informarlo y continuar la sesión sin bloquear al usuario. *(brief RNF-T.1)*
+- **R5.2** — EL sistema SHALL garantizar que un registry instalado por una persona no deje archivo alguno en el árbol versionado del repositorio de trabajo. *(brief RNF-T.3, alcance fijado por DA-1)*
+- **R5.3** — EL contrato de declaración SHALL rechazar credenciales y secretos: ningún campo del manifiesto los admite ni los presupone. *(brief Constraints — frontera personal/corporativo)*
+
+**R6 — No regresión, plataformas y tests**
+
+- **R6.1** — EL sistema SHALL producir, en ausencia de orquestadores declarados, un comportamiento idéntico al vigente antes de este cambio. *(brief RNF-T.2)*
+- **R6.2** — EL sistema SHALL comportarse de forma equivalente en `ubuntu-latest`, `windows-latest` y `macos-latest`. *(brief RNF-T.4)*
+- **R6.3** — SI un test de esta funcionalidad se ejecuta, ENTONCES EL test SHALL usar tmpdirs con `HOME` y `AWM_HOME` sobreescritos, y SHALL NOT tocar el `~/.awm` real. *(brief RNF-T.5)*
+
+## Arquitectura
+
+Dos capas con frontera dura, y el corte de releases la sigue en vez de seguir una dependencia técnica:
+
+- **Capa de contenido** — registries versionados por tag, entregados con `awm update`. No pasa por npm ni por el gate de sensores.
+- **Capa de CLI** — publicada a npm por `.github/workflows/release.yml`, con el gate de tests en tres plataformas como precondición (D-005).
+
+**Release 1 vive enteramente en la capa de contenido.** Ningún archivo bajo `cli/` cambia. **Release 2 es el único que toca CLI**, y ahí se concentra todo el riesgo.
+
+La regla agnóstica que sostiene el diseño: *AWM sabe que existen orquestadores declarados y que se consideran antes que los dos existentes. Nada más.* No hay campo de precedencia, no hay enum de scopes, no hay espacio de hechos de sesión. El orden entre declarados emerge del contrato de terminación (`R2.2`), igual que hoy `product-process` cede a `development-process`.
+
+### Estado verificado del sistema
+
+Verificado durante esta fase, con referencia:
+
+- `awm registry add` clona, valida layout con `validateRegistryLayout` y detecta colisiones antes de escribir configuración — `cli/src/commands/registry/add.ts:38-80`.
+- `buildContext` lee `using-awm/SKILL.md` de **un solo** `registryRoot` y solo emite los nombres de extensión como texto (`Active extensions: ...`); no compone contenido — `cli/src/core/context/provider.ts`.
+- `profileExtensions` se pasa vacío en sus tres únicos llamadores — `cli/src/core/init/steps.ts:445`, `cli/src/core/diagnostics/context.ts:86`, `cli/src/core/diagnostics/provider-checks.ts:408`. Es una costura sin productor.
+- **Claude Code saltea `buildContext`**: `cli/src/commands/hooks/claude.ts:42-49` symlinkea `skills/using-awm/SKILL.md` directo a `~/.awm/hooks/using-awm.md`, y el hook lee ese archivo crudo — `hooks/session-start:28` en `awm-baseline-registry`.
+- La inyección de constitución está atada al cwd: `CONSTITUTION_FILE="$PWD/CONSTITUTION.md"` — `hooks/session-start:56`.
+- `track`/`job` operan sobre un journal **por rama de git** y fallan en HEAD desacoplado — `cli/src/commands/track/index.ts:20`. No son un runtime de sesión reutilizable acá.
+
+## Componentes
+
+### Release 1 — capa de contenido
+
+| Unidad | Responsabilidad | Depende de |
+|---|---|---|
+| `awm-baseline-registry` → `skills/using-awm/SKILL.md` | Su sección *Orchestration* deja de enumerar dos orquestadores fijos: pasa a considerar primero los declarados, con la regla de default seguro (`R2.4`) y la de fail-safe (`R5.1`). Es el único punto que cambia comportamiento en Release 1 | Nada. Es contenido |
+| Registry personal (repo privado nuevo) | Aporta un orquestador: `awm-registry.json`, `catalog.json`, un bundle y `skills/<proceso>/SKILL.md` con su disparador y su destino de terminación | Contrato de registry actual, sin cambios |
+| `agentic-workflow` → `docs/guides/` | Método de autoría reproducible (`R4.1`): layout exigido, cómo declarar, cómo validar localmente, cómo publicar con tag | Contrato de registry actual |
+
+El descubrimiento en Release 1 es **por visibilidad**: los skills ya se enlazan a `~/.claude/skills/`, así que el agente los ve sin que nadie componga nada. Eso es lo que permite entregar sin tocar el CLI — y es también la razón por la que `R1.2` no puede cumplirse todavía.
+
+### Release 2 — capa de CLI
+
+| Unidad | Responsabilidad |
+|---|---|
+| `cli/src/core/registries.ts` | Leer y validar la declaración de orquestador del manifiesto (`R1.1`, `R1.2`, `R1.3`, `R5.3`) |
+| `cli/src/core/context/provider.ts` | `buildContext` compone los descriptores declarados en el payload, en vez de emitir solo nombres |
+| `cli/src/commands/hooks/claude.ts` | Rutear Claude Code por `buildContext`, cerrando el bypass — el cambio de mayor riesgo del release |
+| `cli/src/commands/registry/add.ts` | Rechazar declaraciones malformadas informándolas, en el mismo punto donde ya se detectan colisiones |
+
+## Flujo de datos
+
+```mermaid
+flowchart TD
+    subgraph R1["Release 1 — solo contenido"]
+      A[Registry personal<br/>tag vX.Y.Z] -->|awm update| B[~/.awm/registries/]
+      D[using-awm modificado<br/>en baseline] -->|awm update| B
+      B -->|symlink| C[~/.claude/skills/]
+      C --> E[El agente ve el skill<br/>y lee su disparador]
+    end
+    subgraph R2["Release 2 — CLI"]
+      B -->|declaraciones del manifiesto| F[buildContext<br/>compone descriptores]
+      F --> G[payload unico para<br/>los tres proveedores]
+    end
+    E --> H{Aplica algun<br/>declarado?}
+    G --> H
+    H -->|Ninguno| I[Ruteo actual:<br/>development / product]
+    H -->|Empate sin nombrarse| I
+    H -->|Exactamente uno| J{Puede ejecutarse?}
+    J -->|No| K[Informar y continuar]
+    K --> I
+    J -->|Si| L[Ejecutar orquestador]
+    L --> M[Terminacion: nombra destino]
+    M --> H
+```
+
+## Manejo de errores
+
+| Condición | Comportamiento | Requisito |
+|---|---|---|
+| Declaración malformada | Rechazo informado, sin invalidar los demás orquestadores. **Solo desde Release 2** — en Release 1 no hay detección, y es deuda conocida y aceptada | `R1.2` |
+| Orquestador que no puede ejecutarse | Se informa y la sesión continúa. Nunca bloquea al usuario | `R5.1` |
+| Destino de terminación no instalado | Se informa y se sigue con el ruteo actual, sin abortar | `R3.3` |
+| Dos declarados aplicables sin nombrarse | No se aplica ninguno; ruteo actual | `R2.4` |
+| Ningún declarado | Comportamiento idéntico al de hoy, sin mención alguna | `R2.3`, `R6.1` |
+
+El principio común: **ningún fallo del mecanismo de orquestadores declarados puede impedir trabajar.** El peor caso siempre degrada al comportamiento actual de AWM, que ya funciona.
+
+## Testing
+
+- **No-regresión primero.** La suite actual debe pasar sin tocar expectativas (`R6.1`). Es el test que más importa, porque Release 2 toca el camino de instalación de hooks, compartido por los tres proveedores.
+- **Aislamiento obligatorio.** Todo test usa tmpdirs con `HOME` y `AWM_HOME` sobreescritos, siguiendo el patrón de `cli/tests/commands/hooks/install.test.ts`. Ningún test toca el `~/.awm` real (`R6.3`).
+- **Release 1 no agrega tests de CLI**, porque no cambia código. Se verifica instalando el registry real y abriendo una sesión — contra uso real, nunca contra mocks.
+- **Tres plataformas** como precondición de publicación, relevante solo en Release 2 (`R6.2`).
+- **Casos de error primero.** Las condiciones `IF/THEN` de arriba se escriben como tests antes que los caminos felices: son la clase de fallo que de otro modo aparece tarde.
+
+## Mapa release ↔ requisitos
+
+| Release | Requisitos | Capa | Riesgo |
+|---|---|---|---|
+| **1** | `R2.1`, `R2.2`, `R2.3`, `R2.4`, `R3.1`, `R3.2`, `R3.3`, `R4.1`, `R4.2`, `R5.2`, `R5.3` | Contenido | Bajo — sin código, sin npm, sin gate de sensores |
+| **2** | `R1.1`, `R1.2`, `R1.3`, `R1.4`, `R5.1`, `R6.1`, `R6.2`, `R6.3` | CLI | Alto — toca instalación de hooks y los tres proveedores |
+
+**Naturaleza de la garantía por release.** En Release 1 los requisitos se cumplen **por convención**: quien los hace cumplir es el agente leyendo `using-awm`, no el CLI. Eso vale para `R2.x` y `R3.x` — un orquestador que no nombre su destino de terminación no es rechazado por nadie, solo queda mal escrito. Release 2 agrega la garantía **mecánica**: hay un lector del manifiesto que valida y reporta. La distinción es deliberada y es lo que hace que Release 1 entre en la ventana de tiempo, pero no debe leerse como equivalencia: son dos niveles de garantía distintos sobre los mismos requisitos.
+
+`R1.2` es el único caso que **no** admite la versión por convención, y por eso está asignado a Release 2 y no a Release 1: detectar una declaración malformada exige un lector, y en Release 1 no hay ninguno.
+
+`R5.1` (fail-safe) aparece en Release 2 porque su verificación exige que el framework sepa qué está declarado. En Release 1 la garantía se cumple de hecho —no hay mecanismo que pueda colgarse— pero no es verificable como criterio.
+
+## Fuera de alcance
+
+Heredado del brief, sin cambios: el runtime de sesión con estado y eventos (alternativa D); la concurrencia entre sesiones y la detección de inactividad, que corresponden al proceso y no a AWM; la bandeja de captura; y la implementación del proceso de productividad del dueño y su integración con su sistema personal.
+
+Se agrega: **el predicado determinista O1** queda fuera de ambos releases, diferido en `DA-4` hasta que el uso real demuestre que el juicio del agente sobre el disparador en prosa activa de más o de menos con frecuencia intolerable.

--- a/docs/plans/2026-08-21-registry-declared-orchestrators-r1-plan.md
+++ b/docs/plans/2026-08-21-registry-declared-orchestrators-r1-plan.md
@@ -10,7 +10,16 @@
 
 **Tech Stack:** Markdown (contenido de skills), `node:test` + `node:assert/strict` (tests de contrato), GitHub Actions (`validate.yml`, `auto-tag.yml`), bash (`scripts/check-skill-version-bumps.sh`).
 
-**Modo de ejecución:** interactivo
+**Modo de ejecución:** desatendido
+
+> Mandato de ejecución desatendida: ejecución completa sin pausas de check-in
+> entre tareas, ni de confirmación entre fases (development-process rutea
+> automáticamente y subagent-driven-development no pregunta si continuar con
+> el cierre). harness-retro triagea con criterio propio del agente (solo valor
+> real, recurrente o sistémico — descarta el resto sin preguntar).
+> post-implementation-qa corrige TODOS los hallazgos que surjan, no solo algunos.
+> finishing-a-development-branch crea el PR directamente (opción "push + PR"),
+> sin presentar el menú de 4 opciones.
 
 ---
 

--- a/docs/plans/2026-08-21-registry-declared-orchestrators-r1-plan.md
+++ b/docs/plans/2026-08-21-registry-declared-orchestrators-r1-plan.md
@@ -1,0 +1,625 @@
+# Orquestadores declarados — Release 1 (capa de contenido) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development`
+> (recommended) or `executing-plans` to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Que `use-awm` considere orquestadores declarados por cualquier registry instalado, sin tocar una sola línea del CLI.
+
+**Architecture:** Todo el cambio vive en la capa de contenido. Se modifica la sección `## Orchestration` de `skills/using-awm/SKILL.md` en `awm-baseline-registry` para que deje de enumerar dos orquestadores fijos, y se blinda con un test de contrato al estilo de `tests/r8-sensor-gate-contract.test.mjs`. El descubrimiento es por visibilidad: los skills ya se enlazan a `~/.claude/skills/`, así que el agente ve el orquestador declarado sin que nadie componga nada. La guía de autoría se publica en `agentic-workflow`.
+
+**Tech Stack:** Markdown (contenido de skills), `node:test` + `node:assert/strict` (tests de contrato), GitHub Actions (`validate.yml`, `auto-tag.yml`), bash (`scripts/check-skill-version-bumps.sh`).
+
+**Modo de ejecución:** interactivo
+
+---
+
+## Contexto imprescindible para quien ejecute
+
+Lee esto antes de la Task 1. Son cuatro hechos verificados que, si se ignoran, hacen fallar el release:
+
+1. **Dos repos distintos.** Las Tasks 1–5 se ejecutan en `awm-baseline-registry`. La Task 6 se ejecuta en `agentic-workflow`. La rama de trabajo en ambos es `claude/notion-task-capture-integration-ymltjd`.
+
+2. **Tocar un `SKILL.md` obliga a bumpear tres archivos.** `scripts/check-skill-version-bumps.sh` falla si `skills/*/SKILL.md` cambia sin que avance (a) su propio `version:` de frontmatter, y (b) la versión del bundle que lo contiene, **duplicada** en `bundles/<b>/bundle.json` y en `catalog.json`. `using-awm` pertenece al bundle `dev`.
+
+3. **Un test nuevo no corre solo.** `tests/release-skill-version-gate.test.mjs` verifica que los workflows ejecuten los tests por nombre. Un archivo de test que no se agregue a `validate.yml` **y** a `auto-tag.yml` nunca se ejecuta en CI, y el plan habría producido una garantía decorativa.
+
+4. **El registry personal es tuyo, no del agente.** La Task 7 requiere crear un repositorio privado que no existe y al que el agente no tiene acceso. Está marcada como acción del dueño.
+
+## File Structure
+
+| Archivo | Responsabilidad | Repo |
+|---|---|---|
+| `tests/r9-declared-orchestrators-contract.test.mjs` | Test de contrato: asegura que `using-awm` declara las reglas de orquestadores declarados y que no puede volver a enumerar dos orquestadores fijos sin fallar | `awm-baseline-registry` (crear) |
+| `skills/using-awm/SKILL.md` | Sección `## Orchestration` reescrita + bump de `version:` | `awm-baseline-registry` (modificar) |
+| `bundles/dev/bundle.json` | Bump de `version` del bundle que contiene `using-awm` | `awm-baseline-registry` (modificar) |
+| `catalog.json` | Bump de la versión duplicada del bundle `dev` | `awm-baseline-registry` (modificar) |
+| `.github/workflows/validate.yml` | Ejecutar el test nuevo en validación | `awm-baseline-registry` (modificar) |
+| `.github/workflows/auto-tag.yml` | Ejecutar el test nuevo antes de tagear | `awm-baseline-registry` (modificar) |
+| `docs/guides/authoring-a-registry-with-an-orchestrator.md` | Método de autoría reproducible | `agentic-workflow` (crear) |
+
+---
+
+### Task 1: Test de contrato para orquestadores declarados
+
+_Requirements: R2.1, R2.2, R2.3, R2.4, R3.1, R3.2, R3.3, R5.3_
+
+**Files:**
+- Create: `tests/r9-declared-orchestrators-contract.test.mjs`
+
+- [ ] **Step 1: Escribir el test que falla**
+
+Crear `tests/r9-declared-orchestrators-contract.test.mjs` en `awm-baseline-registry`:
+
+```javascript
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const root = new URL('..', import.meta.url);
+const read = relative => readFileSync(new URL(relative, root), 'utf8');
+
+const USING_AWM = 'skills/using-awm/SKILL.md';
+
+/** Extrae la seccion ## Orchestration completa, sin el resto del skill. */
+function orchestrationSection(text) {
+  const start = text.indexOf('## Orchestration');
+  assert.ok(start >= 0, 'using-awm must keep an ## Orchestration section');
+  const rest = text.slice(start + 1);
+  const nextHeading = rest.indexOf('\n## ');
+  return nextHeading >= 0 ? rest.slice(0, nextHeading) : rest;
+}
+
+test('R2.1: los orquestadores declarados se consideran antes que los dos existentes', () => {
+  const section = orchestrationSection(read(USING_AWM));   // verifies R2.1
+  assert.match(section, /declared orchestrator/i,
+    'the orchestration section must name declared orchestrators as a routing input');
+  const declared = section.search(/declared orchestrator/i);
+  const builtins = section.indexOf('`development-process`');
+  assert.ok(declared >= 0 && builtins > declared,
+    'declared orchestrators must be introduced before the built-in pair, matching their precedence');
+});
+
+test('R2.2: la precedencia entre declarados sale de la terminacion, no de un campo del framework', () => {
+  const section = orchestrationSection(read(USING_AWM));   // verifies R2.2
+  assert.match(section, /termination/i,
+    'ordering among declared orchestrators must be anchored to the termination contract');
+  assert.doesNotMatch(section, /\bprecedence:\s|\bpriority:\s|\border:\s\d/i,
+    'the framework must not introduce a precedence/priority/order field — that is process vocabulary');
+});
+
+test('R2.3: sin declarados aplicables, el ruteo es el actual y no se los menciona', () => {
+  const section = orchestrationSection(read(USING_AWM));   // verifies R2.3
+  assert.match(section, /no declared orchestrator applies/i,
+    'the section must state the fallback when nothing declared applies');
+  assert.match(section, /`product-process`/,
+    'the existing two-orchestrator routing table must survive intact');
+});
+
+test('R2.4: empate sin nombrarse => no aplicar ninguno', () => {
+  const section = orchestrationSection(read(USING_AWM));   // verifies R2.4
+  assert.match(section, /two or more declared orchestrators[\s\S]{0,240}?none of them/i,
+    'the tie case must resolve to applying none, never to an arbitrary pick');
+});
+
+test('R3.1 y R3.2: terminacion explicita y un solo orquestador activo', () => {
+  const section = orchestrationSection(read(USING_AWM));   // verifies R3.1, R3.2
+  assert.match(section, /name(s)? (its|the) (successor|termination target|next)/i,
+    'a declared orchestrator must name its termination target explicitly');
+  assert.match(section, /one orchestrator active at a time/i,
+    'the single-active-orchestrator invariant must be stated');
+});
+
+test('R3.3: destino no instalado degrada, no aborta', () => {
+  const section = orchestrationSection(read(USING_AWM));   // verifies R3.3
+  assert.match(section, /not installed[\s\S]{0,200}?(continue|fall back)/i,
+    'naming an uninstalled successor must degrade to the current routing, never abort the session');
+});
+
+test('R5.3: el contrato de declaracion no admite secretos', () => {
+  const section = orchestrationSection(read(USING_AWM));   // verifies R5.3
+  assert.match(section, /never (contain|carry|include) (credentials|secrets)/i,
+    'the declaration contract must state that it carries no credentials or secrets');
+});
+
+test('RED mutation: volver a enumerar solo dos orquestadores es rechazado', () => {
+  const original = read(USING_AWM);
+  const weakened = original.replace(
+    orchestrationSection(original),
+    '## Orchestration\n\nAWM has two sibling orchestrators: `development-process` and `product-process`.\n',
+  );
+  assert.throws(
+    () => {
+      const section = orchestrationSection(weakened);
+      assert.match(section, /declared orchestrator/i);
+    },
+    /declared orchestrator/i,
+    'reverting to the hardcoded two-orchestrator table must fail this contract',
+  );
+});
+```
+
+- [ ] **Step 2: Correr el test para verificar que falla**
+
+```bash
+cd /home/user/awm-baseline-registry
+node tests/r9-declared-orchestrators-contract.test.mjs
+```
+
+Esperado: FAIL. Los primeros asserts fallan con `the orchestration section must name declared orchestrators as a routing input`, porque `## Orchestration` todavía enumera solo los dos orquestadores fijos.
+
+- [ ] **Step 3: Commit del test en rojo**
+
+```bash
+cd /home/user/awm-baseline-registry
+git add tests/r9-declared-orchestrators-contract.test.mjs
+git commit -m "test: contrato de orquestadores declarados (RED)"
+```
+
+---
+
+### Task 2: Reescribir la seccion Orchestration de using-awm
+
+_Requirements: R2.1, R2.2, R2.3, R2.4, R3.1, R3.2, R3.3, R5.3_
+
+**Files:**
+- Modify: `skills/using-awm/SKILL.md` (sección `## Orchestration` y campo `version:` del frontmatter)
+
+- [ ] **Step 1: Reemplazar la seccion `## Orchestration`**
+
+Sustituir el bloque que hoy empieza en `## Orchestration` y termina justo antes de `## Red Flags` por este texto completo:
+
+```markdown
+## Orchestration
+
+AWM routes a session to exactly one orchestrator. Two ship with the baseline; any installed registry may contribute more.
+
+### Declared orchestrators (considered first)
+
+An installed registry may contribute a **declared orchestrator**: a skill that presents itself as a session entry point, states in its own description when it applies, and names where it hands control afterwards. Consider these before the built-in pair below.
+
+The declaration carries only four things — identity, when it applies, what it does, and its termination target. It never carries domain vocabulary of a particular process, and it must **never contain credentials or secrets** of any kind.
+
+Rules:
+
+- **Precedence.** A declared orchestrator that applies is considered before `development-process` and `product-process`.
+- **Ordering among declared orchestrators comes from the termination contract, not from any framework field.** There is no precedence, priority or order attribute. A declared orchestrator names its successor when it finishes, exactly as `product-process` hands off to `development-process`.
+- **One orchestrator active at a time.** A declared orchestrator runs to its terminal state and only then names its successor: another declared orchestrator, `development-process`, `product-process`, or none.
+- **Tie.** If two or more declared orchestrators apply and none of them names the other, apply none of them and continue with the routing table below.
+- **Uninstalled successor.** If a declared orchestrator names a termination target that is not installed, say so and continue with the routing table below — never abort the session.
+- **Fail-safe.** If a declared orchestrator cannot run for any reason, including an external system it depends on being unavailable, say so and continue. It must never block the user from working.
+- **Silence when absent.** If no declared orchestrator applies, route exactly as below and do not mention that declared orchestrators exist.
+
+### The built-in pair
+
+Route by what the session starts with:
+
+| The session starts with… | Orchestrator |
+|---|---|
+| An idea/need WITHOUT a formed requirement ("I have an idea", "let's explore a new module"), an architecture evaluation or extraction request, or an existing brief to resume | `product-process` |
+| A concrete requirement over code (defined feature, bug, refactor), or a certified-`ready` brief handed off to build | `development-process` |
+| Ambiguous | ASK: "mature the idea (product layer) or build now (development)?" — never guess |
+
+Precedence rule: `brainstorming` explores SOLUTION space and is invoked via `development-process` — never as the entry point for a raw business idea. `product-discovery` explores PROBLEM space.
+
+Architecture disambiguation: a request for a full, standalone architecture evaluation that produces a portable, re-ingestible report ("assess this architecture", "diagnose whether this holds up") goes to `product-process` → `architecture-assessment`. A one-off advisory opinion mid-conversation with no report artifact ("what pattern fits here", "does this design make sense") stays with `architecture-advisor` directly (Specialized tier) — `architecture-assessment` itself invokes `architecture-advisor` in Contextual Mode for exactly this kind of targeted opinion, so the two are complementary, not competing entry points.
+
+Anti-loss rules: one orchestrator active at a time; the brief is the baton between them (context crosses only inside the artifact); returning from development to product happens explicitly through `product-process`, never by improvising business answers mid-development.
+
+For documentation tasks, the equivalent entry point is `docs-system-orchestrator`.
+```
+
+- [ ] **Step 2: Bumpear el `version:` del frontmatter**
+
+En `skills/using-awm/SKILL.md`, cambiar la línea de versión. Es un cambio de comportamiento aditivo, así que corresponde minor:
+
+```
+version: "1.2.3"
+```
+
+pasa a:
+
+```
+version: "1.3.0"
+```
+
+- [ ] **Step 3: Correr el test para verificar que pasa**
+
+```bash
+cd /home/user/awm-baseline-registry
+node tests/r9-declared-orchestrators-contract.test.mjs
+```
+
+Esperado: PASS en los ocho tests, incluida la mutación RED.
+
+- [ ] **Step 4: Correr los contratos vecinos que leen este mismo archivo**
+
+```bash
+cd /home/user/awm-baseline-registry
+node tests/session-start.test.mjs
+node tests/codex-session-start.test.mjs
+node tests/r3-retro-contract.test.mjs
+node tests/r8-sensor-gate-contract.test.mjs
+```
+
+Esperado: PASS los cuatro. Si alguno falla, la reescritura rompió una aserción que otro contrato hacía sobre `using-awm` — arreglar antes de seguir, nunca relajar el test ajeno.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/user/awm-baseline-registry
+git add skills/using-awm/SKILL.md
+git commit -m "feat(using-awm): considerar orquestadores declarados antes que los dos existentes"
+```
+
+---
+
+### Task 3: Bump de bundle y catalog
+
+_Requirements: R4.2_
+
+**Files:**
+- Modify: `bundles/dev/bundle.json`
+- Modify: `catalog.json`
+
+- [ ] **Step 1: Bumpear la version del bundle `dev`**
+
+En `bundles/dev/bundle.json`, cambiar:
+
+```json
+  "version": "3.2.0",
+```
+
+por:
+
+```json
+  "version": "3.3.0",
+```
+
+- [ ] **Step 2: Bumpear la version duplicada en `catalog.json`**
+
+En `catalog.json`, la fila del bundle `dev`:
+
+```json
+    { "name": "dev",       "source": "./bundles/dev",       "version": "3.2.0", "scope": "baseline" },
+```
+
+pasa a:
+
+```json
+    { "name": "dev",       "source": "./bundles/dev",       "version": "3.3.0", "scope": "baseline" },
+```
+
+- [ ] **Step 3: Correr el gate de versiones para verificar que pasa**
+
+```bash
+cd /home/user/awm-baseline-registry
+./scripts/check-skill-version-bumps.sh origin/main HEAD
+```
+
+Esperado: exit 0, sin líneas `FAIL:`. Si reporta `changed but its frontmatter version is unchanged`, falta el bump de la Task 2 Step 2. Si reporta un bundle desactualizado, falta uno de los dos bumps de esta task.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/user/awm-baseline-registry
+git add bundles/dev/bundle.json catalog.json
+git commit -m "chore(dev): bump de bundle por cambio de contrato en using-awm"
+```
+
+---
+
+### Task 4: Cablear el test nuevo en los dos workflows
+
+_Requirements: R2.1, R2.2, R2.3, R2.4, R3.1, R3.2, R3.3, R5.3_
+
+Sin esta task el test existe pero **nunca corre en CI**, y la garantía es decorativa.
+
+**Files:**
+- Modify: `.github/workflows/validate.yml:30`
+- Modify: `.github/workflows/auto-tag.yml:57`
+
+- [ ] **Step 1: Agregar el test a `validate.yml`**
+
+Después de la línea `      - run: node tests/r8-sensor-gate-contract.test.mjs`, insertar:
+
+```yaml
+      - run: node tests/r9-declared-orchestrators-contract.test.mjs
+```
+
+- [ ] **Step 2: Agregar el test a `auto-tag.yml`**
+
+En el bloque de tests, después de `          node tests/r8-sensor-gate-contract.test.mjs`, insertar:
+
+```yaml
+          node tests/r9-declared-orchestrators-contract.test.mjs
+```
+
+- [ ] **Step 3: Verificar que ambos workflows lo referencian**
+
+```bash
+cd /home/user/awm-baseline-registry
+grep -c 'r9-declared-orchestrators-contract' .github/workflows/validate.yml .github/workflows/auto-tag.yml
+```
+
+Esperado: `1` en cada archivo. Un `0` significa que el test quedó huérfano.
+
+- [ ] **Step 4: Correr el gate de release para verificar que sigue verde**
+
+```bash
+cd /home/user/awm-baseline-registry
+node tests/release-skill-version-gate.test.mjs
+```
+
+Esperado: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/user/awm-baseline-registry
+git add .github/workflows/validate.yml .github/workflows/auto-tag.yml
+git commit -m "ci: ejecutar el contrato de orquestadores declarados en validate y auto-tag"
+```
+
+---
+
+### Task 5: Suite completa en verde antes de publicar
+
+_Requirements: R2.1, R2.2, R2.3, R2.4, R3.1, R3.2, R3.3, R5.3_
+
+- [ ] **Step 1: Correr la suite entera tal como la corre CI**
+
+```bash
+cd /home/user/awm-baseline-registry
+node scripts/validate-portability.mjs
+node tests/validate-portability.test.mjs
+node tests/r3-release-metadata.test.mjs
+node tests/r3-retro-contract.test.mjs
+node tests/r8-sensor-gate-contract.test.mjs
+node tests/r9-declared-orchestrators-contract.test.mjs
+node tests/release-skill-version-gate.test.mjs
+node tests/codex-session-start.test.mjs
+node tests/session-start.test.mjs
+```
+
+Esperado: todos PASS. Cualquier fallo se arregla acá, no después del tag.
+
+- [ ] **Step 2: Push de la rama**
+
+```bash
+cd /home/user/awm-baseline-registry
+git push -u origin claude/notion-task-capture-integration-ymltjd
+```
+
+---
+
+### Task 6: Guia de autoria de un registry con orquestador
+
+_Requirements: R4.1_
+
+**Files:**
+- Create: `docs/guides/authoring-a-registry-with-an-orchestrator.md` (repo `agentic-workflow`)
+
+- [ ] **Step 1: Escribir la guia**
+
+Crear el archivo con este contenido:
+
+```markdown
+# Crear un registry que aporte un orquestador
+
+Un registry externo puede aportar un **orquestador declarado**: un proceso propio que AWM considera al inicio de la sesión, antes de `development-process` y `product-process`. Esta guía es el método reproducible; no hace falta copiar nada del registry base a mano.
+
+## 1. Layout mínimo
+
+Un registry es un repositorio git con al menos uno de los directorios de contenido en su raíz. Para aportar un orquestador alcanza con `skills/`:
+
+```
+mi-registry/
+├── awm-registry.json
+├── catalog.json
+├── bundles/
+│   └── mi-proceso/
+│       └── bundle.json
+└── skills/
+    └── mi-proceso/
+        └── SKILL.md
+```
+
+`awm registry add` valida este layout y **rechaza el registry si colisiona por nombre** con contenido ya instalado, revirtiendo el clon. Elegí nombres de skill específicos.
+
+## 2. `awm-registry.json`
+
+Declara la versión mínima de CLI que tu contenido necesita:
+
+```json
+{
+  "minCliVersion": "8.1.5"
+}
+```
+
+## 3. `catalog.json`
+
+Enumera tus bundles. `scope` es `baseline` si querés que se instale por defecto, o `project` si es opt-in por proyecto:
+
+```json
+{
+  "version": 1,
+  "bundles": [
+    { "name": "mi-proceso", "source": "./bundles/mi-proceso", "version": "1.0.0", "scope": "project" }
+  ]
+}
+```
+
+## 4. `bundles/mi-proceso/bundle.json`
+
+```json
+{
+  "name": "mi-proceso",
+  "version": "1.0.0",
+  "description": "Mi proceso de trabajo propio.",
+  "scope": "project",
+  "dependsOn": [],
+  "skills": ["mi-proceso"],
+  "workflows": [],
+  "agents": []
+}
+```
+
+La versión está **duplicada** a propósito entre `catalog.json` y `bundle.json`, y las dos deben avanzar juntas en cada release.
+
+## 5. `skills/mi-proceso/SKILL.md`
+
+El frontmatter y las cuatro cosas que el contrato exige: identidad, cuándo aplica, qué hace, y a quién le cede el control.
+
+```markdown
+---
+name: mi-proceso
+version: "1.0.0"
+description: Use when <la condición concreta en la que este proceso aplica>. Declared orchestrator.
+---
+
+# Mi proceso
+
+## Cuándo aplica
+
+<Redactalo filoso. Es lo único que el agente lee para decidir si te activa.
+Un disparador vago activa de más; uno demasiado angosto no activa nunca.>
+
+## Qué hace
+
+<Los pasos del proceso.>
+
+## Terminación
+
+Este orquestador cede el control a `development-process` cuando termina.
+
+<Nombrá exactamente uno: otro orquestador declarado, `development-process`,
+`product-process`, o ninguno. Si nombrás uno que puede no estar instalado,
+el agente lo informa y sigue con el ruteo normal — no aborta.>
+```
+
+**Nunca pongas credenciales ni tokens acá.** El registry se publica; el acceso a sistemas externos se resuelve por fuera.
+
+## 6. Validar antes de publicar
+
+Instalalo desde la ruta local, sin publicar nada:
+
+```bash
+awm registry add /ruta/a/mi-registry --name mi-proceso
+awm registry status
+```
+
+Si el layout está mal o hay colisión de nombres, el comando falla y revierte el clon. Para volver atrás:
+
+```bash
+awm registry remove mi-proceso
+```
+
+## 7. Publicar
+
+```bash
+git tag v1.0.0
+git push origin v1.0.0
+```
+
+En las máquinas que lo usen:
+
+```bash
+awm update
+```
+
+## Aislamiento
+
+El registry se instala bajo `~/.awm/registries/` y sus skills se enlazan a `~/.claude/skills/`. **Nada toca el árbol versionado de tu repositorio de trabajo**, así que un registry personal instalado en tu máquina es invisible para quien clone ese repositorio. Verificalo con `git status --porcelain` después de instalar: debe salir vacío.
+```
+
+- [ ] **Step 2: Verificar que la guia no quedo con placeholders**
+
+```bash
+cd /home/user/agentic-workflow
+grep -nE 'TBD|TODO|XXX' docs/guides/authoring-a-registry-with-an-orchestrator.md || echo "sin placeholders"
+```
+
+Esperado: `sin placeholders`.
+
+- [ ] **Step 3: Commit y push**
+
+```bash
+cd /home/user/agentic-workflow
+git add docs/guides/authoring-a-registry-with-an-orchestrator.md
+git commit -m "docs(guides): metodo para crear un registry con orquestador declarado"
+git push -u origin claude/notion-task-capture-integration-ymltjd
+```
+
+---
+
+### Task 7: Registry personal real — ACCION DEL DUENO
+
+_Requirements: R4.1, R4.2, R5.2_
+
+**Esta task no la ejecuta el agente.** Requiere crear un repositorio privado nuevo, fuera del alcance de GitHub de la sesión. El agente puede preparar el contenido en un directorio local, pero la creación del repo y su publicación son tuyas.
+
+- [ ] **Step 1: Crear el repositorio privado**
+
+Crear `mi-proceso-registry` (o el nombre que prefieras) como repo **privado** en tu cuenta.
+
+- [ ] **Step 2: Poblarlo siguiendo la guia de la Task 6**
+
+Seguir `docs/guides/authoring-a-registry-with-an-orchestrator.md` de punta a punta. Este es el ejercicio real de `R4.1`: si algún paso de la guía no alcanza, la guía tiene un hueco y hay que corregirla.
+
+- [ ] **Step 3: Verificar aislamiento (R5.2)**
+
+Desde un repositorio de la compañía, con el registry ya instalado:
+
+```bash
+cd <cualquier-repo-corporativo>
+git status --porcelain
+```
+
+Esperado: **salida vacía**. Cualquier archivo listado significa que el registry ensució el árbol versionado y `R5.2` no se cumple.
+
+- [ ] **Step 4: Verificar propagacion por tag (R4.2)**
+
+```bash
+cd /ruta/a/mi-proceso-registry
+git tag v1.0.1 && git push origin v1.0.1
+awm update
+awm registry status
+```
+
+Esperado: `awm registry status` reporta la versión nueva sin ningún paso manual adicional.
+
+- [ ] **Step 5: Verificar activacion end-to-end**
+
+Abrir una sesión en un repo cualquiera bajo una condición que cumpla el disparador declarado, y confirmar que el agente considera el orquestador declarado antes que `development-process`. Después abrir una sesión que **no** cumpla el disparador y confirmar que no se lo menciona (`R2.3`).
+
+---
+
+## Traceability matrix
+
+| Req | Task(s) | Test(s) / verificación |
+|---|---|---|
+| R2.1 | T1, T2, T4 | `R2.1: los orquestadores declarados se consideran antes que los dos existentes` |
+| R2.2 | T1, T2, T4 | `R2.2: la precedencia entre declarados sale de la terminacion...` — chequea además la **ausencia** de campos `precedence/priority/order` |
+| R2.3 | T1, T2, T4, T7 | `R2.3: sin declarados aplicables, el ruteo es el actual...` + T7 Step 5 (sesión que no cumple el disparador) |
+| R2.4 | T1, T2, T4 | `R2.4: empate sin nombrarse => no aplicar ninguno` |
+| R3.1 | T1, T2, T4 | `R3.1 y R3.2: terminacion explicita y un solo orquestador activo` |
+| R3.2 | T1, T2, T4 | `R3.1 y R3.2: terminacion explicita y un solo orquestador activo` |
+| R3.3 | T1, T2, T4 | `R3.3: destino no instalado degrada, no aborta` |
+| R4.1 | T6, T7 | **Verificación manual** — T7 Step 2. `CA-4.1` exige que una persona siga la guía y produzca un registry instalable; no hay proxy automatizable honesto para eso |
+| R4.2 | T3, T7 | T3 Step 3 (`check-skill-version-bumps.sh` exit 0) + T7 Step 4 (`awm update` trae la versión nueva) |
+| R5.2 | T7 | T7 Step 3 — `git status --porcelain` vacío. Automatizable y ejecutado contra instalación real |
+| R5.3 | T1, T2, T4 | `R5.3: el contrato de declaracion no admite secretos` |
+
+**Precisión de la matriz.** Los tests de T1 no cuentan ocurrencias de un marcador genérico: cada uno ancla la frase específica de su requisito (por ejemplo `R2.2` verifica positivamente la mención de *termination* **y** negativamente la ausencia de un campo de precedencia). `R4.1` es el único que descansa en lectura manual, y queda declarado como tal en vez de disfrazarse con un grep.
+
+## Analyze gate
+
+- Todo requisito tiene ≥1 task y ≥1 verificación: **sí** (11/11).
+- Ninguna task o test sin requisito anclado: **sí**. T5 es ejecución de la suite existente, no aporta cobertura nueva y por eso comparte los IDs de T1.
+
+## Fuera de alcance de este plan
+
+Todo lo asignado a Release 2 en el design doc: manifiesto formal de declaración, validación de declaraciones malformadas (`R1.2`), composición en `buildContext` y cierre del bypass de Claude Code. Ver el plan de Release 2.
+
+**Deuda conocida y aceptada:** en Release 1 nadie valida una declaración malformada. Un registry con un `SKILL.md` mal escrito no es rechazado — simplemente el agente lo lee mal o lo ignora. Se cierra en Release 2 con `R1.2`.

--- a/docs/plans/2026-08-21-registry-declared-orchestrators-r2-plan.md
+++ b/docs/plans/2026-08-21-registry-declared-orchestrators-r2-plan.md
@@ -1,0 +1,794 @@
+# Orquestadores declarados — Release 2 (capa de CLI) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development`
+> (recommended) or `executing-plans` to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Que AWM lea, valide y componga las declaraciones de orquestador de todos los registries instalados, y que eso llegue a los tres proveedores — incluido Claude Code, que hoy no lo recibe.
+
+**Architecture:** Se extiende `awm-registry.json` con un bloque `orchestrator` opcional, leído por un parser **tolerante** que colecta diagnósticos en vez de lanzar (un orquestador mal declarado no puede invalidar el registry ni a los demás). `buildContext` deja de emitir solo nombres de extensión y pasa a componer los descriptores declarados. Finalmente se cierra el bypass: `hooks/claude.ts` deja de symlinkear el `SKILL.md` crudo y pasa a materializar el payload de `buildContext`, que es lo que hace que la composición efectivamente llegue a Claude Code.
+
+**Tech Stack:** TypeScript, jest + ts-jest (`npm test` → `jest --runInBand`), sin dependencias nuevas (la restricción de costo del brief lo prohíbe).
+
+**Modo de ejecución:** interactivo
+
+---
+
+## Contexto imprescindible para quien ejecute
+
+1. **Repo y rama.** Todo ocurre en `agentic-workflow`, rama `claude/notion-task-capture-integration-ymltjd`. Directorio de trabajo del CLI: `cli/`.
+2. **Release 1 debe estar entregado antes.** Este plan compone descripciones que solo tienen sentido si `using-awm` ya sabe qué hacer con ellas. Ver `2026-08-21-registry-declared-orchestrators-r1-plan.md`.
+3. **El bypass es el cambio de mayor riesgo del repo.** `cli/src/commands/hooks/claude.ts:42-49` es el camino de instalación de hooks. Romperlo deja a los usuarios sin AWM en sesiones nuevas. Por eso la no-regresión se testea **antes** de tocarlo (Task 6), no después.
+4. **Tolerancia, no excepción.** `readRegistryManifest` (`cli/src/core/registries.ts:323`) lanza ante manifiesto inválido, y eso está bien para el manifiesto. Pero `R1.2` exige que una **declaración de orquestador** malformada se rechace sin invalidar las demás. Por eso el parser nuevo colecciona diagnósticos y nunca lanza.
+
+## File Structure
+
+| Archivo | Responsabilidad |
+|---|---|
+| `cli/src/core/orchestrators.ts` | **Crear.** Tipo `DeclaredOrchestrator`, parser tolerante y diagnósticos. Módulo propio y no dentro de `registries.ts`, que ya carga demasiadas responsabilidades |
+| `cli/tests/core/orchestrators.test.ts` | **Crear.** Parser: válido, malformado, ausente, aislamiento entre declaraciones |
+| `cli/src/core/context/provider.ts` | **Modificar.** `buildContext` compone descriptores en vez de emitir solo nombres |
+| `cli/tests/core/context/provider.test.ts` | **Crear o extender.** Composición y degradación |
+| `cli/src/commands/registry/add.ts` | **Modificar.** Informar declaraciones inválidas sin abortar la instalación por ellas |
+| `cli/src/commands/hooks/claude.ts` | **Modificar.** Materializar el payload de `buildContext` en vez de symlinkear `SKILL.md` crudo |
+
+---
+
+### Task 1: Parser tolerante de declaraciones
+
+_Requirements: R1.1, R1.2, R1.3_
+
+**Files:**
+- Create: `cli/src/core/orchestrators.ts`
+- Test: `cli/tests/core/orchestrators.test.ts`
+
+- [ ] **Step 1: Escribir el test que falla**
+
+Crear `cli/tests/core/orchestrators.test.ts`:
+
+```typescript
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { readDeclaredOrchestrators } from '../../src/core/orchestrators';
+
+function registryWith(manifest: unknown): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-orch-'));
+    fs.writeFileSync(path.join(root, 'awm-registry.json'), JSON.stringify(manifest));
+    return root;
+}
+
+describe('readDeclaredOrchestrators', () => {
+    const created: string[] = [];
+    afterEach(() => {
+        for (const r of created.splice(0)) fs.rmSync(r, { recursive: true, force: true });
+    });
+
+    it('lee una declaracion valida', () => {           // verifies R1.1
+        const root = registryWith({
+            minCliVersion: '8.1.5',
+            orchestrator: { name: 'mi-proceso', appliesWhen: 'cuando arranco una tarea', terminatesTo: 'development-process' },
+        });
+        created.push(root);
+        const { orchestrators, diagnostics } = readDeclaredOrchestrators(root);
+        expect(diagnostics).toEqual([]);
+        expect(orchestrators).toHaveLength(1);
+        expect(orchestrators[0]).toEqual({
+            name: 'mi-proceso',
+            appliesWhen: 'cuando arranco una tarea',
+            terminatesTo: 'development-process',
+        });
+    });
+
+    it('un registry sin bloque orchestrator no declara nada y no es un error', () => {  // verifies R1.4
+        const root = registryWith({ minCliVersion: '8.1.5' });
+        created.push(root);
+        const { orchestrators, diagnostics } = readDeclaredOrchestrators(root);
+        expect(orchestrators).toEqual([]);
+        expect(diagnostics).toEqual([]);
+    });
+
+    it('un registry sin manifiesto no declara nada y no es un error', () => {           // verifies R1.4
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-orch-'));
+        created.push(root);
+        const { orchestrators, diagnostics } = readDeclaredOrchestrators(root);
+        expect(orchestrators).toEqual([]);
+        expect(diagnostics).toEqual([]);
+    });
+
+    it('rechaza una declaracion malformada SIN lanzar, reportandola', () => {           // verifies R1.2
+        const root = registryWith({ orchestrator: { name: 'mi-proceso' } });            // falta appliesWhen y terminatesTo
+        created.push(root);
+        const { orchestrators, diagnostics } = readDeclaredOrchestrators(root);
+        expect(orchestrators).toEqual([]);
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]).toMatch(/appliesWhen/);
+    });
+
+    it('un manifiesto con JSON invalido se reporta, no explota', () => {                // verifies R1.2
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-orch-'));
+        created.push(root);
+        fs.writeFileSync(path.join(root, 'awm-registry.json'), '{ no es json');
+        const { orchestrators, diagnostics } = readDeclaredOrchestrators(root);
+        expect(orchestrators).toEqual([]);
+        expect(diagnostics).toHaveLength(1);
+    });
+
+    it('una declaracion invalida no invalida las validas de otros registries', () => {  // verifies R1.2
+        const bad = registryWith({ orchestrator: { name: 'roto' } });
+        const good = registryWith({
+            orchestrator: { name: 'sano', appliesWhen: 'siempre', terminatesTo: 'none' },
+        });
+        created.push(bad, good);
+        const all = [bad, good].map(readDeclaredOrchestrators);
+        expect(all[0].orchestrators).toEqual([]);
+        expect(all[1].orchestrators).toHaveLength(1);
+        expect(all[1].diagnostics).toEqual([]);
+    });
+
+    it('rechaza campos de precedencia: no son vocabulario del framework', () => {       // verifies R1.3
+        const root = registryWith({
+            orchestrator: { name: 'x', appliesWhen: 'y', terminatesTo: 'none', precedence: 1 },
+        });
+        created.push(root);
+        const { orchestrators, diagnostics } = readDeclaredOrchestrators(root);
+        expect(orchestrators).toEqual([]);
+        expect(diagnostics[0]).toMatch(/unknown field "precedence"/i);
+    });
+
+    it('rechaza una declaracion que traiga secretos', () => {                            // verifies R5.3
+        const root = registryWith({
+            orchestrator: { name: 'x', appliesWhen: 'y', terminatesTo: 'none', token: 'ghp_abc' },
+        });
+        created.push(root);
+        const { diagnostics } = readDeclaredOrchestrators(root);
+        expect(diagnostics[0]).toMatch(/unknown field "token"/i);
+    });
+});
+```
+
+- [ ] **Step 2: Correr el test para verificar que falla**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/core/orchestrators.test.ts --runInBand
+```
+
+Esperado: FAIL con `Cannot find module '../../src/core/orchestrators'`.
+
+- [ ] **Step 3: Escribir la implementacion minima**
+
+Crear `cli/src/core/orchestrators.ts`:
+
+```typescript
+// cli/src/core/orchestrators.ts
+// Lector de declaraciones de orquestador. A diferencia de readRegistryManifest
+// (registries.ts), este parser NUNCA lanza: una declaracion malformada se
+// rechaza y se reporta, sin invalidar el registry que la contiene ni a los
+// demas (R1.2). El contrato admite exactamente cuatro campos — identidad,
+// cuando aplica, y a quien cede el control — y rechaza cualquier otro, que
+// es como se impide que vocabulario de un proceso concreto (o un secreto)
+// entre al framework (R1.3, R5.3).
+import fs from 'fs';
+import path from 'path';
+import { REGISTRY_MANIFEST_NAME } from './registries';
+
+export interface DeclaredOrchestrator {
+    name: string;
+    appliesWhen: string;
+    terminatesTo: string;
+}
+
+export interface DeclaredOrchestratorsResult {
+    orchestrators: DeclaredOrchestrator[];
+    diagnostics: string[];
+}
+
+const ALLOWED_FIELDS = ['name', 'appliesWhen', 'terminatesTo'] as const;
+
+export function readDeclaredOrchestrators(root: string): DeclaredOrchestratorsResult {
+    const file = path.join(root, REGISTRY_MANIFEST_NAME);
+    if (!fs.existsSync(file)) return { orchestrators: [], diagnostics: [] };
+
+    let raw: unknown;
+    try {
+        raw = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    } catch (e) {
+        return { orchestrators: [], diagnostics: [`${file}: manifest is not valid JSON (${e instanceof Error ? e.message : String(e)})`] };
+    }
+
+    const decl = (raw as Record<string, unknown>)?.orchestrator;
+    if (decl === undefined) return { orchestrators: [], diagnostics: [] };
+
+    if (typeof decl !== 'object' || decl === null || Array.isArray(decl)) {
+        return { orchestrators: [], diagnostics: [`${file}: "orchestrator" must be an object`] };
+    }
+
+    const diagnostics: string[] = [];
+    const entries = decl as Record<string, unknown>;
+
+    for (const key of Object.keys(entries)) {
+        if (!(ALLOWED_FIELDS as readonly string[]).includes(key)) {
+            diagnostics.push(`${file}: unknown field "${key}" in "orchestrator" — the contract admits only ${ALLOWED_FIELDS.join(', ')}`);
+        }
+    }
+    for (const field of ALLOWED_FIELDS) {
+        const value = entries[field];
+        if (typeof value !== 'string' || value.trim() === '') {
+            diagnostics.push(`${file}: "orchestrator.${field}" must be a non-empty string`);
+        }
+    }
+
+    if (diagnostics.length > 0) return { orchestrators: [], diagnostics };
+
+    return {
+        orchestrators: [{
+            name: entries.name as string,
+            appliesWhen: entries.appliesWhen as string,
+            terminatesTo: entries.terminatesTo as string,
+        }],
+        diagnostics: [],
+    };
+}
+```
+
+- [ ] **Step 4: Correr el test para verificar que pasa**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/core/orchestrators.test.ts --runInBand
+```
+
+Esperado: PASS los ocho casos.
+
+- [ ] **Step 5: Typecheck y lint**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npm run typecheck
+npm run lint
+```
+
+Esperado: sin errores.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/user/agentic-workflow
+git add cli/src/core/orchestrators.ts cli/tests/core/orchestrators.test.ts
+git commit -m "feat(cli): parser tolerante de declaraciones de orquestador"
+```
+
+---
+
+### Task 2: `awm registry add` informa declaraciones invalidas
+
+_Requirements: R1.2, R1.4_
+
+**Files:**
+- Modify: `cli/src/commands/registry/add.ts`
+- Test: `cli/tests/commands/registry/add.test.ts` (crear o extender)
+
+- [ ] **Step 1: Escribir el test que falla**
+
+Agregar a `cli/tests/commands/registry/add.test.ts`:
+
+```typescript
+it('reporta una declaracion de orquestador invalida sin abortar la instalacion', async () => {  // verifies R1.2
+    // Registry local con layout valido y declaracion rota
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-src-'));
+    fs.mkdirSync(path.join(src, 'skills/mi-proceso'), { recursive: true });
+    fs.writeFileSync(path.join(src, 'skills/mi-proceso/SKILL.md'), '---\nname: mi-proceso\n---\nx');
+    fs.writeFileSync(path.join(src, 'awm-registry.json'), JSON.stringify({ orchestrator: { name: 'roto' } }));
+    await simpleGit(src).init().add('.').commit('init');
+
+    const result = await addRegistry(src, 'roto-reg');
+
+    expect(result.ok).toBe(true);                       // la instalacion NO se aborta por esto
+    expect(result.ok && result.orchestratorDiagnostics).toBeDefined();
+    expect(result.ok && result.orchestratorDiagnostics!.join('\n')).toMatch(/appliesWhen/);
+});
+
+it('un registry sin declaracion se instala sin diagnosticos', async () => {                     // verifies R1.4
+    const src = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-src-'));
+    fs.mkdirSync(path.join(src, 'skills/otro'), { recursive: true });
+    fs.writeFileSync(path.join(src, 'skills/otro/SKILL.md'), '---\nname: otro\n---\nx');
+    await simpleGit(src).init().add('.').commit('init');
+
+    const result = await addRegistry(src, 'sin-decl');
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && (result.orchestratorDiagnostics ?? [])).toEqual([]);
+});
+```
+
+- [ ] **Step 2: Correr el test para verificar que falla**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/commands/registry/add.test.ts --runInBand
+```
+
+Esperado: FAIL — `orchestratorDiagnostics` no existe en el tipo de retorno.
+
+- [ ] **Step 3: Implementar**
+
+En `cli/src/commands/registry/add.ts`, extender el tipo de resultado:
+
+```typescript
+export type AddRegistryResult =
+    | { ok: true; name: string; contentRoot: string; orchestratorDiagnostics: string[] }
+    | { ok: false; name?: string; error: string };
+```
+
+Importar el lector:
+
+```typescript
+import { readDeclaredOrchestrators } from '../../core/orchestrators';
+```
+
+Y en el retorno de éxito, justo antes de `writeRegistriesConfig`, leer los diagnósticos y devolverlos:
+
+```typescript
+    // Una declaracion de orquestador malformada se REPORTA, no aborta: el
+    // registry puede aportar skills utiles aunque su declaracion este rota,
+    // y abortar por eso invalidaria contenido sano (R1.2).
+    const { diagnostics: orchestratorDiagnostics } = readDeclaredOrchestrators(dest);
+
+    writeRegistriesConfig([...existing, { name, remote }]);
+    return { ok: true, name, contentRoot: dest, orchestratorDiagnostics };
+```
+
+- [ ] **Step 4: Correr el test para verificar que pasa**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/commands/registry/add.test.ts --runInBand
+```
+
+Esperado: PASS, incluidos los tests preexistentes de este archivo.
+
+- [ ] **Step 5: Verificar que el comando imprime los diagnosticos**
+
+En el wiring de commander de `awm registry add`, tras un resultado `ok`, imprimir cada diagnóstico como advertencia. Buscar dónde se imprime el mensaje de éxito y agregar:
+
+```typescript
+for (const d of result.orchestratorDiagnostics) {
+    console.warn(`warning: ${d}`);
+}
+```
+
+- [ ] **Step 6: Typecheck, lint y commit**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npm run typecheck && npm run lint
+cd /home/user/agentic-workflow
+git add cli/src/commands/registry/add.ts cli/tests/commands/registry/add.test.ts cli/src/commands/registry/index.ts
+git commit -m "feat(cli): reportar declaraciones de orquestador invalidas en registry add"
+```
+
+---
+
+### Task 3: `buildContext` compone los descriptores declarados
+
+_Requirements: R1.1_
+
+**Files:**
+- Modify: `cli/src/core/context/provider.ts`
+- Test: `cli/tests/core/context/provider.test.ts`
+
+- [ ] **Step 1: Escribir el test que falla**
+
+Crear `cli/tests/core/context/provider.test.ts`:
+
+```typescript
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { buildContext } from '../../../src/core/context/provider';
+
+function registryRootWithSkill(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'awm-ctx-'));
+    fs.mkdirSync(path.join(root, 'skills/using-awm'), { recursive: true });
+    fs.writeFileSync(
+        path.join(root, 'skills/using-awm/SKILL.md'),
+        '---\nname: using-awm\nversion: "1.3.0"\n---\n\n# Using Skills\n',
+    );
+    return root;
+}
+
+describe('buildContext', () => {
+    const created: string[] = [];
+    afterEach(() => { for (const r of created.splice(0)) fs.rmSync(r, { recursive: true, force: true }); });
+
+    it('compone los descriptores declarados en el payload', () => {          // verifies R1.1
+        const root = registryRootWithSkill();
+        created.push(root);
+        const ctx = buildContext({
+            registryRoot: root,
+            profileExtensions: [],
+            declaredOrchestrators: [
+                { name: 'mi-proceso', appliesWhen: 'cuando arranco una tarea', terminatesTo: 'development-process' },
+            ],
+        });
+        expect(ctx.markdown).toContain('mi-proceso');
+        expect(ctx.markdown).toContain('cuando arranco una tarea');
+        expect(ctx.markdown).toContain('development-process');
+        expect(ctx.markdown).toContain('# Using Skills');   // el skill sigue entero
+    });
+
+    it('sin declarados, el payload es identico al de antes del cambio', () => {  // verifies R6.1
+        const root = registryRootWithSkill();
+        created.push(root);
+        const withEmpty = buildContext({ registryRoot: root, profileExtensions: [], declaredOrchestrators: [] });
+        const withNone = buildContext({ registryRoot: root, profileExtensions: [] });
+        expect(withEmpty.markdown).toEqual(withNone.markdown);
+        expect(withEmpty.markdown).not.toContain('Declared orchestrators');
+        expect(withEmpty.contentHash).toEqual(withNone.contentHash);
+    });
+
+    it('el hash cambia cuando cambian los declarados', () => {                    // verifies R1.1
+        const root = registryRootWithSkill();
+        created.push(root);
+        const a = buildContext({ registryRoot: root, profileExtensions: [], declaredOrchestrators: [] });
+        const b = buildContext({
+            registryRoot: root, profileExtensions: [],
+            declaredOrchestrators: [{ name: 'x', appliesWhen: 'y', terminatesTo: 'none' }],
+        });
+        expect(a.contentHash).not.toEqual(b.contentHash);
+    });
+});
+```
+
+- [ ] **Step 2: Correr el test para verificar que falla**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/core/context/provider.test.ts --runInBand
+```
+
+Esperado: FAIL — `declaredOrchestrators` no existe en `ContextInput`.
+
+- [ ] **Step 3: Implementar**
+
+En `cli/src/core/context/provider.ts`, extender el input y la composición:
+
+```typescript
+import { DeclaredOrchestrator } from '../orchestrators';
+
+export type ContextInput = {
+    registryRoot: string;
+    profileExtensions: string[];
+    /** Declaraciones recolectadas de todos los registries instalados. Ausente o
+     *  vacio => payload byte-identico al previo a este cambio (R6.1). */
+    declaredOrchestrators?: DeclaredOrchestrator[];
+};
+
+function renderDeclared(list: DeclaredOrchestrator[]): string {
+    if (list.length === 0) return '';
+    const rows = list
+        .map(o => `- **${o.name}** — applies when: ${o.appliesWhen}. Terminates to: \`${o.terminatesTo}\`.`)
+        .join('\n');
+    return `## Declared orchestrators\n\nConsider these before the built-in pair:\n\n${rows}\n\n`;
+}
+
+export function buildContext(input: ContextInput): AwmContext {
+    const skillPath = path.join(input.registryRoot, 'skills/using-awm/SKILL.md');
+    if (!fs.existsSync(skillPath)) {
+        throw new Error(`using-awm skill not found at ${skillPath}. Run 'awm update' first.`);
+    }
+    const skill = fs.readFileSync(skillPath, 'utf-8');
+    const exts = input.profileExtensions.length ? input.profileExtensions.join(', ') : 'none';
+    const header = `<!-- AWM context (generated) -->\n# AWM\n\nActive extensions: ${exts}\n\n`;
+    const declared = renderDeclared(input.declaredOrchestrators ?? []);
+    const markdown = header + declared + skill;
+    return { markdown, sourceVersion: parseVersion(skill), contentHash: sha256(markdown) };
+}
+```
+
+- [ ] **Step 4: Correr el test para verificar que pasa**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/core/context/provider.test.ts --runInBand
+```
+
+Esperado: PASS los tres.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/user/agentic-workflow/cli && npm run typecheck && npm run lint
+cd /home/user/agentic-workflow
+git add cli/src/core/context/provider.ts cli/tests/core/context/provider.test.ts
+git commit -m "feat(cli): componer orquestadores declarados en buildContext"
+```
+
+---
+
+### Task 4: Degradacion sin excepcion (fail-safe)
+
+_Requirements: R5.1_
+
+**Files:**
+- Modify: `cli/src/core/context/orchestrator.ts`
+- Test: `cli/tests/core/context/provider.test.ts` (extender)
+
+- [ ] **Step 1: Escribir el test que falla**
+
+Agregar a `cli/tests/core/context/provider.test.ts`:
+
+```typescript
+it('un registry con declaracion rota no impide construir el contexto', () => {   // verifies R5.1
+    const root = registryRootWithSkill();
+    created.push(root);
+    fs.writeFileSync(path.join(root, 'awm-registry.json'), '{ roto');
+    // El contexto se construye igual: la declaracion rota se omite, no se propaga.
+    const ctx = buildContext({ registryRoot: root, profileExtensions: [], declaredOrchestrators: [] });
+    expect(ctx.markdown).toContain('# Using Skills');
+});
+```
+
+- [ ] **Step 2: Correr el test**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/core/context/provider.test.ts --runInBand
+```
+
+Esperado: PASS ya en verde — `readDeclaredOrchestrators` de la Task 1 nunca lanza, así que la garantía se hereda. **Si falla, hay una ruta que sí propaga la excepción: encontrarla antes de seguir.**
+
+- [ ] **Step 3: Cablear la recoleccion en el orquestador de inyeccion**
+
+En `cli/src/core/context/orchestrator.ts`, dentro de `inputFor`, recolectar de todos los registries instalados y pasar el resultado a `buildContext`:
+
+```typescript
+import { listRegistries } from '../registries';
+import { readDeclaredOrchestrators, DeclaredOrchestrator } from '../orchestrators';
+
+function collectDeclared(): { declared: DeclaredOrchestrator[]; diagnostics: string[] } {
+    const declared: DeclaredOrchestrator[] = [];
+    const diagnostics: string[] = [];
+    for (const reg of listRegistries()) {
+        const r = readDeclaredOrchestrators(reg.contentRoot);
+        declared.push(...r.orchestrators);
+        diagnostics.push(...r.diagnostics);
+    }
+    return { declared, diagnostics };
+}
+```
+
+Y en `inputFor`:
+
+```typescript
+        const { declared, diagnostics } = collectDeclared();
+        for (const d of diagnostics) console.warn(`warning: ${d}`);
+        const ctx = buildContext({
+            registryRoot: op.registryRoot,
+            profileExtensions: op.profileExtensions,
+            declaredOrchestrators: declared,
+        });
+```
+
+- [ ] **Step 4: Correr la suite completa de context**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/core/context --runInBand
+```
+
+Esperado: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/user/agentic-workflow/cli && npm run typecheck && npm run lint
+cd /home/user/agentic-workflow
+git add cli/src/core/context/orchestrator.ts cli/tests/core/context/provider.test.ts
+git commit -m "feat(cli): recolectar declaraciones de todos los registries, degradando ante error"
+```
+
+---
+
+### Task 5: Red de no-regresion ANTES de tocar el bypass
+
+_Requirements: R6.1_
+
+Esta task no cambia comportamiento: fija el comportamiento actual para que la Task 6 no pueda romperlo en silencio.
+
+**Files:**
+- Modify: `cli/tests/commands/hooks/install.test.ts`
+
+- [ ] **Step 1: Agregar un test que fije el contrato observable del hook**
+
+```typescript
+it('el hook queda apuntando a un archivo legible con el contenido de using-awm', () => {  // verifies R6.1
+    installHook({ agent: 'claude', registryRoot: tmpRegistry, installMethod: 'symlink' });
+
+    const skillDest = path.join(tmpHome, '.awm', 'hooks', 'using-awm.md');
+    expect(fs.existsSync(skillDest)).toBe(true);
+    const content = fs.readFileSync(skillDest, 'utf-8');
+    expect(content).toContain('MUST invoke skills.');   // el cuerpo del skill llega al hook
+});
+```
+
+Este test pasa **hoy** (con symlink) y debe seguir pasando **después** (con payload materializado). Es exactamente la garantía que protege a los usuarios.
+
+- [ ] **Step 2: Correr para verificar que pasa en el codigo actual**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/commands/hooks/install.test.ts --runInBand
+```
+
+Esperado: PASS. **Si falla acá, el test está mal escrito** — corregirlo antes de seguir, porque no sirve como red si no refleja el comportamiento actual.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/user/agentic-workflow
+git add cli/tests/commands/hooks/install.test.ts
+git commit -m "test(cli): fijar el contrato observable del hook antes de cerrar el bypass"
+```
+
+---
+
+### Task 6: Cerrar el bypass de Claude Code
+
+_Requirements: R1.1, R6.1_
+
+El cambio de mayor riesgo. La red de la Task 5 ya está puesta.
+
+**Files:**
+- Modify: `cli/src/commands/hooks/claude.ts:42-49`
+
+- [ ] **Step 1: Escribir el test que falla**
+
+Agregar a `cli/tests/commands/hooks/install.test.ts`:
+
+```typescript
+it('el hook recibe los orquestadores declarados, no el SKILL.md crudo', () => {   // verifies R1.1
+    fs.writeFileSync(
+        path.join(tmpRegistry, 'awm-registry.json'),
+        JSON.stringify({ orchestrator: { name: 'mi-proceso', appliesWhen: 'al arrancar', terminatesTo: 'development-process' } }),
+    );
+    installHook({ agent: 'claude', registryRoot: tmpRegistry, installMethod: 'symlink' });
+
+    const content = fs.readFileSync(path.join(tmpHome, '.awm', 'hooks', 'using-awm.md'), 'utf-8');
+    expect(content).toContain('mi-proceso');            // la composicion LLEGA a Claude Code
+    expect(content).toContain('MUST invoke skills.');   // y el skill sigue entero
+});
+```
+
+- [ ] **Step 2: Correr para verificar que falla**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/commands/hooks/install.test.ts --runInBand
+```
+
+Esperado: FAIL en el assert de `mi-proceso` — hoy el hook lee el `SKILL.md` crudo y la composición nunca llega.
+
+- [ ] **Step 3: Reemplazar el symlink por el payload materializado**
+
+En `cli/src/commands/hooks/claude.ts`, reemplazar el bloque del paso 3 (`// 3. Link the skill ...`, líneas 42-49) por:
+
+```typescript
+    // 3. Materializar el payload compuesto (using-awm + orquestadores declarados).
+    //    Antes esto era un symlink al SKILL.md crudo, con la consecuencia de que
+    //    todo lo que buildContext compone NUNCA llegaba a Claude Code — el
+    //    proveedor principal. Se escribe el archivo en vez de enlazarlo porque
+    //    el contenido ya no es un archivo del registry sino un derivado suyo.
+    const skillDest = path.join(config.scriptsDir, 'using-awm.md');
+    const { declared, diagnostics } = collectDeclaredOrchestrators();
+    for (const d of diagnostics) console.warn(`warning: ${d}`);
+    const ctx = buildContext({
+        registryRoot: options.registryRoot,
+        profileExtensions: [],
+        declaredOrchestrators: declared,
+    });
+    try { fs.unlinkSync(skillDest); } catch { /* not exists */ }
+    fs.writeFileSync(skillDest, ctx.markdown, 'utf-8');
+```
+
+Importar arriba lo necesario, y exportar `collectDeclaredOrchestrators` desde `core/context/orchestrator.ts` (era privada en la Task 4 — promoverla).
+
+- [ ] **Step 4: Correr los dos tests**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/commands/hooks/install.test.ts --runInBand
+```
+
+Esperado: PASS ambos — el nuevo **y** la red de no-regresión de la Task 5. Si la red se rompe, se rompió el contrato observable para usuarios existentes: revertir y replantear.
+
+- [ ] **Step 5: Verificar que `awm update` sigue propagando**
+
+Antes el symlink hacía que `awm update` propagara solo. Ahora el archivo es un derivado, así que hay que confirmar que el camino de resync lo regenera:
+
+```bash
+cd /home/user/agentic-workflow/cli
+npx jest tests/commands/hooks --runInBand
+```
+
+Esperado: PASS. **Si algún test de resync falla, es el hallazgo más importante de este plan:** el archivo materializado quedaría rancio tras `awm update`. Arreglarlo cableando la regeneración en el mismo lugar que hoy resuelve el symlink.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/user/agentic-workflow/cli && npm run typecheck && npm run lint
+cd /home/user/agentic-workflow
+git add cli/src/commands/hooks/claude.ts cli/src/core/context/orchestrator.ts
+git commit -m "fix(cli): rutear Claude Code por buildContext, cerrando el bypass del SKILL.md crudo"
+```
+
+---
+
+### Task 7: Suite completa y tres plataformas
+
+_Requirements: R6.1, R6.2, R6.3_
+
+- [ ] **Step 1: Suite entera local**
+
+```bash
+cd /home/user/agentic-workflow/cli
+npm run typecheck
+npm run lint
+npm run depcheck
+npm test
+```
+
+Esperado: todo verde. Cualquier fallo se arregla acá.
+
+- [ ] **Step 2: Verificar aislamiento de tests (R6.3)**
+
+```bash
+cd /home/user/agentic-workflow/cli
+grep -rLn "process.env.AWM_HOME" tests/core/orchestrators.test.ts tests/core/context/provider.test.ts || echo "revisar: tests que no fijan AWM_HOME"
+ls -la ~/.awm 2>/dev/null && echo "--- ~/.awm debe estar intacto tras la suite"
+```
+
+Los tests nuevos de `orchestrators` y `provider` operan sobre tmpdirs explícitos y no leen `awmHome()`, así que no necesitan sobreescribir `AWM_HOME`. Los que sí lo tocan (`hooks/install.test.ts`) ya siguen el patrón. **Confirmar que `~/.awm` quedó sin modificar.**
+
+- [ ] **Step 3: Push y verificar CI en las tres plataformas**
+
+```bash
+cd /home/user/agentic-workflow
+git push -u origin claude/notion-task-capture-integration-ymltjd
+```
+
+Esperado: el job `test` verde en `ubuntu-latest`, `windows-latest` y `macos-latest`. **Rojo en cualquiera bloquea la publicación** (D-005): el job `release` declara `needs: test`.
+
+Prestar atención especial a Windows: la Task 6 cambia un symlink por un `writeFileSync`, lo que en principio **mejora** el comportamiento en Windows sin Developer Mode (donde el symlink caía al fallback de copia). Confirmarlo en el log, no asumirlo.
+
+---
+
+## Traceability matrix
+
+| Req | Task(s) | Test(s) |
+|---|---|---|
+| R1.1 | T1, T3, T6 | `lee una declaracion valida` · `compone los descriptores declarados en el payload` · `el hook recibe los orquestadores declarados, no el SKILL.md crudo` |
+| R1.2 | T1, T2 | `rechaza una declaracion malformada SIN lanzar` · `un manifiesto con JSON invalido se reporta` · `una declaracion invalida no invalida las validas de otros registries` · `reporta una declaracion de orquestador invalida sin abortar la instalacion` |
+| R1.3 | T1 | `rechaza campos de precedencia: no son vocabulario del framework` — verifica la **ausencia** de campos fuera del contrato, no la presencia de un marcador |
+| R1.4 | T1, T2 | `un registry sin bloque orchestrator no declara nada` · `un registry sin manifiesto no declara nada` · `un registry sin declaracion se instala sin diagnosticos` |
+| R5.1 | T4 | `un registry con declaracion rota no impide construir el contexto` |
+| R5.3 | T1 | `rechaza una declaracion que traiga secretos` |
+| R6.1 | T3, T5, T6 | `sin declarados, el payload es identico al de antes del cambio` (incluye igualdad de `contentHash`) · `el hook queda apuntando a un archivo legible con el contenido de using-awm` |
+| R6.2 | T7 | T7 Step 3 — job `test` verde en las tres plataformas de CI |
+| R6.3 | T7 | T7 Step 2 — `~/.awm` intacto tras la suite |
+
+**Precisión de la matriz.** `R1.3` y `R5.3` se verifican por **rechazo** de campos fuera del contrato, que es la forma que prueba la clausura del contrato; un grep por un campo permitido probaría lo contrario de lo que hace falta. `R6.1` se ancla en igualdad de `contentHash`, no en que "el texto contenga algo".
+
+## Analyze gate
+
+- Todo requisito con ≥1 task y ≥1 test: **sí** (9/9 — los 8 del design doc más `R5.3`, que el diseño asignaba a Release 1 y acá se refuerza mecánicamente).
+- Ninguna task o test sin requisito anclado: **sí**.
+
+## Riesgos especificos de este plan
+
+| Riesgo | Mitigación |
+|---|---|
+| El archivo materializado queda rancio tras `awm update`, donde antes el symlink lo resolvía solo | T6 Step 5 lo verifica explícitamente y lo declara como el hallazgo más importante si falla |
+| Romper la instalación de hooks deja a usuarios existentes sin AWM | T5 pone la red **antes** de T6, y T6 Step 4 exige que siga verde |
+| Windows se comporta distinto con symlinks vs escritura | T7 Step 3 exige leer el log de Windows, no asumir |


### PR DESCRIPTION
## Summary

Este PR trae dos piezas de trabajo relacionadas pero separables, ambas producidas durante la misma sesión de discovery→brief→diseño sobre extensibilidad de AWM (orquestadores declarados por registry):

**1. Fix de CLI — `packageRoot` en el manifiesto de sensores (3 commits, `feat(sensors)`)**

Encontrado al intentar migrar `.awm/sensors.json` de este mismo repo de formato legacy a v2: `awm sensors init --pack js-ts` producía un manifiesto vacío (`sensors: {}`) porque el pack `js-ts` declara `"detects": ["package.json"]` y busca esa condición relativa al `cwd` — pero este repo es un monorepo (`package.json` real vive en `cli/`, no en la raíz).

- `compatibility/manifest.ts` — nuevo campo opcional `packageRoot` en el manifiesto v2: ruta relativa contenida desde el directorio del manifiesto hasta el proyecto real. Ausente = comportamiento idéntico al actual.
- `run.ts` — `runSensors` resuelve un `projectCwd` a partir de `manifestDir + packageRoot` y lo usa tanto para detección de compatibilidad (`resolveLiveV2`) como para ejecución real (`executePrepared`). Un `packageRoot` que no resuelve a un directorio real degrada con gracia a `not_certified` (nunca lanza, nunca certifica un pass falso — mismo patrón "honest floor" que el módulo ya usa).
- `init.ts` + `compatibility/materialize.ts` + `index.ts` — nuevo flag `awm sensors init --package-root <dir>`: detección y assets copiados (ej. `eslint.config.awm.mjs`) aterrizan en el subdirectorio real, mientras el manifiesto sigue escribiéndose en la raíz (`findManifestDir` camina hacia arriba, nunca hacia abajo, así que moverlo habría roto el descubrimiento).

Este fix es lo que permite que `.awm/sensors.json` de este propio repo pueda migrarse a v2 con una certificación real (`awm preflight --verify-sensors` → `pass`) — hoy el manifiesto legacy nunca puede certificar `pass` por diseño del CLI (`run.ts`: *"their shell-backed contract cannot certify a green run"*), aunque los 5 sensores corran y pasen genuinamente. La migración real de `.awm/sensors.json` de este repo queda **fuera de este PR** — depende de que esta versión del CLI esté publicada primero.

**2. Brief + diseño + planes — orquestadores de proceso declarados por registry (docs, sin código)**

Producto de una sesión de `product-discovery` → `product-brief` (sellado `ready` por `readiness-gate`, 9/9) → `brainstorming` → `writing-plans`. Resuelve cómo AWM puede considerar procesos declarados por cualquier registry instalado (hoy solo conoce `development-process`/`product-process`), manteniendo el framework agnóstico al vocabulario de cualquier proceso concreto.

- `docs/plans/2026-08-21-registry-declared-orchestrators-brief.md`
- `docs/plans/2026-08-21-registry-declared-orchestrators-design.md`
- `docs/plans/2026-08-21-registry-declared-orchestrators-r1-plan.md` (Release 1 — capa de contenido, sin tocar `cli/`)
- `docs/plans/2026-08-21-registry-declared-orchestrators-r2-plan.md` (Release 2 — capa de CLI)

Ningún código de estos planes se implementó todavía; son artefactos de diseño para ejecución posterior.

## Verification

- `npm run typecheck` — limpio
- `npm run lint` — 0 errores/warnings
- `npm run depcheck` — 1 hallazgo preexistente en `watch/` (verificado contra `origin/main`, no relacionado a este cambio)
- `npm test` — 235/236 test suites (1 skip preexistente), 2671/2675 tests, 0 fallos
- Tests nuevos: `compatibility/manifest.test.ts` (+3), `run.test.ts` (+2), `init.test.ts` (+2) — todos TDD (rojo→verde documentado en los commits)

## Test plan

- [ ] CI verde en las tres plataformas (`ubuntu-latest`, `windows-latest`, `macos-latest`) — gate de publicación (D-005)
- [ ] Tras merge y publish, migrar `.awm/sensors.json` de este repo a v2 con `--package-root cli` en un cambio separado, y confirmar `awm preflight --verify-sensors` → `pass`


---
_Generated by [Claude Code](https://claude.ai/code/session_01SYEjWJrfPkYkQhTj7mn4nR)_