### PR TITLE
fix(update): report pin-capped registry resolution

### DIFF
--- a/.awm/sensors.json
+++ b/.awm/sensors.json
@@ -22,7 +22,7 @@
         "reason": "range-and-probe",
         "variantId": "eslint-10-flat",
         "toolVersion": "10.8.1",
-        "runtimeVersion": "22.22.2",
+        "runtimeVersion": "24.19.0",
         "certifiedRange": "=10.8.1",
         "evidence": [
           {
@@ -46,7 +46,7 @@
           },
           {
             "kind": "runtime-version",
-            "status": "22.22.2"
+            "status": "24.19.0"
           },
           {
             "kind": "probe",
@@ -74,7 +74,7 @@
         "reason": "range-and-probe",
         "variantId": "typescript-native",
         "toolVersion": "5.9.3",
-        "runtimeVersion": "22.22.2",
+        "runtimeVersion": "24.19.0",
         "certifiedRange": "=5.9.3",
         "evidence": [
           {
@@ -98,7 +98,7 @@
           },
           {
             "kind": "runtime-version",
-            "status": "22.22.2"
+            "status": "24.19.0"
           },
           {
             "kind": "probe",
@@ -127,7 +127,7 @@
         "reason": "range-and-probe",
         "variantId": "dependency-cruiser-17",
         "toolVersion": "17.4.3",
-        "runtimeVersion": "22.22.2",
+        "runtimeVersion": "24.19.0",
         "certifiedRange": "=17.4.3",
         "evidence": [
           {
@@ -151,7 +151,7 @@
           },
           {
             "kind": "runtime-version",
-            "status": "22.22.2"
+            "status": "24.19.0"
           },
           {
             "kind": "probe",
@@ -166,6 +166,6 @@
     }
   },
   "packSelection": "explicit",
-  "registryRoot": "/root/.awm/registries/baseline",
+  "registryRoot": "/srv/agentmobile/.awm/registries/baseline",
   "packageRoot": "cli"
 }

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -15,6 +15,7 @@
 // by tests).
 import pc from 'picocolors';
 import { AgentTarget } from '../providers';
+import { normalizePin } from '../core/versioning';
 import { noteWindowsCaveat } from '../core/paths';
 import { getPreferences } from '../utils/config';
 import { resolveAgentTargetsOrError } from '../core/agent-targets';
@@ -134,7 +135,28 @@ export async function runUpdateCore(
     const registryResults = await d.syncRegistries();
     for (const r of registryResults) {
         if (r.action === 'error') console.warn(pc.yellow(`  ⚠  registry ${r.name}: ${r.error}`));
-        else console.log(pc.green(`  ✓ Registry ${r.name} ${r.action === 'pulled' ? 'updated' : 're-cloned'} @ ${r.version}`));
+        else if (r.disposition === 'regressed') {
+            const latest = r.availableVersion && r.availableVersion !== r.version
+                ? ` Latest available: ${r.availableVersion}.`
+                : '';
+            console.warn(pc.yellow(
+                `  ⚠ Registry ${r.name} regressed ${r.previousVersion ?? '(previous version)'} → ${r.version} `
+                + `because it is pinned to v${normalizePin(r.pin ?? '')}.${latest} Run \`awm unpin ${r.name}\` to move forward.`,
+            ));
+        } else if (r.pin && r.availableVersion !== r.version) {
+            console.log(pc.yellow(
+                `  ✓ Registry ${r.name} resolved @ ${r.version} (pinned to v${normalizePin(r.pin)}; `
+                + `latest available: ${r.availableVersion ?? 'unknown'}). Run \`awm unpin ${r.name}\` to move forward.`,
+            ));
+        } else if (r.disposition === 'unchanged') {
+            console.log(pc.dim(`  ✓ Registry ${r.name} already at ${r.version}`));
+        } else if (r.disposition === 'advanced') {
+            console.log(pc.green(`  ✓ Registry ${r.name} updated @ ${r.version}`));
+        } else if (r.disposition === 'installed') {
+            console.log(pc.green(`  ✓ Registry ${r.name} installed @ ${r.version}`));
+        } else {
+            console.log(pc.green(`  ✓ Registry ${r.name} resolved @ ${r.version}`));
+        }
     }
     const registries: RegistryOutcome = {
         configured: registryResults.length,

--- a/cli/src/core/registries.ts
+++ b/cli/src/core/registries.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import simpleGit from 'simple-git';
 import { resolveBaseRemote } from './registry';
-import { resolveTargetRef, machineVersionOpts, compareSemver } from './versioning';
+import { resolveTargetRef, machineVersionOpts, compareSemver, currentVersion, normalizePin } from './versioning';
 import { cliVersion } from './cli-version';
 import { awmHome } from './paths';
 
@@ -214,8 +214,22 @@ export function registriesNeedSync(): boolean {
     return listRegistries().some((registry) => !validateRegistryLayout(registry.contentRoot));
 }
 
+export type RegistrySyncDisposition = 'installed' | 'advanced' | 'unchanged' | 'regressed' | 'resolved';
+
 export type RegistrySyncResult =
-    | { name: string; action: 'pulled' | 'recloned'; version: string }  // version: 'vX.Y.Z' | 'HEAD'
+    | {
+        name: string;
+        action: 'pulled' | 'recloned';
+        version: string;
+        /** Dirección real del checkout. Ausente solo para implementaciones previas/injectadas. */
+        disposition?: RegistrySyncDisposition;
+        /** Pin de máquina que resolvió el target, si lo hubo. */
+        pin?: string;
+        /** Versión semver previa, para que el renderer pueda explicar un rollback. */
+        previousVersion?: string;
+        /** Último tag semver disponible al resolver, aun cuando un pin eligió otro. */
+        availableVersion?: string;
+    }  // version: 'vX.Y.Z' | 'HEAD'
     | { name: string; action: 'error'; error: string };
 
 /** Sincroniza cada registry configurado al ref resuelto (pin > último tag > HEAD);
@@ -240,9 +254,11 @@ export async function syncRegistries(): Promise<RegistrySyncResult[]> {
                 await simpleGit(reg.contentRoot).reset(['--hard']);
             }
             const git = simpleGit(reg.contentRoot);
+            const previousVersion = freshClone ? null : await currentVersion(reg.contentRoot);
+            const versionOpts = machineVersionOpts(reg.name);
             let resolved;
             try {
-                resolved = await resolveTargetRef(reg.contentRoot, machineVersionOpts(reg.name));
+                resolved = await resolveTargetRef(reg.contentRoot, versionOpts);
                 await git.checkout(resolved.ref);
                 if (resolved.kind !== 'tag') await git.pull('origin', resolved.ref);
                 if (!validateRegistryLayout(reg.contentRoot)) {
@@ -252,10 +268,22 @@ export async function syncRegistries(): Promise<RegistrySyncResult[]> {
                 if (freshClone) fs.rmSync(reg.contentRoot, { recursive: true, force: true });
                 throw e;
             }
+            const version = resolved.kind === 'tag' ? `v${resolved.version}` : 'HEAD';
+            let disposition: RegistrySyncDisposition;
+            if (freshClone) disposition = 'installed';
+            else if (resolved.kind !== 'tag' || previousVersion === null) disposition = 'resolved';
+            else {
+                const direction = compareSemver(resolved.version, previousVersion);
+                disposition = direction > 0 ? 'advanced' : direction < 0 ? 'regressed' : 'unchanged';
+            }
             results.push({
                 name: reg.name,
                 action: freshClone ? 'recloned' : 'pulled',
-                version: resolved.kind === 'tag' ? `v${resolved.version}` : 'HEAD',
+                version,
+                disposition,
+                ...(versionOpts.pin ? { pin: normalizePin(versionOpts.pin) } : {}),
+                ...(previousVersion ? { previousVersion: `v${previousVersion}` } : {}),
+                ...(resolved.kind === 'tag' ? { availableVersion: `v${resolved.latestVersion}` } : {}),
             });
         } catch (e) {
             results.push({ name: reg.name, action: 'error', error: e instanceof Error ? e.message : String(e) });

--- a/cli/src/core/versioning.ts
+++ b/cli/src/core/versioning.ts
@@ -8,7 +8,7 @@ import { getPreferences } from '../utils/config';
 export type Channel = 'stable' | 'dev';
 
 export type ResolvedRef =
-    | { kind: 'tag'; ref: string; version: string }   // ref = "vX.Y.Z", version sin prefijo
+    | { kind: 'tag'; ref: string; version: string; latestVersion: string } // versiones sin prefijo
     | { kind: 'head'; ref: string }                    // canal dev — ref = default branch
     | { kind: 'head-fallback'; ref: string };          // stable sin tags — el caller avisa
 
@@ -74,7 +74,7 @@ export async function resolveTargetRef(
                 : 'the registry has no version tags';
             throw new Error(`Pinned version ${want} not found in ${repoDir} — ${available}`);
         }
-        return { kind: 'tag', ref: want, version: normalizePin(opts.pin) };
+        return { kind: 'tag', ref: want, version: normalizePin(opts.pin), latestVersion: tags[tags.length - 1].slice(1) };
     }
 
     const branch = await defaultBranch(git);
@@ -82,7 +82,7 @@ export async function resolveTargetRef(
     if (tags.length === 0) return { kind: 'head-fallback', ref: branch };
 
     const latest = tags[tags.length - 1];
-    return { kind: 'tag', ref: latest, version: latest.slice(1) };
+    return { kind: 'tag', ref: latest, version: latest.slice(1), latestVersion: latest.slice(1) };
 }
 
 /** Versión checkouteada actual ("X.Y.Z") si HEAD coincide exactamente con un tag semver; null si sigue un branch. */

--- a/cli/tests/commands/update.test.ts
+++ b/cli/tests/commands/update.test.ts
@@ -128,6 +128,41 @@ describe('awm update — honest outcome', () => {
         expect(updateOutro(result)).toBe('✅ 2 registries, skills and hooks updated.');
     });
 
+    it('una regresión causada por pin se advierte y explica cómo volver a avanzar', async () => {
+        const { runUpdateCore } = require('../../src/commands/update');
+        await runUpdateCore({}, deps({
+            syncRegistries: async () => [{
+                name: 'baseline',
+                action: 'pulled',
+                version: 'v1.0.0',
+                disposition: 'regressed',
+                pin: '1.0.0',
+                availableVersion: 'v1.1.0',
+            }],
+        }));
+
+        const output = [...logSpy.mock.calls, ...warnSpy.mock.calls].flat().join('\n');
+        expect(output).toMatch(/regress/i);
+        expect(output).toMatch(/v1\.0\.0/);
+        expect(output).toMatch(/v1\.1\.0/);
+        expect(output).toMatch(/awm unpin baseline/);
+        expect(output).not.toMatch(/Registry baseline updated/i);
+    });
+
+    it('un pin que ya coincide con el último release no recomienda unpin', async () => {
+        const { runUpdateCore } = require('../../src/commands/update');
+        await runUpdateCore({}, deps({
+            syncRegistries: async () => [{
+                name: 'baseline', action: 'pulled', version: 'v1.1.0', disposition: 'unchanged',
+                pin: 'v1.1.0', availableVersion: 'v1.1.0',
+            }],
+        }));
+
+        const output = [...logSpy.mock.calls, ...warnSpy.mock.calls].flat().join('\n');
+        expect(output).toMatch(/already at v1\.1\.0/i);
+        expect(output).not.toMatch(/awm unpin baseline/);
+    });
+
     it('un registry que falló y NO dejó contenido en disco falla cerrado', async () => {
         const { runUpdateCore } = require('../../src/commands/update');
         const result = await runUpdateCore({}, deps({

--- a/cli/tests/core/registries-sync.test.ts
+++ b/cli/tests/core/registries-sync.test.ts
@@ -82,7 +82,7 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         const results = await m.syncRegistries();
 
-        expect(results).toEqual([{ name: 'personal', action: 'recloned', version: 'HEAD' }]);
+        expect(results).toEqual([{ name: 'personal', action: 'recloned', version: 'HEAD', disposition: 'installed' }]);
         expect(fs.existsSync(path.join(tmpHome, '.awm/registries/personal/skills/alpha/SKILL.md'))).toBe(true);
     });
 
@@ -102,7 +102,7 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         const results = await m.syncRegistries();
 
-        expect(results[0]).toEqual({ name: 'personal', action: 'pulled', version: 'HEAD' });
+        expect(results[0]).toEqual({ name: 'personal', action: 'pulled', version: 'HEAD', disposition: 'resolved' });
         expect(results[1].name).toBe('broken');
         expect(results[1].action).toBe('error');
         const synced = fs.readFileSync(path.join(tmpHome, '.awm/registries/personal/skills/alpha/SKILL.md'), 'utf-8');
@@ -140,7 +140,7 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         const results = await m.syncRegistries();
 
-        expect(results).toEqual([{ name: 'personal', action: 'recloned', version: 'v1.0.0' }]);
+        expect(results).toEqual([{ name: 'personal', action: 'recloned', version: 'v1.0.0', disposition: 'installed', availableVersion: 'v1.0.0' }]);
         const synced = fs.readFileSync(path.join(tmpHome, '.awm/registries/personal/skills/alpha/SKILL.md'), 'utf-8');
         expect(synced).toContain('test skill'); // contenido del tag, no del HEAD
     });
@@ -182,7 +182,9 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         const results = await m.syncRegistries();
 
-        expect(results).toEqual([{ name: 'personal', action: 'recloned', version: 'v1.0.0' }]);
+        expect(results).toEqual([{
+            name: 'personal', action: 'recloned', version: 'v1.0.0', disposition: 'installed', pin: '1.0.0', availableVersion: 'v1.1.0',
+        }]);
     });
 
     it('baseline sembrado se sincroniza por el mismo loop que cualquier registry', async () => {
@@ -195,7 +197,7 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         const results = await m.syncRegistries();
 
-        expect(results).toEqual([{ name: 'baseline', action: 'recloned', version: 'v1.0.0' }]);
+        expect(results).toEqual([{ name: 'baseline', action: 'recloned', version: 'v1.0.0', disposition: 'installed', availableVersion: 'v1.0.0' }]);
         expect(fs.existsSync(path.join(tmpHome, '.awm/registries/baseline/skills/alpha/SKILL.md'))).toBe(true);
     });
 
@@ -224,7 +226,7 @@ describe('syncRegistries (git fixtures locales)', () => {
         m.writeRegistriesConfig([{ name: 'personal', remote: source }]);
         // primera sync: queda en v1.0.0
         const r1 = await m.syncRegistries();
-        expect(r1).toEqual([{ name: 'personal', action: 'recloned', version: 'v1.0.0' }]);
+        expect(r1).toEqual([{ name: 'personal', action: 'recloned', version: 'v1.0.0', disposition: 'installed', availableVersion: 'v1.0.0' }]);
 
         // nueva release en el remote
         fs.writeFileSync(path.join(source, 'skills', 'alpha', 'SKILL.md'), '---\nname: alpha\ndescription: v2\n---\n');
@@ -234,9 +236,16 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         // segunda sync: avanza al nuevo tag
         const r2 = await m.syncRegistries();
-        expect(r2).toEqual([{ name: 'personal', action: 'pulled', version: 'v1.1.0' }]);
+        expect(r2).toEqual([{
+            name: 'personal', action: 'pulled', version: 'v1.1.0', disposition: 'advanced', previousVersion: 'v1.0.0', availableVersion: 'v1.1.0',
+        }]);
         const content = fs.readFileSync(path.join(tmpHome, '.awm/registries/personal/skills/alpha/SKILL.md'), 'utf-8');
         expect(content).toContain('v2');
+
+        const r3 = await m.syncRegistries();
+        expect(r3).toEqual([{
+            name: 'personal', action: 'pulled', version: 'v1.1.0', disposition: 'unchanged', previousVersion: 'v1.1.0', availableVersion: 'v1.1.0',
+        }]);
     });
 
     it('rollback tag→tag: clone en v1.1.0 retrocede a v1.0.0 al establecer pin', async () => {
@@ -251,7 +260,7 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         // primera sync sin pin: queda en v1.1.0
         const r1 = await m.syncRegistries();
-        expect(r1).toEqual([{ name: 'personal', action: 'recloned', version: 'v1.1.0' }]);
+        expect(r1).toEqual([{ name: 'personal', action: 'recloned', version: 'v1.1.0', disposition: 'installed', availableVersion: 'v1.1.0' }]);
 
         // establece pin a la versión anterior
         const awmDir = path.join(tmpHome, '.awm');
@@ -262,7 +271,15 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         // segunda sync con pin: retrocede a v1.0.0
         const r2 = await m.syncRegistries();
-        expect(r2).toEqual([{ name: 'personal', action: 'pulled', version: 'v1.0.0' }]);
+        expect(r2).toEqual([{
+            name: 'personal',
+            action: 'pulled',
+            version: 'v1.0.0',
+            disposition: 'regressed',
+            pin: '1.0.0',
+            previousVersion: 'v1.1.0',
+            availableVersion: 'v1.1.0',
+        }]);
         const content = fs.readFileSync(path.join(tmpHome, '.awm/registries/personal/skills/alpha/SKILL.md'), 'utf-8');
         expect(content).toContain('test skill'); // contenido original del tag v1.0.0
     });
@@ -281,7 +298,7 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         // primera sync en canal dev: queda en HEAD (no en el tag)
         const r1 = await m.syncRegistries();
-        expect(r1).toEqual([{ name: 'personal', action: 'recloned', version: 'HEAD' }]);
+        expect(r1).toEqual([{ name: 'personal', action: 'recloned', version: 'HEAD', disposition: 'installed' }]);
 
         // nuevo commit en el remote (post-tag, no release)
         fs.writeFileSync(path.join(source, 'skills', 'alpha', 'SKILL.md'), '---\nname: alpha\ndescription: head-2\n---\n');
@@ -290,7 +307,9 @@ describe('syncRegistries (git fixtures locales)', () => {
 
         // segunda sync: recibe el nuevo commit
         const r2 = await m.syncRegistries();
-        expect(r2).toEqual([{ name: 'personal', action: 'pulled', version: 'HEAD' }]);
+        expect(r2).toEqual([{
+            name: 'personal', action: 'pulled', version: 'HEAD', disposition: 'resolved', previousVersion: 'v1.0.0',
+        }]);
         const content = fs.readFileSync(path.join(tmpHome, '.awm/registries/personal/skills/alpha/SKILL.md'), 'utf-8');
         expect(content).toContain('head-2');
     });

--- a/cli/tests/core/versioning.test.ts
+++ b/cli/tests/core/versioning.test.ts
@@ -61,7 +61,7 @@ describe('versioning core', () => {
             const clone = cloneOf(source, tmpWork, 'clone');
             const { resolveTargetRef } = require('../../src/core/versioning');
             const r = await resolveTargetRef(clone, { channel: 'stable' });
-            expect(r).toEqual({ kind: 'tag', ref: 'v1.10.0', version: '1.10.0' });
+            expect(r).toEqual({ kind: 'tag', ref: 'v1.10.0', version: '1.10.0', latestVersion: '1.10.0' });
         });
 
         it('pin exacto gana, con y sin prefijo v', async () => {
@@ -69,9 +69,9 @@ describe('versioning core', () => {
             const clone = cloneOf(source, tmpWork, 'clone');
             const { resolveTargetRef } = require('../../src/core/versioning');
             expect(await resolveTargetRef(clone, { pin: '1.0.0', channel: 'stable' }))
-                .toEqual({ kind: 'tag', ref: 'v1.0.0', version: '1.0.0' });
+                .toEqual({ kind: 'tag', ref: 'v1.0.0', version: '1.0.0', latestVersion: '1.1.0' });
             expect(await resolveTargetRef(clone, { pin: 'v1.0.0', channel: 'stable' }))
-                .toEqual({ kind: 'tag', ref: 'v1.0.0', version: '1.0.0' });
+                .toEqual({ kind: 'tag', ref: 'v1.0.0', version: '1.0.0', latestVersion: '1.1.0' });
         });
 
         it('pin inexistente → error que lista las versiones disponibles', async () => {
@@ -106,7 +106,7 @@ describe('versioning core', () => {
             const clone = cloneOf(source, tmpWork, 'clone');
             const { resolveTargetRef } = require('../../src/core/versioning');
             const r = await resolveTargetRef(clone, { channel: 'stable' });
-            expect(r).toEqual({ kind: 'tag', ref: 'v1.0.0', version: '1.0.0' });
+            expect(r).toEqual({ kind: 'tag', ref: 'v1.0.0', version: '1.0.0', latestVersion: '1.0.0' });
         });
 
         it('hace fetch: ve tags creados en el remote después del clone', async () => {
@@ -119,7 +119,7 @@ describe('versioning core', () => {
             GIT(source, 'tag v1.1.0');
             const { resolveTargetRef } = require('../../src/core/versioning');
             const r = await resolveTargetRef(clone, { channel: 'stable' });
-            expect(r).toEqual({ kind: 'tag', ref: 'v1.1.0', version: '1.1.0' });
+            expect(r).toEqual({ kind: 'tag', ref: 'v1.1.0', version: '1.1.0', latestVersion: '1.1.0' });
         });
     });
 


### PR DESCRIPTION
Summary: propagates sync disposition, prior version, and latest available release; distinguishes installed, advanced, unchanged, resolved, and pin-driven regression; warns on stale pins with latest release and the unpin command, while avoiding that advice for a current pin. Fixes #118. Verification: cli full test suite; cli build; awm sensors run (overall pass); rollback regression red/green proof completed.