### PR TITLE
fix(release): accept npm 12 pack manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           set -euo pipefail
           npm run native:package-check
-          TARBALL="$(npm pack --json | node -e 'let input=""; process.stdin.on("data", chunk => input += chunk); process.stdin.on("end", () => console.log(JSON.parse(input)[0].filename));')"
+          TARBALL="$(npm pack --json | node -e 'let input=""; process.stdin.on("data", chunk => input += chunk); process.stdin.on("end", () => { const packed = JSON.parse(input); const item = Array.isArray(packed) ? packed[0] : Object.values(packed)[0]; if (!item || typeof item !== "object" || typeof item.filename !== "string") throw new Error("npm pack returned no tarball filename"); console.log(item.filename); });')"
           for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64 win32-arm64; do
             tar -tzf "$TARBALL" | grep -Fx "package/prebuilds/$target/secure_fs.node"
           done

--- a/cli/tests/structural/release-registry-provenance.test.ts
+++ b/cli/tests/structural/release-registry-provenance.test.ts
@@ -16,4 +16,9 @@ describe('release registry provenance', () => {
             .toBeLessThan(workflow.indexOf('- name: Release'));
         expect(workflow).toMatch(/REGISTRY_TAG: v3\.4\.0[\s\S]*AWM_PUBLISHED_REGISTRY_TAG: v3\.4\.0/);
     });
+
+    it('normalizes npm pack JSON from both array and object output formats', () => {
+        expect(workflow).toContain('Array.isArray(packed) ? packed[0] : Object.values(packed)[0]');
+        expect(workflow).toContain('npm pack returned no tarball filename');
+    });
 });


### PR DESCRIPTION
Root cause: npm latest is now npm 12. Its npm pack JSON output is keyed by package name rather than an array, while the release workflow indexed the first array element. The universal package gate therefore failed before publishing.

Change: normalize both array and keyed-object pack manifests, and fail explicitly when a tarball filename is absent.

Verification: targeted regression test passed; a real npm 12.0.2 pack manifest was parsed successfully; project sensors passed; diff check passed.