### PR TITLE
fix(tests): scope shell:true to npm on Windows in published-doctor-evidence

### DIFF
--- a/cli/tests/integration/published-doctor-evidence.e2e.test.ts
+++ b/cli/tests/integration/published-doctor-evidence.e2e.test.ts
@@ -13,8 +13,15 @@ const registryRemote = process.env.AWM_PUBLISHED_REGISTRY_REMOTE ?? 'https://git
 const enabled = Boolean(cliVersion && registryTag);
 const acceptance = enabled ? describe : describe.skip;
 
+// Windows resolves `npm` to `npm.cmd`; spawnSync can't execute a .cmd file
+// directly without a shell — it fails to spawn (status: null) instead of
+// running. git.exe and node.exe are real binaries and don't need this, so
+// scope it narrowly: unconditional shell:true would also apply to the
+// `node -e <script>` call below, and on POSIX Node's shell:true joins args
+// with plain spaces (no escaping), which would corrupt that script argument.
 function command(cwd: string, executable: string, args: string[], env = process.env): SpawnSyncReturns<string> {
-    return spawnSync(executable, args, { cwd, encoding: 'utf8', env });
+    const needsShell = process.platform === 'win32' && executable === 'npm';
+    return spawnSync(executable, args, { cwd, encoding: 'utf8', env, shell: needsShell });
 }
 
 /** Published evidence accepts only exact versions and immutable git tags. */


### PR DESCRIPTION
## Summary

The `release.yml` push for #121 (v9.0.0) failed on `published-doctor-evidence (windows-latest)` — the only red job out of 7. Root cause: `command()`'s `spawnSync('npm', ...)` had no `shell: true`. On Windows `npm` resolves to `npm.cmd`, which `spawnSync` cannot execute directly without a shell — it fails to spawn (`status: null`) instead of running, which is exactly what the job showed (`expect(...).status).toBe(0)` — `Received: null`).

- `ubuntu-latest` and `macos-latest` of the same job were unaffected (npm is a real executable there) and both successfully installed the just-published `agentic-workflow-manager@9.0.0` from npm and validated the full dashboard/evidence contract — **the actual publish was never broken**, only this one Windows acceptance check.
- This test file is pre-existing (last touched in #116, before this session's work) and is gated behind `AWM_PUBLISHED_CLI_VERSION`/`AWM_PUBLISHED_REGISTRY_TAG`, which only the post-publish `published-doctor-evidence` job sets — so it never runs on PR CI or local `npm test`, and only runs at all when a push to `main` triggers a real npm publish. That's why this was never caught before: it's structurally invisible outside an actual release.

## Fix

Scoped `shell: true` to `win32 && executable === 'npm'`, not applied unconditionally. This same helper also spawns `node -e <script>` with a multi-statement JS string as a single argument elsewhere in the file — on POSIX, Node's `shell: true` joins args with plain spaces (no escaping), which would have corrupted that call if applied blanket.

## Test plan

- [x] `npm run typecheck` clean
- [x] `awm sensors run` → `overall: pass`
- [x] Ran the acceptance test locally against the **real published artifacts** from the v9.0.0 release (`AWM_PUBLISHED_CLI_VERSION=9.0.0 AWM_PUBLISHED_REGISTRY_TAG=v3.4.0 AWM_PUBLISHED_REGISTRY_COMMIT=fd65959...`): 16/16 pass, including the full install → clone → doctor → journal → evidence capture flow
- [ ] Windows behavior itself isn't reproducible locally (no Windows runner here) — will be confirmed by the next `release.yml` run on `main`

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYEjWJrfPkYkQhTj7mn4nR)_