### PR TITLE
fix(release): ignore native artifact staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,6 @@ cli/.npmrc
 # Los binarios nativos se compilan por plataforma en la matriz y se ensamblan
 # como artefactos efímeros antes de publicar; nunca son fuente versionada.
 cli/prebuilds/
+# `actions/download-artifact` usa este directorio como staging del release.
+cli/native-artifacts/
 .worktrees/

--- a/cli/tests/structural/native-release-artifacts.test.ts
+++ b/cli/tests/structural/native-release-artifacts.test.ts
@@ -14,6 +14,7 @@ describe('native release artifacts', () => {
         }).trim();
 
         expect(gitignore).toContain('cli/prebuilds/');
+        expect(gitignore).toContain('cli/native-artifacts/');
         expect(tracked).toBe('');
     });
 });


### PR DESCRIPTION
Fixes the release workspace boundary: actions/download-artifact stages downloaded native artifacts under cli/native-artifacts/, which must remain a generated ignored directory. Adds a regression assertion alongside the prebuild artifact rule.\n\nValidated with red-green regression, 28 release tests, and typecheck.