### PR TITLE
docs(doctor): guide dashboard and project evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ components, which phases are optional, and which quality gates are mandatory.
 2. [Configure providers and registries](docs/configuration.md)
 3. [Initialize a project](docs/project-setup.md)
 4. [Operate AWM day to day](docs/runbook.md)
+5. [Inspect the dashboard and local project evidence](docs/guides/dashboard-and-evidence.md)
 
 The [documentation hub](docs/README.md) maps the complete set of active guides
 by intent.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ engineering system and the second to configure and operate it.
 2. [Configuration](configuration.md) — providers, defaults, multiple-provider coexistence, and registries.
 3. [Project setup](project-setup.md) — initialize a new, existing, or already-configured repository.
 4. [Runbook](runbook.md) — daily work, updates, teams, and troubleshooting.
+5. [Dashboard and project evidence](guides/dashboard-and-evidence.md) — inspect and share current readiness plus local cycle evidence.
 
 ## Reference
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -61,7 +61,7 @@ the final panel is the result to act on.
 Read-only dashboard of machine + project harness state. Changes nothing.
 
 ```
-awm doctor [--json]
+awm doctor [--json | --full | --html <file> [--force]] [--agent <agent[,agent...]>]
 ```
 
 Glyphs: `✔` healthy · `⚠` advisory (does not degrade) · `✖` missing (degrades state). Each non-healthy row carries a remedy — a command (`→ awm …`) or a skill to ask the agent to run (`→ skill: …`). `--json` emits a `ProviderDiagnosticReport`: `{ providers: [...], overall }`, one entry
@@ -76,6 +76,31 @@ red one nobody can act on. Two rows worth knowing:
   extension. Advisory; `awm sync` heals or prunes them.
 - **`workflows.global`** — machine-scope workflows, for the providers that use them
   (today: Antigravity).
+
+Use `--full` for the complete, read-only machine/project dashboard in the terminal.
+Use `--html <file>` to write the same snapshot as one self-contained HTML file;
+it writes only the requested file and refuses to replace an existing one unless
+`--force` is supplied. `--json`, `--full`, and `--html` are alternative output
+modes; `--force` is valid only with `--html`. See [Dashboard and project
+evidence](guides/dashboard-and-evidence.md) for how to interpret the lifecycle
+and history sections.
+
+### `awm evidence capture`
+
+Persist one privacy-preserving, local observation for a completed or blocked
+cycle. The retrospective flow normally runs it before archiving the branch
+ledger, so most operators do not need to invoke it directly.
+
+```
+awm evidence capture --plan <repo-relative-plan> [--pr-provider github|gitlab|other --pr-number <number>]
+```
+
+The command prints the opaque cycle identifier on success and stores the
+record in `.awm/evidence/cycles/`. It records structural states and counts,
+not repository identity, plan paths, ledger prose, command output, environment
+values, or secrets. Both PR options must be supplied together. A missing,
+corrupt, or still-active journal is an explicit error rather than an inferred
+result.
 
 ### `awm agent list`
 

--- a/docs/guides/dashboard-and-evidence.md
+++ b/docs/guides/dashboard-and-evidence.md
@@ -1,0 +1,73 @@
+# Dashboard and project evidence
+
+The AWM dashboard answers two different questions without changing your project:
+
+- **Is it ready and configured correctly?** It uses the current machine and project state.
+- **What happened during development cycles?** It shows local, accumulated, sanitized planning, execution, QA, and retrospective evidence.
+
+It is not a productivity score or a comparison between people or repositories. It shows the observations that are available, their state, and—when action is needed—the exact command to run.
+
+## Choose the right view
+
+Run these commands from the repository root:
+
+```bash
+# Brief provider and configuration diagnosis
+awm doctor
+
+# Complete machine, project, and cycle view in the terminal
+awm doctor --full
+
+# One HTML report to open or share within the team
+awm doctor --html awm-dashboard.html
+```
+
+`awm doctor` and `awm doctor --full` are read-only. The `--html` variant writes only the file you name; use `--force` to replace an existing report:
+
+```bash
+awm doctor --html awm-dashboard.html --force
+```
+
+The HTML file is self-contained: it needs neither a server nor network access when opened. It is designed to share technical state, not private work content: it excludes plan paths, repository identity, ledger prose, environment values, secrets, and command output.
+
+## Read the complete dashboard
+
+In a detected project, the complete view keeps this order:
+
+| Section | What it answers |
+| --- | --- |
+| Machine | State of installed AWM providers and content. |
+| Project | Declared profile, context, bundles, and sensors. |
+| Planning | State of the current cycle or most recently captured cycle. |
+| Execution | Whether work completed a cycle or became blocked. |
+| QA | Aggregated findings and fixes for a cycle, without exposing their text. |
+| Retro | Whether the cycle reached retrospective and harness learning. |
+| History | Eligible local cycles and the confidence of the observation. |
+
+States are deliberately explicit:
+
+- **OK** means the observation is available and needs no action.
+- **Attention**, **missing**, or **unavailable** include a safe remedy, such as `awm sync`, `awm update`, `awm sensors status`, or `awm preflight`.
+- **Not applicable** and an empty history section do not mean failure. In particular, a new project has no trend or historical evidence yet.
+
+Follow the remedy shown beside an observation. To learn whether a project can execute its gates, also run `awm preflight`; to execute the real quality checks, run `awm sensors run`.
+
+## When impact evidence appears
+
+Evidence is stored locally when a development cycle finishes and is included in the next `awm doctor --full` or `--html` view. Capture retains only structural data: cycle state, task and retry counts, QA counts and opaque signatures, first gate evaluations, and plan state.
+
+You normally do not capture it manually: the retrospective workflow does so before archiving the ledger. If you are operating an already completed or blocked cycle and need an explicit capture, use a repository-relative plan path:
+
+```bash
+awm evidence capture --plan docs/plans/my-plan.md
+```
+
+The command prints an opaque cycle identifier and stores the observation under `.awm/evidence/cycles/`. It requires an available journal and a `COMPLETE` or `BLOCKED` cycle; if either is missing, it fails explicitly instead of inventing a metric.
+
+Confidence increases only when enough local cycles exist. AWM shows every eligible cycle it can read: it does not hide rows, calculate rankings, or claim improvement from a single observation.
+
+## Share and retain a report
+
+Generate HTML where it is useful for review—for example, a CI artifact directory or a PR attachment—and regenerate it whenever you need current state. You do not need to commit the report unless your team has deliberately decided to retain it as review evidence.
+
+For complete syntax and option constraints, see the [CLI reference](../cli-reference.md#awm-doctor).

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -73,6 +73,10 @@ Use the least invasive command that answers the question:
 runnable; it does not run the code checks. Use both `awm preflight` and
 `awm sensors run` when you need evidence about project readiness.
 
+For the complete terminal dashboard, its self-contained HTML report, and the
+local cycle evidence that appears after development work, see [Dashboard and
+project evidence](guides/dashboard-and-evidence.md).
+
 If a provider has project-only delivery, a machine-only init intentionally
 defers its content. Run normal project initialization in the repository instead
 of creating provider files by hand; see [configuration](configuration.md).


### PR DESCRIPTION
## Summary
- Add an operator-focused dashboard and evidence guide.
- Link it from the README, documentation hub, and runbook.
- Document awm doctor --full, awm doctor --html, and awm evidence capture in the CLI reference.

## Verification
- Validated internal Markdown links across all changed user-facing documents.
- git diff --check.
- awm sensors run is not certified in this host because the installed registry cannot revalidate compatibility; GitHub CI is pending.