### PR TITLE
fix(currentness): query bounded npm latest metadata

### DIFF
--- a/cli/src/core/currentness/check.ts
+++ b/cli/src/core/currentness/check.ts
@@ -8,7 +8,7 @@ import type { CurrentnessComponent, CurrentnessDeps, CurrentnessReport, GitTrans
 const execFileAsync = promisify(execFile);
 const TIMEOUT_MS = 2_000;
 const MAX_OUTPUT_BYTES = 64 * 1024;
-const NPM_SOURCE = `https://registry.npmjs.org/${CLI_PACKAGE_NAME}`;
+const NPM_SOURCE = `https://registry.npmjs.org/${CLI_PACKAGE_NAME}/latest`;
 const STRICT_SEMVER = /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
 function deadline<T>(operation: Promise<T>, timeoutMs = TIMEOUT_MS): Promise<T> {
@@ -106,8 +106,7 @@ async function latestCli(fetchImpl: typeof fetch): Promise<string | null> {
         if (Buffer.byteLength(text, 'utf8') > MAX_OUTPUT_BYTES) return null;
         const body: unknown = JSON.parse(text);
         if (!body || typeof body !== 'object') return null;
-        const tags = (body as Record<string, unknown>)['dist-tags'];
-        const latest = tags && typeof tags === 'object' ? (tags as Record<string, unknown>).latest : undefined;
+        const latest = (body as Record<string, unknown>).version;
         return typeof latest === 'string' && parseVersion(latest) ? latest : null;
     } catch {
         return null;
@@ -191,8 +190,8 @@ export async function checkCurrentness(cwd: string, deps: CurrentnessDeps = {}):
     const cli: CurrentnessComponent = !parseVersion(installedCli) || !latest || compareStrict(installedCli, latest) === null
         ? unavailable('cli', NPM_SOURCE, checkedAt, parseVersion(installedCli) ? installedCli : null)
         : compareStrict(installedCli, latest) === 0
-            ? { component: 'cli', installed: installedCli, latest, channel: 'stable', source: NPM_SOURCE, checkedAt, status: 'current', detail: 'Installed version equals npm dist-tags.latest.', remedy: 'No action required.' }
-            : { component: 'cli', installed: installedCli, latest, channel: 'stable', source: NPM_SOURCE, checkedAt, status: 'stale', detail: 'Installed version is behind npm dist-tags.latest.', remedy: `npm i -g ${CLI_PACKAGE_NAME}@latest && rerun in a fresh process` };
+            ? { component: 'cli', installed: installedCli, latest, channel: 'stable', source: NPM_SOURCE, checkedAt, status: 'current', detail: 'Installed version equals the npm latest release.', remedy: 'No action required.' }
+            : { component: 'cli', installed: installedCli, latest, channel: 'stable', source: NPM_SOURCE, checkedAt, status: 'stale', detail: 'Installed version is behind the npm latest release.', remedy: `npm i -g ${CLI_PACKAGE_NAME}@latest && rerun in a fresh process` };
 
     const components = [cli];
     let registries: RegistrySource[];

--- a/cli/tests/core/currentness/check.test.ts
+++ b/cli/tests/core/currentness/check.test.ts
@@ -21,7 +21,7 @@ describe('checkCurrentness', () => {
             now: () => 1_700_000_000_000,
             fetch: jest.fn().mockResolvedValue({
                 ok: true,
-                text: async () => JSON.stringify({ 'dist-tags': { latest: '1.2.3' } }),
+                text: async () => JSON.stringify({ version: '1.2.3' }),
             }),
             readPreferences: () => ({ pins: {} }),
             listRegistries: () => [{ name: 'baseline', remote: 'https://example.test/team/repo.git', contentRoot: '/registry' }],
@@ -46,6 +46,21 @@ describe('checkCurrentness', () => {
         ]);
         expect(JSON.stringify(result)).not.toContain('secret');
         expect(result.components[1].source).toBe('https://example.test/team/repo.git');
+    });
+
+    it('reads npm currentness from the bounded latest metadata endpoint', async () => {
+        const fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            text: async () => JSON.stringify({ version: '1.2.3' }),
+        });
+        const { checkCurrentness } = require('../../../src/core/currentness/check');
+        const result = await checkCurrentness(root, deps({ fetch }));
+
+        expect(fetch).toHaveBeenCalledWith(
+            'https://registry.npmjs.org/agentic-workflow-manager/latest',
+            expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        );
+        expect(result.components[0]).toEqual(expect.objectContaining({ status: 'current', latest: '1.2.3' }));
     });
 
     it('marks an older pinned registry as pinned-behind with the unpin remedy', async () => {
@@ -74,7 +89,7 @@ describe('checkCurrentness', () => {
             cliVersion: () => '1.9007199254740992.0',
             fetch: jest.fn().mockResolvedValue({
                 ok: true,
-                text: async () => JSON.stringify({ 'dist-tags': { latest: '1.9007199254740993.0' } }),
+                text: async () => JSON.stringify({ version: '1.9007199254740993.0' }),
             }),
         }));
 
@@ -143,7 +158,7 @@ describe('checkCurrentness', () => {
     ])('fails closed for %s', async (name, git) => {
         const { checkCurrentness } = require('../../../src/core/currentness/check');
         const result = await checkCurrentness(root, deps(name === 'malformed npm semver'
-            ? { fetch: jest.fn().mockResolvedValue({ ok: true, text: async () => JSON.stringify({ 'dist-tags': { latest: 'latest' } }) }) }
+            ? { fetch: jest.fn().mockResolvedValue({ ok: true, text: async () => JSON.stringify({ version: 'latest' }) }) }
             : { git }
         ));
 


### PR DESCRIPTION
## Summary
- Query npm latest metadata rather than complete package metadata.
- Preserve strict SemVer validation and the 64 KiB response bound.
- Cover the endpoint contract and update existing fixtures.

## Verification
- Focused currentness Jest suite: 22 passed.
- CLI typecheck passed.
- CLI build passed.
- AWM sensors passed: lint, typecheck, depcheck.

Fixes #133

This unblocks R4b strict preflight: npm was reachable, but complete package metadata exceeded the CLI safety limit and was incorrectly reported as unverifiable.