### PR TITLE
fix(tests): stop pinning r3-cli-major-version to a hardcoded major

### DIFF
--- a/cli/tests/structural/r3-cli-major-version.test.ts
+++ b/cli/tests/structural/r3-cli-major-version.test.ts
@@ -4,7 +4,6 @@ import { spawnSync } from 'child_process';
 
 const CLI_ROOT = path.resolve(__dirname, '../..');
 const DIST_ENTRYPOINT = path.join(CLI_ROOT, 'dist', 'src', 'index.js');
-const R3_MAJOR_VERSION = 8;
 
 function readJson(file: string): Record<string, unknown> {
     return JSON.parse(fs.readFileSync(path.join(CLI_ROOT, file), 'utf8')) as Record<string, unknown>;
@@ -21,14 +20,20 @@ function runCompiledCli(...args: string[]): string {
 }
 
 describe('R3 public major CLI release contract', () => {
-    it('retains the R3 major version consistently in package metadata and the lockfile root', () => {
+    // #92: the bump wrote only package.json, so the lockfile trailed by one
+    // version on EVERY release. This is the real invariant — package.json,
+    // package-lock.json, and its root entry must always agree. A hardcoded
+    // expected major (originally 8, from when this test was written) goes
+    // stale on every legitimate `!:`/BREAKING major bump and was never the
+    // actual contract, so it isn't asserted here.
+    it('retains a consistent version across package metadata and the lockfile root', () => {
         const pkg = readJson('package.json');
         const lock = readJson('package-lock.json');
         const root = (lock.packages as Record<string, Record<string, unknown>>)[''];
         const version = pkg.version;
 
         expect(typeof version).toBe('string');
-        expect(version).toMatch(new RegExp(`^${R3_MAJOR_VERSION}\\.`));
+        expect(version).toMatch(/^\d+\.\d+\.\d+$/);
         expect(lock.version).toBe(version);
         expect(root.version).toBe(version);
     });


### PR DESCRIPTION
## Summary

`tests/structural/r3-cli-major-version.test.ts` hardcoded `R3_MAJOR_VERSION = 8` and asserted `package.json`'s version matches `/^8\./`. This broke on the v9.0.0 release (PR #121, a legitimate `feat(dashboard)!:` major bump) — first surfaced on PR #122, whose CI failed here on a completely unrelated change (a Windows `spawnSync` fix in a different file).

The real invariant this test protects (per its neighbor comment in `cli/tests/release/orchestrator.test.ts:61-62`, issue #92) is that `package.json`, `package-lock.json`, and the lockfile's root entry all agree on version — that's the bug it was written to catch (the bump script wrote only `package.json`, so the lockfile trailed by one version on every release). The hardcoded major was an incidental artifact of when the test was authored (during the R3 sensors release, when major happened to be 8), not a real contract — nothing else in the codebase pins the CLI to major 8, and `CLAUDE.md` documents `!:`/BREAKING commits bumping major as ordinary, expected release behavior.

Why this wasn't caught before merging: the version-bump commit (`chore(release): vX.Y.Z`) is pushed with `[skip ci]` specifically so it doesn't retrigger `ci.yml` — so `ci.yml` never actually ran against a tree with the bumped `package.json`. The first real CI run to see v9.0.0 was PR #122's `test (ubuntu-latest)` job.

## Fix

Drop the hardcoded major; keep asserting `version` is a valid `major.minor.patch` string and that all three sources (`package.json`, `package-lock.json`, lockfile root) agree — the actual bug-catching behavior.

## Test plan

- [x] `npm run build && npx jest tests/structural/r3-cli-major-version.test.ts` — 2/2 pass
- [x] Full suite: `npx jest --runInBand` — 253/255 suites, 2941/2947 tests, 0 failures
- [x] `awm sensors run` → `overall: pass`

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYEjWJrfPkYkQhTj7mn4nR)_