### PR TITLE
fix(orchestrators): require declared skill resolution

### DIFF
--- a/cli/src/commands/context/index.ts
+++ b/cli/src/commands/context/index.ts
@@ -33,7 +33,9 @@ export function runContextOrchestrators(collected: CollectedOrchestrators, opts:
         // un usuario que tipee el nombre declarado exacto (con un caracter que el saneo
         // quita, p.ej. `_` o un byte de control) se lleva un falso "not composed" (R3.5/R3.6).
         const verifyNormalized = sanitizeDeclaredField(opts.verify);
-        const found = composed.some((o) => o.name === verifyNormalized);
+        // A dropped raw identity must not borrow a retained declaration's sanitized name.
+        const found = !collected.droppedNames.includes(opts.verify)
+            && composed.some((o) => o.name === verifyNormalized);
         if (!found) {
             const available = composed.map((o) => o.name).join(', ') || '(none)';
             return {

--- a/cli/src/core/discovery.ts
+++ b/cli/src/core/discovery.ts
@@ -1,7 +1,7 @@
 // src/core/discovery.ts
 import fs from 'fs';
 import path from 'path';
-import { contentRoots, readRegistryManifest } from './registries';
+import { assertRegularRegistryFile, contentRoots, readRegistryManifest } from './registries';
 
 export interface SkillArtifact {
     name: string;
@@ -81,7 +81,7 @@ function mergeEntry(
 
 /**
  * Scans skills directories across all provided content roots and returns all valid skills.
- * A valid skill is a directory that contains a SKILL.md file.
+ * A valid skill is a directory that contains a regular, non-symlink SKILL.md file.
  * Throws on name collision across roots unless the later root declares the name in its awm-registry.json overrides.
  */
 export function discoverSkills(roots: string[] = contentRoots()): SkillArtifact[] {
@@ -93,11 +93,16 @@ export function discoverSkills(roots: string[] = contentRoots()): SkillArtifact[
         for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
             if (!entry.isDirectory()) continue;
             const skillPath = path.join(dir, entry.name);
-            if (!fs.existsSync(path.join(skillPath, 'SKILL.md'))) continue;
+            const skillFile = path.join(skillPath, 'SKILL.md');
+            try {
+                if (!assertRegularRegistryFile(skillFile)) continue;
+            } catch (e) {
+                throw new Error(`${skillFile}: cannot read (${e instanceof Error ? e.message : String(e)})`);
+            }
             mergeEntry('skill', byName, {
                 name: entry.name,
                 path: skillPath,
-                description: readArtifactDescription(path.join(skillPath, 'SKILL.md')),
+                description: readArtifactDescription(skillFile),
             }, overrides);
         }
     }
@@ -153,4 +158,3 @@ export function discoverAgents(roots: string[] = contentRoots()): AgentArtifact[
     }
     return Array.from(byName.values());
 }
-

--- a/cli/src/core/discovery.ts
+++ b/cli/src/core/discovery.ts
@@ -1,7 +1,7 @@
 // src/core/discovery.ts
 import fs from 'fs';
 import path from 'path';
-import { assertRegularRegistryFile, contentRoots, readRegistryManifest } from './registries';
+import { contentRoots, readRegistryManifest } from './registries';
 
 export interface SkillArtifact {
     name: string;
@@ -42,6 +42,49 @@ export function readArtifactDescription(filePath: string): string {
         return readFrontmatterDescription(frontmatter);
     } catch {
         return '';
+    }
+}
+
+/** CTX-CONSTITUTION-052: read only the identity inspected before opening. */
+function readSkillDescription(file: string): string | null {
+    const absolute = path.resolve(file);
+    const parents: string[] = [];
+    for (let parent = path.dirname(absolute); ; parent = path.dirname(parent)) {
+        parents.unshift(parent);
+        if (parent === path.dirname(parent)) break;
+    }
+    for (const parent of parents) {
+        const stat = fs.lstatSync(parent);
+        if (stat.isSymbolicLink()) throw new Error(`${parent}: must not be a symbolic link`);
+        if (!stat.isDirectory()) throw new Error(`${parent}: must be a directory`);
+    }
+    let inspected: fs.BigIntStats;
+    try {
+        inspected = fs.lstatSync(file, { bigint: true });
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
+        throw error;
+    }
+    if (inspected.isSymbolicLink()) throw new Error('must not be a symbolic link');
+    if (!inspected.isFile()) throw new Error('must be a regular file');
+    if (typeof inspected.dev !== 'bigint' || typeof inspected.ino !== 'bigint'
+        || typeof inspected.size !== 'bigint' || inspected.dev < 0n
+        || inspected.ino <= 0n || inspected.size < 0n) {
+        throw new Error('file identity or size is unobservable');
+    }
+    const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0) | (fs.constants.O_NONBLOCK ?? 0);
+    const fd = fs.openSync(file, flags);
+    try {
+        const opened = fs.fstatSync(fd, { bigint: true });
+        if (!opened.isFile()) throw new Error('must be a regular file');
+        if (opened.dev !== inspected.dev || opened.ino !== inspected.ino || opened.size !== inspected.size) {
+            throw new Error('file identity or size changed after inspection');
+        }
+        const raw = fs.readFileSync(fd, 'utf-8');
+        const frontmatter = matchFrontmatterBlock(raw);
+        return frontmatter === null ? '' : readFrontmatterDescription(frontmatter);
+    } finally {
+        fs.closeSync(fd);
     }
 }
 
@@ -94,15 +137,17 @@ export function discoverSkills(roots: string[] = contentRoots()): SkillArtifact[
             if (!entry.isDirectory()) continue;
             const skillPath = path.join(dir, entry.name);
             const skillFile = path.join(skillPath, 'SKILL.md');
+            let description: string | null;
             try {
-                if (!assertRegularRegistryFile(skillFile)) continue;
+                description = readSkillDescription(skillFile);
+                if (description === null) continue;
             } catch (e) {
                 throw new Error(`${skillFile}: cannot read (${e instanceof Error ? e.message : String(e)})`);
             }
             mergeEntry('skill', byName, {
                 name: entry.name,
                 path: skillPath,
-                description: readArtifactDescription(skillFile),
+                description,
             }, overrides);
         }
     }

--- a/cli/src/core/discovery.ts
+++ b/cli/src/core/discovery.ts
@@ -45,7 +45,20 @@ export function readArtifactDescription(filePath: string): string {
     }
 }
 
-/** CTX-CONSTITUTION-052: read only the identity inspected before opening. */
+function inspectSkillDirectory(parent: string, expected?: fs.BigIntStats): fs.BigIntStats {
+    const stat = fs.lstatSync(parent, { bigint: true });
+    if (stat.isSymbolicLink()) throw new Error(`${parent}: must not be a symbolic link`);
+    if (!stat.isDirectory()) throw new Error(`${parent}: must be a directory`);
+    if (typeof stat.dev !== 'bigint' || typeof stat.ino !== 'bigint' || stat.dev < 0n || stat.ino <= 0n) {
+        throw new Error(`${parent}: directory identity is unobservable`);
+    }
+    if (expected && (stat.dev !== expected.dev || stat.ino !== expected.ino)) {
+        throw new Error(`${parent}: directory identity changed after inspection`);
+    }
+    return stat;
+}
+
+/** CTX-CONSTITUTION-052: bind the inspected leaf to its observable parent chain. */
 function readSkillDescription(file: string): string | null {
     const absolute = path.resolve(file);
     const parents: string[] = [];
@@ -53,11 +66,10 @@ function readSkillDescription(file: string): string | null {
         parents.unshift(parent);
         if (parent === path.dirname(parent)) break;
     }
-    for (const parent of parents) {
-        const stat = fs.lstatSync(parent);
-        if (stat.isSymbolicLink()) throw new Error(`${parent}: must not be a symbolic link`);
-        if (!stat.isDirectory()) throw new Error(`${parent}: must be a directory`);
-    }
+    const inspectedParents = parents.map(parent => ({ path: parent, stat: inspectSkillDirectory(parent) }));
+    const validateParents = (): void => {
+        for (const parent of inspectedParents) inspectSkillDirectory(parent.path, parent.stat);
+    };
     let inspected: fs.BigIntStats;
     try {
         inspected = fs.lstatSync(file, { bigint: true });
@@ -65,6 +77,8 @@ function readSkillDescription(file: string): string | null {
         if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
         throw error;
     }
+    // A parent swapped before leaf lstat must not establish a new trusted identity.
+    validateParents();
     if (inspected.isSymbolicLink()) throw new Error('must not be a symbolic link');
     if (!inspected.isFile()) throw new Error('must be a regular file');
     if (typeof inspected.dev !== 'bigint' || typeof inspected.ino !== 'bigint'
@@ -80,6 +94,8 @@ function readSkillDescription(file: string): string | null {
         if (opened.dev !== inspected.dev || opened.ino !== inspected.ino || opened.size !== inspected.size) {
             throw new Error('file identity or size changed after inspection');
         }
+        // Reject substitutions observable after open, while retaining descriptor authority.
+        validateParents();
         const raw = fs.readFileSync(fd, 'utf-8');
         const frontmatter = matchFrontmatterBlock(raw);
         return frontmatter === null ? '' : readFrontmatterDescription(frontmatter);

--- a/cli/src/core/orchestrators.ts
+++ b/cli/src/core/orchestrators.ts
@@ -161,7 +161,7 @@ export function collectDeclaredOrchestrators(): { declared: DeclaredOrchestrator
         for (const orch of r.orchestrators) {
             const file = path.join(reg.contentRoot, REGISTRY_MANIFEST_NAME);
             if (!availableSkillNames.has(orch.name)) {
-                diagnostics.push(`${file}: orchestrator declaration dropped because skill "${stripControlChars(orch.name)}" is not discoverable in configured safe registries`);
+                diagnostics.push(`${stripControlChars(file)}: orchestrator declaration dropped because skill "${stripControlChars(orch.name)}" is not discoverable in configured safe registries`);
                 continue;
             }
             if (seenNames.has(orch.name)) {

--- a/cli/src/core/orchestrators.ts
+++ b/cli/src/core/orchestrators.ts
@@ -62,7 +62,7 @@ export function readDeclaredOrchestrators(root: string): DeclaredOrchestratorsRe
     try {
         exists = assertRegularRegistryFile(file);
     } catch (e) {
-        return { orchestrators: [], diagnostics: [`${file}: ${e instanceof Error ? e.message : String(e)}`] };
+        return { orchestrators: [], diagnostics: [sanitizeDiagnosticText(`${file}: ${e instanceof Error ? e.message : String(e)}`)] };
     }
     if (!exists) return { orchestrators: [], diagnostics: [] };
 
@@ -70,21 +70,21 @@ export function readDeclaredOrchestrators(root: string): DeclaredOrchestratorsRe
     try {
         contents = fs.readFileSync(file, 'utf-8');
     } catch (e) {
-        return { orchestrators: [], diagnostics: [`${file}: cannot read manifest (${e instanceof Error ? e.message : String(e)})`] };
+        return { orchestrators: [], diagnostics: [sanitizeDiagnosticText(`${file}: cannot read manifest (${e instanceof Error ? e.message : String(e)})`)] };
     }
 
     let raw: unknown;
     try {
         raw = JSON.parse(contents);
     } catch (e) {
-        return { orchestrators: [], diagnostics: [`${file}: manifest is not valid JSON (${e instanceof Error ? e.message : String(e)})`] };
+        return { orchestrators: [], diagnostics: [sanitizeDiagnosticText(`${file}: manifest is not valid JSON (${e instanceof Error ? e.message : String(e)})`)] };
     }
 
     const decl = (raw as Record<string, unknown>)?.orchestrator;
     if (decl === undefined) return { orchestrators: [], diagnostics: [] };
 
     if (typeof decl !== 'object' || decl === null || Array.isArray(decl)) {
-        return { orchestrators: [], diagnostics: [`${file}: "orchestrator" must be an object`] };
+        return { orchestrators: [], diagnostics: [sanitizeDiagnosticText(`${file}: "orchestrator" must be an object`)] };
     }
 
     const problems: string[] = [];
@@ -92,9 +92,8 @@ export function readDeclaredOrchestrators(root: string): DeclaredOrchestratorsRe
 
     for (const key of Object.keys(entries)) {
         if (!(ALLOWED_FIELDS as readonly string[]).includes(key)) {
-            // key comes straight from an untrusted registry's JSON — JSON.stringify keeps the
-            // diagnostic single-line and unambiguous even if the key contains newlines or other
-            // control characters, which would otherwise let a crafted key forge extra log lines.
+            // Quote keys unambiguously; sanitize the complete diagnostic below because
+            // JSON.stringify preserves Unicode line separators and C1 controls.
             problems.push(`unknown field ${JSON.stringify(key)} — the contract admits only ${ALLOWED_FIELDS.join(', ')}`);
         }
     }
@@ -108,7 +107,7 @@ export function readDeclaredOrchestrators(root: string): DeclaredOrchestratorsRe
     }
 
     if (problems.length > 0) {
-        return { orchestrators: [], diagnostics: [`${file}: invalid "orchestrator" declaration — ${problems.join('; ')}`] };
+        return { orchestrators: [], diagnostics: [sanitizeDiagnosticText(`${file}: invalid "orchestrator" declaration — ${problems.join('; ')}`)] };
     }
 
     return {

--- a/cli/src/core/orchestrators.ts
+++ b/cli/src/core/orchestrators.ts
@@ -10,7 +10,7 @@ import fs from 'fs';
 import path from 'path';
 import { REGISTRY_MANIFEST_NAME, assertRegularRegistryFile, contentRoots, listRegistries } from './registries';
 import { discoverSkills } from './discovery';
-import { sanitizeDeclaredField, stripControlChars } from './text';
+import { sanitizeDeclaredField, sanitizeDiagnosticText, stripControlChars } from './text';
 
 export interface DeclaredOrchestrator {
     name: string;
@@ -32,15 +32,19 @@ const ALLOWED_FIELDS = ['name', 'appliesWhen', 'terminatesTo'] as const;
 const MAX_FIELD_LENGTH = 500;
 
 function discoverDeclaredSkillNames(): { names: Set<string>; diagnostics: string[] } {
-    const names = new Set<string>();
+    let names = new Set<string>();
     const diagnostics: string[] = [];
+    const acceptedRoots: string[] = [];
 
     for (const root of contentRoots()) {
         try {
-            for (const skill of discoverSkills([root])) names.add(skill.name);
+            // Admit the entire root only after global collision/override resolution succeeds.
+            const skills = discoverSkills([...acceptedRoots, root]);
+            names = new Set(skills.map((skill) => skill.name));
+            acceptedRoots.push(root);
         } catch (e) {
             const message = e instanceof Error ? e.message : String(e);
-            diagnostics.push(`${stripControlChars(root)}: orchestrator skill discovery unavailable (${stripControlChars(message)})`);
+            diagnostics.push(`${sanitizeDiagnosticText(root)}: orchestrator skill discovery unavailable (${sanitizeDiagnosticText(message)})`);
         }
     }
 
@@ -151,8 +155,9 @@ export function readDeclaredOrchestrators(root: string): DeclaredOrchestratorsRe
  * context/provider.ts, el cual ya importa `DeclaredOrchestrator` DESDE este archivo -- pueda
  * calcular el mismo nombre saneado sin duplicar el regex.
  */
-export function collectDeclaredOrchestrators(): { declared: DeclaredOrchestrator[]; diagnostics: string[] } {
+export function collectDeclaredOrchestrators(): { declared: DeclaredOrchestrator[]; diagnostics: string[]; droppedNames: string[] } {
     const declared: DeclaredOrchestrator[] = [];
+    const droppedNames: string[] = [];
     const { names: availableSkillNames, diagnostics } = discoverDeclaredSkillNames();
     const seenNames = new Set<string>();
     const seenSanitizedNames = new Set<string>();
@@ -161,7 +166,8 @@ export function collectDeclaredOrchestrators(): { declared: DeclaredOrchestrator
         for (const orch of r.orchestrators) {
             const file = path.join(reg.contentRoot, REGISTRY_MANIFEST_NAME);
             if (!availableSkillNames.has(orch.name)) {
-                diagnostics.push(`${stripControlChars(file)}: orchestrator declaration dropped because skill "${stripControlChars(orch.name)}" is not discoverable in configured safe registries`);
+                droppedNames.push(orch.name);
+                diagnostics.push(`${sanitizeDiagnosticText(file)}: orchestrator declaration dropped because skill "${sanitizeDiagnosticText(orch.name)}" is not discoverable in configured safe registries`);
                 continue;
             }
             if (seenNames.has(orch.name)) {
@@ -180,7 +186,7 @@ export function collectDeclaredOrchestrators(): { declared: DeclaredOrchestrator
         }
         diagnostics.push(...r.diagnostics);
     }
-    return { declared, diagnostics };
+    return { declared, diagnostics, droppedNames };
 }
 
 /** Recolecta declarados y emite sus diagnosticos como warnings. Punto unico usado por

--- a/cli/src/core/orchestrators.ts
+++ b/cli/src/core/orchestrators.ts
@@ -8,7 +8,8 @@
 // entre al framework (R1.3, R5.3).
 import fs from 'fs';
 import path from 'path';
-import { REGISTRY_MANIFEST_NAME, assertRegularRegistryFile, listRegistries } from './registries';
+import { REGISTRY_MANIFEST_NAME, assertRegularRegistryFile, contentRoots, listRegistries } from './registries';
+import { discoverSkills } from './discovery';
 import { sanitizeDeclaredField, stripControlChars } from './text';
 
 export interface DeclaredOrchestrator {
@@ -29,6 +30,22 @@ const ALLOWED_FIELDS = ['name', 'appliesWhen', 'terminatesTo'] as const;
 // untrusted input whose fields flow straight into the AI-provider context payload, so an
 // unbounded string here would let a crafted registry bloat/DoS that context.
 const MAX_FIELD_LENGTH = 500;
+
+function discoverDeclaredSkillNames(): { names: Set<string>; diagnostics: string[] } {
+    const names = new Set<string>();
+    const diagnostics: string[] = [];
+
+    for (const root of contentRoots()) {
+        try {
+            for (const skill of discoverSkills([root])) names.add(skill.name);
+        } catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            diagnostics.push(`${stripControlChars(root)}: orchestrator skill discovery unavailable (${stripControlChars(message)})`);
+        }
+    }
+
+    return { names, diagnostics };
+}
 
 export function readDeclaredOrchestrators(root: string): DeclaredOrchestratorsResult {
     const file = path.join(root, REGISTRY_MANIFEST_NAME);
@@ -136,13 +153,17 @@ export function readDeclaredOrchestrators(root: string): DeclaredOrchestratorsRe
  */
 export function collectDeclaredOrchestrators(): { declared: DeclaredOrchestrator[]; diagnostics: string[] } {
     const declared: DeclaredOrchestrator[] = [];
-    const diagnostics: string[] = [];
+    const { names: availableSkillNames, diagnostics } = discoverDeclaredSkillNames();
     const seenNames = new Set<string>();
     const seenSanitizedNames = new Set<string>();
     for (const reg of listRegistries()) {
         const r = readDeclaredOrchestrators(reg.contentRoot);
         for (const orch of r.orchestrators) {
             const file = path.join(reg.contentRoot, REGISTRY_MANIFEST_NAME);
+            if (!availableSkillNames.has(orch.name)) {
+                diagnostics.push(`${file}: orchestrator declaration dropped because skill "${stripControlChars(orch.name)}" is not discoverable in configured safe registries`);
+                continue;
+            }
             if (seenNames.has(orch.name)) {
                 diagnostics.push(`${file}: orchestrator "${stripControlChars(orch.name)}" duplicates one already declared by an earlier registry — shadowed duplicate dropped`);
                 continue;

--- a/cli/src/core/text.ts
+++ b/cli/src/core/text.ts
@@ -13,6 +13,13 @@ export function stripControlChars(text: string): string {
     return text.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
 }
 
+/** Keeps an untrusted diagnostic field on one terminal line, without changing
+ * the whitespace policy for multiline public text or composed markdown. */
+export function sanitizeDiagnosticText(text: string): string {
+    // eslint-disable-next-line no-control-regex -- remove all C0/C1 controls, including terminal escape bytes
+    return text.replace(/\r\n|[\r\n\t\u2028\u2029]/g, ' ').replace(/[\x00-\x1f\x7f-\x9f]/g, '');
+}
+
 /**
  * Neutraliza marcado markdown (colapsa `\r?\n` a un espacio y quita
  * `` ` * _ # < > ``) de contenido no confiable antes de interpolarlo en un

--- a/cli/tests/commands/context.test.ts
+++ b/cli/tests/commands/context.test.ts
@@ -1,7 +1,7 @@
 import { runContextOrchestrators } from '../../src/commands/context';
 
 const collected = (declared: { name: string; appliesWhen: string; terminatesTo: string }[], diagnostics: string[] = []) =>
-    ({ declared, diagnostics });
+    ({ declared, diagnostics, droppedNames: [] as string[] });
 
 const uno = { name: 'mi-proceso', appliesWhen: 'cuando hay una tarea', terminatesTo: 'development-process' };
 
@@ -64,6 +64,15 @@ describe('awm context orchestrators', () => {
     it('--verify sigue saliendo 2 para un nombre genuinamente ausente', () => {   // verifies confirmed Finding 2 (no regression)
         const r = runContextOrchestrators(collected([uno]), { json: false, verify: 'de-verdad-no-existe' });
         expect(r.code).toBe(2);
+    });
+
+    it('--verify rejects a dropped raw identity that sanitizes to a retained name', () => {
+        const input = {
+            ...collected([{ name: 'foobar', appliesWhen: 'x', terminatesTo: 'y' }]),
+            droppedNames: ['foo_bar'],
+        };
+        expect(runContextOrchestrators(input, { json: false, verify: 'foo_bar' }).code).toBe(2);
+        expect(runContextOrchestrators(input, { json: false, verify: 'foobar' }).code).toBe(0);
     });
 
     it('sanea bytes de control antes de escribir a la terminal', () => {         // verifies R5.4

--- a/cli/tests/commands/hooks/install.test.ts
+++ b/cli/tests/commands/hooks/install.test.ts
@@ -208,6 +208,8 @@ describe('installHook (happy path + merge)', () => {
         fs.writeFileSync(path.join(regHooks, 'session-start'), '#!/usr/bin/env bash\necho "{}"', { mode: 0o755 });
         fs.writeFileSync(path.join(regHooks, 'run-hook.cmd'), '#!/usr/bin/env bash\nexec bash "$1"', { mode: 0o755 });
         fs.writeFileSync(path.join(regSkill, 'SKILL.md'), '---\nname: using-awm\n---\nMUST invoke skills.');
+        fs.mkdirSync(path.join(registryRoot, 'skills', 'mi-proceso'), { recursive: true });
+        fs.writeFileSync(path.join(registryRoot, 'skills', 'mi-proceso', 'SKILL.md'), '---\nname: mi-proceso\n---\n');
         fs.writeFileSync(
             path.join(registryRoot, 'awm-registry.json'),
             JSON.stringify({ orchestrator: { name: 'mi-proceso', appliesWhen: 'al arrancar', terminatesTo: 'development-process' } }),
@@ -280,6 +282,8 @@ describe('installHook (happy path + merge)', () => {
         fs.writeFileSync(path.join(regHooks, 'session-start'), '#!/usr/bin/env bash\necho "{}"', { mode: 0o755 });
         fs.writeFileSync(path.join(regHooks, 'run-hook.cmd'), '#!/usr/bin/env bash\nexec bash "$1"', { mode: 0o755 });
         fs.writeFileSync(path.join(regSkill, 'SKILL.md'), '---\nname: using-awm\n---\nMUST invoke skills.');
+        fs.mkdirSync(path.join(registryRoot, 'skills', 'proceso-valido'), { recursive: true });
+        fs.writeFileSync(path.join(registryRoot, 'skills', 'proceso-valido', 'SKILL.md'), '---\nname: proceso-valido\n---\n');
         fs.writeFileSync(
             path.join(registryRoot, 'awm-registry.json'),
             JSON.stringify({ orchestrator: { name: 'proceso-valido', appliesWhen: 'al arrancar', terminatesTo: 'development-process' } }),

--- a/cli/tests/commands/hooks/resync.test.ts
+++ b/cli/tests/commands/hooks/resync.test.ts
@@ -104,6 +104,8 @@ describe('resyncInstalledHooks', () => {
         fs.writeFileSync(path.join(regHooks, 'session-start'), '#!/usr/bin/env bash\necho "{}"', { mode: 0o755 });
         fs.writeFileSync(path.join(regHooks, 'run-hook.cmd'), '#!/usr/bin/env bash\nexec bash "$1"', { mode: 0o755 });
         fs.writeFileSync(path.join(regSkill, 'SKILL.md'), '---\nname: using-awm\n---\nMUST invoke skills.');
+        fs.mkdirSync(path.join(registryRoot, 'skills', 'mi-proceso'), { recursive: true });
+        fs.writeFileSync(path.join(registryRoot, 'skills', 'mi-proceso', 'SKILL.md'), '---\nname: mi-proceso\n---\n');
         fs.writeFileSync(
             path.join(registryRoot, 'awm-registry.json'),
             JSON.stringify({ orchestrator: { name: 'mi-proceso', appliesWhen: 'al arrancar', terminatesTo: 'development-process' } }),

--- a/cli/tests/core/context/orchestrator.test.ts
+++ b/cli/tests/core/context/orchestrator.test.ts
@@ -280,6 +280,8 @@ describe('InjectionOrchestrator (declared orchestrators from an installed regist
             path.join(registryRoot, 'skills/using-awm/SKILL.md'),
             '---\nversion: "1.0.0"\n---\nBODY',
         );
+        fs.mkdirSync(path.join(registryRoot, 'skills/mi-proceso'), { recursive: true });
+        fs.writeFileSync(path.join(registryRoot, 'skills/mi-proceso/SKILL.md'), '---\nname: mi-proceso\n---\n');
         fs.writeFileSync(
             path.join(registryRoot, 'awm-registry.json'),
             JSON.stringify({

--- a/cli/tests/core/discovery-multiroot.test.ts
+++ b/cli/tests/core/discovery-multiroot.test.ts
@@ -66,4 +66,11 @@ describe('discovery multi-root', () => {
         expect(discoverSkills([rootA, rootB]).length).toBe(1);
         expect(discoverAgents([rootA, rootB])).toEqual([]);
     });
+
+    it('rejects a real directory named SKILL.md as a nonregular artifact without blocking', () => {
+        fs.mkdirSync(path.join(rootA, 'skills', 'unsafe', 'SKILL.md'), { recursive: true });
+        const { discoverSkills } = require('../../src/core/discovery');
+
+        expect(() => discoverSkills([rootA])).toThrow(/SKILL\.md.*regular file/);
+    });
 });

--- a/cli/tests/core/discovery-parent-race.test.ts
+++ b/cli/tests/core/discovery-parent-race.test.ts
@@ -72,9 +72,24 @@ describe('real skill parent races', () => {
         const read = jest.spyOn(fs, 'readFileSync');
         const close = jest.spyOn(fs, 'closeSync');
 
-        expect(() => discoverSkills([root])).toThrow(/symbolic link/i);
+        let thrown: unknown;
+        try {
+            discoverSkills([root]);
+        } catch (error) {
+            thrown = error;
+        }
+        if (process.platform === 'win32') {
+            // Windows holds the opened file's parent directory handle, so the
+            // replacement itself is denied before a symlink can be introduced.
+            // This is the same security guarantee: outside bytes cannot be read.
+            expect(thrown).toBeInstanceOf(Error);
+            expect((thrown as Error).message).toMatch(/EPERM.*rename|rename.*EPERM/i);
+        } else {
+            expect(thrown).toBeInstanceOf(Error);
+            expect((thrown as Error).message).toMatch(/symbolic link/i);
+            expect(close).toHaveBeenCalledWith(descriptor);
+        }
         expect(read.mock.calls.filter(([file]) => typeof file === 'number'
             || String(file).startsWith(fixture + path.sep))).toEqual([]);
-        expect(close).toHaveBeenCalledWith(descriptor);
     });
 });

--- a/cli/tests/core/discovery-parent-race.test.ts
+++ b/cli/tests/core/discovery-parent-race.test.ts
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { discoverSkills } from '../../src/core/discovery';
+
+describe('real skill parent races', () => {
+    let fixture: string;
+    let root: string;
+    let skillDir: string;
+    let skillFile: string;
+
+    beforeEach(() => {
+        fixture = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'skill-parent-race-'));
+        root = path.join(fixture, 'registry');
+        skillDir = path.join(root, 'skills', 'safe');
+        skillFile = path.join(skillDir, 'SKILL.md');
+        fs.mkdirSync(skillDir, { recursive: true });
+        fs.writeFileSync(skillFile, '---\ndescription: Inside skill\n---\n');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        fs.rmSync(fixture, { recursive: true, force: true });
+    });
+
+    it('reads an unchanged skill through its descriptor', () => {
+        expect(discoverSkills([root])).toEqual([
+            { name: 'safe', path: skillDir, description: 'Inside skill' },
+        ]);
+    });
+
+    describe.each(['root', 'skills', 'skill directory'])('%s substitution', (component) => {
+        it.each(['symlink', 'directory'])('rejects a %s swapped after parent inspection before reading outside bytes', (replacement) => {
+            const parent = component === 'root' ? root : component === 'skills' ? path.dirname(skillDir) : skillDir;
+            const outside = path.join(fixture, 'outside');
+            const outsideFile = path.join(outside, path.relative(parent, skillFile));
+            fs.mkdirSync(path.dirname(outsideFile), { recursive: true });
+            fs.writeFileSync(outsideFile, '---\ndescription: Outside skill\n---\n');
+
+            const lstat = fs.lstatSync;
+            let swapped = false;
+            // Keep real lstat results; only schedule a real rename/symlink at the race boundary.
+            jest.spyOn(fs, 'lstatSync').mockImplementation(((...args: Parameters<typeof fs.lstatSync>) => {
+                const stat = lstat(...args);
+                if (args[0] === parent && !swapped) {
+                    swapped = true;
+                    fs.renameSync(parent, path.join(fixture, 'original-parent'));
+                    if (replacement === 'symlink') fs.symlinkSync(outside, parent, 'junction');
+                    else fs.renameSync(outside, parent);
+                }
+                return stat;
+            }) as typeof fs.lstatSync);
+            const read = jest.spyOn(fs, 'readFileSync');
+
+            expect(() => discoverSkills([root])).toThrow(/symbolic link|directory identity/i);
+            expect(swapped).toBe(true);
+            expect(read.mock.calls.filter(([file]) => typeof file === 'number'
+                || String(file).startsWith(fixture + path.sep))).toEqual([]);
+        });
+    });
+
+    it('rejects an observable parent symlink introduced after open and closes the descriptor without reading', () => {
+        const open = fs.openSync;
+        let descriptor: number | undefined;
+        jest.spyOn(fs, 'openSync').mockImplementation((...args) => {
+            descriptor = open(...args);
+            const moved = path.join(fixture, 'original-parent');
+            fs.renameSync(skillDir, moved);
+            fs.symlinkSync(moved, skillDir, 'junction');
+            return descriptor;
+        });
+        const read = jest.spyOn(fs, 'readFileSync');
+        const close = jest.spyOn(fs, 'closeSync');
+
+        expect(() => discoverSkills([root])).toThrow(/symbolic link/i);
+        expect(read.mock.calls.filter(([file]) => typeof file === 'number'
+            || String(file).startsWith(fixture + path.sep))).toEqual([]);
+        expect(close).toHaveBeenCalledWith(descriptor);
+    });
+});

--- a/cli/tests/core/discovery-safe-read.test.ts
+++ b/cli/tests/core/discovery-safe-read.test.ts
@@ -13,7 +13,7 @@ const inspected = {
     dev: 7n, ino: 9007199254740993n, size: BigInt(Buffer.byteLength(content)),
     isFile: () => true, isSymbolicLink: () => false, isDirectory: () => false,
 };
-const directory = { isFile: () => false, isSymbolicLink: () => false, isDirectory: () => true };
+const directory = { dev: 7n, ino: 8n, isFile: () => false, isSymbolicLink: () => false, isDirectory: () => true };
 
 describe.each([true, false])('skill descriptor safety (O_NOFOLLOW available: %s)', (noFollowAvailable) => {
     beforeEach(() => {
@@ -104,6 +104,17 @@ describe.each([true, false])('skill descriptor safety (O_NOFOLLOW available: %s)
         (fs.fstatSync as jest.Mock).mockReturnValue(unknown);
 
         expect(() => discoverSkills([root])).toThrow(/identity|size/i);
+        expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it.each(['dev', 'ino'])('fails closed when parent %s is unobservable', (field) => {
+        const lstat = (fs.lstatSync as jest.Mock).getMockImplementation()!;
+        (fs.lstatSync as jest.Mock).mockImplementation((file, options) => file === skillDir
+            ? { ...directory, [field]: undefined }
+            : lstat(file, options));
+
+        expect(() => discoverSkills([root])).toThrow(/directory identity/i);
+        expect(fs.openSync).not.toHaveBeenCalled();
         expect(fs.readFileSync).not.toHaveBeenCalled();
     });
 });

--- a/cli/tests/core/discovery-safe-read.test.ts
+++ b/cli/tests/core/discovery-safe-read.test.ts
@@ -1,0 +1,109 @@
+import fs from 'fs';
+import path from 'path';
+import { discoverSkills } from '../../src/core/discovery';
+
+jest.mock('fs');
+
+const root = path.resolve('registry');
+const skillDir = path.join(root, 'skills', 'safe');
+const skillFile = path.join(skillDir, 'SKILL.md');
+const content = '---\ndescription: >-\n  Ordinary skill\n---\n';
+const descriptor = 42;
+const inspected = {
+    dev: 7n, ino: 9007199254740993n, size: BigInt(Buffer.byteLength(content)),
+    isFile: () => true, isSymbolicLink: () => false, isDirectory: () => false,
+};
+const directory = { isFile: () => false, isSymbolicLink: () => false, isDirectory: () => true };
+
+describe.each([true, false])('skill descriptor safety (O_NOFOLLOW available: %s)', (noFollowAvailable) => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+        const actual = jest.requireActual<typeof fs>('fs');
+        jest.replaceProperty(fs, 'constants', {
+            ...actual.constants,
+            O_NOFOLLOW: noFollowAvailable ? 0x20000 : undefined,
+            O_NONBLOCK: 0x800,
+        } as typeof fs.constants);
+        (fs.existsSync as jest.Mock).mockReturnValue(true);
+        (fs.readdirSync as jest.Mock).mockReturnValue([{ name: 'safe', isDirectory: () => true }]);
+        (fs.lstatSync as jest.Mock).mockImplementation((file) => {
+            if (file === skillFile) return inspected;
+            if (file.endsWith('awm-registry.json')) throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+            return directory;
+        });
+        (fs.openSync as jest.Mock).mockReturnValue(descriptor);
+        (fs.fstatSync as jest.Mock).mockReturnValue(inspected);
+        (fs.readFileSync as jest.Mock).mockReturnValue(content);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('reads an ordinary skill from the validated descriptor and closes it', () => {
+        expect(discoverSkills([root])).toEqual([{ name: 'safe', path: skillDir, description: 'Ordinary skill' }]);
+        expect(fs.readFileSync).toHaveBeenCalledWith(descriptor, 'utf-8');
+        expect(fs.closeSync).toHaveBeenCalledWith(descriptor);
+        const flags = (fs.openSync as jest.Mock).mock.calls[0][1];
+        expect(typeof flags).toBe('number');
+        if (noFollowAvailable) expect(flags & fs.constants.O_NOFOLLOW).toBe(fs.constants.O_NOFOLLOW);
+        expect(flags & fs.constants.O_NONBLOCK).toBe(fs.constants.O_NONBLOCK);
+    });
+
+    it.each([
+        ['another inode', { ino: inspected.ino + 1n }],
+        ['another device', { dev: inspected.dev + 1n }],
+        ['changed size', { size: inspected.size + 1n }],
+        ['FIFO replacement', { isFile: (): boolean => false }],
+        ['symlink replacement', { isFile: (): boolean => false, isSymbolicLink: (): boolean => true }],
+        ['unobservable device', { dev: undefined }],
+        ['unobservable inode', { ino: undefined }],
+    ])('rejects %s after inspection, without reading replacement bytes', (_label, change) => {
+        (fs.fstatSync as jest.Mock).mockReturnValue({ ...inspected, ...change });
+
+        expect(() => discoverSkills([root])).toThrow(/SKILL\.md.*(identity|regular|size|symbolic)/i);
+        expect(fs.readFileSync).not.toHaveBeenCalled();
+        expect(fs.closeSync).toHaveBeenCalledWith(descriptor);
+    });
+
+    it('opens nonblocking so a FIFO replacement cannot hang before fstat rejects it', () => {
+        // No FIFO is created: the open mock enforces the flag needed to avoid blocking.
+        (fs.openSync as jest.Mock).mockImplementation((_file, flags) => {
+            if (!(flags & fs.constants.O_NONBLOCK)) throw new Error('would block opening FIFO');
+            return descriptor;
+        });
+        (fs.fstatSync as jest.Mock).mockReturnValue({ ...inspected, isFile: () => false });
+
+        expect(() => discoverSkills([root])).toThrow(/regular file/i);
+        expect(fs.readFileSync).not.toHaveBeenCalled();
+        expect(fs.closeSync).toHaveBeenCalledWith(descriptor);
+    });
+
+    it.each(['openSync', 'fstatSync', 'readFileSync'] as const)('fails closed on %s errors', (operation) => {
+        (fs[operation] as jest.Mock).mockImplementation(() => { throw new Error('replaced or unreadable'); });
+
+        expect(() => discoverSkills([root])).toThrow(/SKILL\.md.*replaced or unreadable/);
+        if (operation === 'openSync') expect(fs.closeSync).not.toHaveBeenCalled();
+        else expect(fs.closeSync).toHaveBeenCalledWith(descriptor);
+        if (operation !== 'readFileSync') expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it.each([root, path.join(root, 'skills'), skillDir])('rejects an observable directory symlink at %s', (linked) => {
+        const lstat = (fs.lstatSync as jest.Mock).getMockImplementation()!;
+        (fs.lstatSync as jest.Mock).mockImplementation((file, options) => file === linked
+            ? { ...directory, isDirectory: () => false, isSymbolicLink: () => true }
+            : lstat(file, options));
+
+        expect(() => discoverSkills([root])).toThrow(/symbolic link/i);
+        expect(fs.openSync).not.toHaveBeenCalled();
+        expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it.each(['dev', 'ino', 'size'])('fails closed when inspected %s is unobservable', (field) => {
+        const unknown = { ...inspected, [field]: undefined };
+        const lstat = (fs.lstatSync as jest.Mock).getMockImplementation()!;
+        (fs.lstatSync as jest.Mock).mockImplementation((file, options) => file === skillFile ? unknown : lstat(file, options));
+        (fs.fstatSync as jest.Mock).mockReturnValue(unknown);
+
+        expect(() => discoverSkills([root])).toThrow(/identity|size/i);
+        expect(fs.readFileSync).not.toHaveBeenCalled();
+    });
+});

--- a/cli/tests/core/discovery.test.ts
+++ b/cli/tests/core/discovery.test.ts
@@ -12,7 +12,7 @@ const WORKFLOWS_ROOT = CONTENT_ROOT;
 // For backward-compat with mock expectations that check SKILLS_DIR-style paths:
 const SKILLS_DIR = path.join(CONTENT_ROOT, 'skills');
 const WORKFLOWS_DIR = path.join(CONTENT_ROOT, 'workflows');
-const directoryStat = { isDirectory: () => true, isSymbolicLink: () => false };
+const directoryStat = { dev: 1n, ino: 3n, isDirectory: () => true, isSymbolicLink: () => false };
 const skillStat = { dev: 1n, ino: 2n, size: 0n, isFile: () => true, isSymbolicLink: () => false };
 
 describe('Artifact Discovery', () => {

--- a/cli/tests/core/discovery.test.ts
+++ b/cli/tests/core/discovery.test.ts
@@ -24,6 +24,10 @@ describe('Artifact Discovery', () => {
 
     describe('discoverSkills', () => {
         it('should return a list of skill directories that contain a SKILL.md', () => {
+            (fs.lstatSync as jest.Mock).mockImplementation((p: string) => {
+                if (p.endsWith('SKILL.md')) return { isFile: () => true, isSymbolicLink: () => false };
+                throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+            });
             (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
                 if (p === SKILLS_DIR) return true;
                 if (p.endsWith('SKILL.md')) return true;
@@ -49,6 +53,18 @@ describe('Artifact Discovery', () => {
             const skills = discoverSkills([SKILLS_ROOT]);
 
             expect(skills).toEqual([]);
+        });
+
+        it.each(['fifo', 'symlink'])('rejects a %s SKILL.md before attempting any read', (kind) => {
+            (fs.existsSync as jest.Mock).mockReturnValue(true);
+            (fs.readdirSync as jest.Mock).mockReturnValue([{ name: 'unsafe', isDirectory: () => true }]);
+            (fs.lstatSync as jest.Mock).mockImplementation((p: string) => {
+                if (p.endsWith('SKILL.md')) return { isFile: () => false, isSymbolicLink: () => kind === 'symlink' };
+                throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+            });
+
+            expect(() => discoverSkills([SKILLS_ROOT])).toThrow(/regular file|symbolic link/);
+            expect(fs.readFileSync).not.toHaveBeenCalled();
         });
 
         it('should skip skill directories without a SKILL.md', () => {

--- a/cli/tests/core/discovery.test.ts
+++ b/cli/tests/core/discovery.test.ts
@@ -12,20 +12,27 @@ const WORKFLOWS_ROOT = CONTENT_ROOT;
 // For backward-compat with mock expectations that check SKILLS_DIR-style paths:
 const SKILLS_DIR = path.join(CONTENT_ROOT, 'skills');
 const WORKFLOWS_DIR = path.join(CONTENT_ROOT, 'workflows');
+const directoryStat = { isDirectory: () => true, isSymbolicLink: () => false };
+const skillStat = { dev: 1n, ino: 2n, size: 0n, isFile: () => true, isSymbolicLink: () => false };
 
 describe('Artifact Discovery', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        (fs.lstatSync as jest.Mock).mockImplementation(() => {
+        (fs.lstatSync as jest.Mock).mockImplementation((p: string) => {
+            if (!p.endsWith('.md') && !p.endsWith('.json')) return directoryStat;
             const error = Object.assign(new Error('missing'), { code: 'ENOENT' });
             throw error;
         });
+        (fs.openSync as jest.Mock).mockReturnValue(42);
+        (fs.fstatSync as jest.Mock).mockReturnValue(skillStat);
+        (fs.readFileSync as jest.Mock).mockReturnValue('');
     });
 
     describe('discoverSkills', () => {
         it('should return a list of skill directories that contain a SKILL.md', () => {
             (fs.lstatSync as jest.Mock).mockImplementation((p: string) => {
-                if (p.endsWith('SKILL.md')) return { isFile: () => true, isSymbolicLink: () => false };
+                if (p.endsWith('SKILL.md')) return skillStat;
+                if (!p.endsWith('.json')) return directoryStat;
                 throw Object.assign(new Error('missing'), { code: 'ENOENT' });
             });
             (fs.existsSync as jest.Mock).mockImplementation((p: string) => {
@@ -60,6 +67,7 @@ describe('Artifact Discovery', () => {
             (fs.readdirSync as jest.Mock).mockReturnValue([{ name: 'unsafe', isDirectory: () => true }]);
             (fs.lstatSync as jest.Mock).mockImplementation((p: string) => {
                 if (p.endsWith('SKILL.md')) return { isFile: () => false, isSymbolicLink: () => kind === 'symlink' };
+                if (!p.endsWith('.json')) return directoryStat;
                 throw Object.assign(new Error('missing'), { code: 'ENOENT' });
             });
 

--- a/cli/tests/core/orchestrators.test.ts
+++ b/cli/tests/core/orchestrators.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { diagnosticsToStderr } from '../../src/core/command-result';
 import { readDeclaredOrchestrators, collectDeclaredOrchestrators } from '../../src/core/orchestrators';
 import { writeRegistriesConfig, registryContentRoot } from '../../src/core/registries';
 
@@ -13,6 +14,7 @@ function registryWith(manifest: unknown): string {
 describe('readDeclaredOrchestrators', () => {
     const created: string[] = [];
     afterEach(() => {
+        jest.restoreAllMocks();
         for (const r of created.splice(0)) fs.rmSync(r, { recursive: true, force: true });
     });
 
@@ -189,6 +191,67 @@ describe('readDeclaredOrchestrators', () => {
         expect(diagnostics).toHaveLength(1);
         expect(diagnostics[0].split('\n')).toHaveLength(1);
         expect(diagnostics[0]).toContain(JSON.stringify('evil\nfake-warning: injected line'));
+    });
+
+    describe('single-line diagnostic boundary', () => {
+        const hostile = 'before\u2028\u2029\u0085\r\n\t'
+            + String.fromCharCode(...Array.from({ length: 32 }, (_, i) => i))
+            + String.fromCharCode(...Array.from({ length: 33 }, (_, i) => 127 + i)) + 'after';
+
+        it('sanitizes unknown metadata keys without accepting the declaration', () => {
+            const root = registryWith({
+                orchestrator: { name: 'x', appliesWhen: 'y', terminatesTo: 'none', [hostile]: true },
+            });
+            created.push(root);
+
+            const result = readDeclaredOrchestrators(root);
+
+            expect(result.orchestrators).toEqual([]);
+            expect(result.diagnostics).toHaveLength(1);
+            expect(result.diagnostics[0]).toContain('unknown field');
+            expect(result.diagnostics[0]).toContain('before');
+            expect(result.diagnostics[0]).toContain('after');
+            const stderrBoundary = jest.fn(diagnosticsToStderr);
+            stderrBoundary(result.diagnostics);
+            expect(stderrBoundary.mock.calls[0][0].join('')).not.toMatch(/[\u2028\u0085]/);
+            expect(stderrBoundary.mock.results[0].value).not.toMatch(/[\u2028\u0085]/);
+            // eslint-disable-next-line no-control-regex -- reject all terminal controls and line separators
+            expect(result.diagnostics[0]).not.toMatch(/[\x00-\x1f\x7f-\x9f\u2028\u2029]/);
+        });
+
+        it.each(['inspection', 'read', 'parse', 'shape', 'fields'])('sanitizes %s diagnostics, including paths and error text', (branch) => {
+            // Mock hostile paths instead of creating filenames that are invalid on Windows.
+            const root = path.join(os.tmpdir(), hostile);
+            const error = new Error(hostile);
+            jest.spyOn(fs, 'lstatSync').mockImplementation(() => {
+                if (branch === 'inspection') throw error;
+                return { isFile: () => true, isSymbolicLink: () => false } as fs.Stats;
+            });
+            jest.spyOn(fs, 'readFileSync').mockImplementation(() => {
+                if (branch === 'read') throw error;
+                if (branch === 'parse') return `{ ${hostile}`;
+                return JSON.stringify({ orchestrator: branch === 'shape' ? [] : {} });
+            });
+            if (branch === 'parse') jest.spyOn(JSON, 'parse').mockImplementationOnce(() => { throw new SyntaxError(hostile); });
+
+            const result = readDeclaredOrchestrators(root);
+
+            expect(result.orchestrators).toEqual([]);
+            expect(result.diagnostics).toHaveLength(1);
+            expect(result.diagnostics[0]).toContain('awm-registry.json');
+            expect(result.diagnostics[0]).toContain('before');
+            expect(result.diagnostics[0]).toContain('after');
+            // eslint-disable-next-line no-control-regex -- reject all terminal controls and line separators
+            expect(result.diagnostics[0]).not.toMatch(/[\x00-\x1f\x7f-\x9f\u2028\u2029]/);
+        });
+
+        it('preserves valid raw fields and structural parsing without skill discovery', () => {
+            const declaration = { name: hostile, appliesWhen: hostile, terminatesTo: hostile };
+            const root = registryWith({ orchestrator: declaration });
+            created.push(root);
+
+            expect(readDeclaredOrchestrators(root)).toEqual({ orchestrators: [declaration], diagnostics: [] });
+        });
     });
 });
 

--- a/cli/tests/core/orchestrators.test.ts
+++ b/cli/tests/core/orchestrators.test.ts
@@ -216,6 +216,12 @@ describe('collectDeclaredOrchestrators', () => {
         fs.writeFileSync(path.join(root, 'awm-registry.json'), JSON.stringify(manifest));
     }
 
+    function writeSkill(registryName: string, skillName: string): void {
+        const skillDir = path.join(registryContentRoot(registryName), 'skills', skillName);
+        fs.mkdirSync(skillDir, { recursive: true });
+        fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `---\nname: ${skillName}\n---\n\n# ${skillName}\n`);
+    }
+
     it('dedupea por nombre entre dos registries, conservando el primero por orden de registries.json', () => {  // verifies Finding 2
         writeRegistriesConfig([
             { name: 'first', remote: 'unused' },
@@ -227,6 +233,7 @@ describe('collectDeclaredOrchestrators', () => {
         writeManifest('second', {
             orchestrator: { name: 'shared', appliesWhen: 'segundo', terminatesTo: 'b' },
         });
+        writeSkill('first', 'shared');
 
         const { declared, diagnostics } = collectDeclaredOrchestrators();
 
@@ -249,6 +256,7 @@ describe('collectDeclaredOrchestrators', () => {
         writeManifest('second', {
             orchestrator: { name: nombreHostil, appliesWhen: 'segundo', terminatesTo: 'b' },
         });
+        writeSkill('first', nombreHostil);
 
         const { diagnostics } = collectDeclaredOrchestrators();
 
@@ -267,14 +275,16 @@ describe('collectDeclaredOrchestrators', () => {
             orchestrator: { name: 'foo_bar', appliesWhen: 'x', terminatesTo: 'a' },
         });
         writeManifest('second', {
-            orchestrator: { name: 'foo*bar', appliesWhen: 'y', terminatesTo: 'b' },
+            orchestrator: { name: 'foobar', appliesWhen: 'y', terminatesTo: 'b' },
         });
+        writeSkill('first', 'foo_bar');
+        writeSkill('second', 'foobar');
 
         const { declared, diagnostics } = collectDeclaredOrchestrators();
 
         // Ambas declaraciones son genuinamente distintas (nombre crudo distinto) — ninguna se descarta.
         expect(declared).toHaveLength(2);
-        expect(declared.map((d) => d.name).sort()).toEqual(['foo*bar', 'foo_bar']);
+        expect(declared.map((d) => d.name).sort()).toEqual(['foo_bar', 'foobar']);
         // Pero se advierte de la colision post-saneo (ambas renderizan como "foobar").
         expect(diagnostics).toHaveLength(1);
         expect(diagnostics[0]).toMatch(/foobar/);
@@ -292,11 +302,77 @@ describe('collectDeclaredOrchestrators', () => {
         writeManifest('second', {
             orchestrator: { name: 'dos', appliesWhen: 'y', terminatesTo: 'b' },
         });
+        writeSkill('first', 'uno');
+        writeSkill('second', 'dos');
 
         const { declared, diagnostics } = collectDeclaredOrchestrators();
 
         expect(declared).toHaveLength(2);
         expect(declared.map((d) => d.name).sort()).toEqual(['dos', 'uno']);
+        expect(diagnostics).toEqual([]);
+    });
+
+    it('omite una declaracion cuyo skill no existe y la diagnostica', () => {
+        writeRegistriesConfig([{ name: 'phantom', remote: 'unused' }]);
+        writeManifest('phantom', {
+            orchestrator: { name: 'phantom-process', appliesWhen: 'x', terminatesTo: 'none' },
+        });
+        writeSkill('phantom', 'real-skill');
+
+        const { declared, diagnostics } = collectDeclaredOrchestrators();
+
+        expect(declared).toEqual([]);
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]).toMatch(/phantom-process/);
+        expect(diagnostics[0]).toMatch(/declaration dropped|skill/i);
+    });
+
+    it('resuelve una declaracion contra un skill de otro registry configurado', () => {
+        writeRegistriesConfig([
+            { name: 'declarations', remote: 'unused' },
+            { name: 'skills', remote: 'unused' },
+        ]);
+        writeManifest('declarations', {
+            orchestrator: { name: 'cross-registry', appliesWhen: 'x', terminatesTo: 'none' },
+        });
+        writeSkill('skills', 'cross-registry');
+
+        const { declared, diagnostics } = collectDeclaredOrchestrators();
+
+        expect(declared).toEqual([{ name: 'cross-registry', appliesWhen: 'x', terminatesTo: 'none' }]);
+        expect(diagnostics).toEqual([]);
+    });
+
+    it('diagnostica un root cuyo discovery falla y conserva una declaracion sana', () => {
+        writeRegistriesConfig([
+            { name: 'broken', remote: 'unused' },
+            { name: 'healthy', remote: 'unused' },
+        ]);
+        writeManifest('broken', {
+            orchestrator: { name: 'broken-process', appliesWhen: 'x', terminatesTo: 'none' },
+        });
+        fs.writeFileSync(path.join(registryContentRoot('broken'), 'skills'), 'not a directory');
+        writeManifest('healthy', {
+            orchestrator: { name: 'healthy-process', appliesWhen: 'x', terminatesTo: 'none' },
+        });
+        writeSkill('healthy', 'healthy-process');
+
+        const { declared, diagnostics } = collectDeclaredOrchestrators();
+
+        expect(declared).toEqual([{ name: 'healthy-process', appliesWhen: 'x', terminatesTo: 'none' }]);
+        expect(diagnostics.join('\n')).toMatch(/broken.*discovery unavailable/i);
+    });
+
+    it('conserva terminatesTo aunque no corresponda a un skill descubierto', () => {
+        writeRegistriesConfig([{ name: 'registry', remote: 'unused' }]);
+        writeManifest('registry', {
+            orchestrator: { name: 'entry-process', appliesWhen: 'x', terminatesTo: 'missing-successor' },
+        });
+        writeSkill('registry', 'entry-process');
+
+        const { declared, diagnostics } = collectDeclaredOrchestrators();
+
+        expect(declared).toEqual([{ name: 'entry-process', appliesWhen: 'x', terminatesTo: 'missing-successor' }]);
         expect(diagnostics).toEqual([]);
     });
 });

--- a/cli/tests/core/orchestrators.test.ts
+++ b/cli/tests/core/orchestrators.test.ts
@@ -244,26 +244,71 @@ describe('collectDeclaredOrchestrators', () => {
         expect(diagnostics[0]).toMatch(/duplicate|shadow/i);
     });
 
-    it('sanea el nombre antes de interpolarlo en el diagnostico de duplicado', () => {  // verifies confirmed Finding 3
-        writeRegistriesConfig([
-            { name: 'first', remote: 'unused' },
-            { name: 'second', remote: 'unused' },
-        ]);
-        const nombreHostil = 'shared\x1b[31m';
+    it('keeps missing-skill diagnostics single-line with hostile metadata and portable paths', () => {
+        writeRegistriesConfig([{ name: 'first', remote: 'unused' }]);
+        const nombreHostil = 'shared\r\nforged\t\x1b[31m\x00\x7f\x85\x9b\u2028\u2029';
         writeManifest('first', {
             orchestrator: { name: nombreHostil, appliesWhen: 'primero', terminatesTo: 'a' },
         });
-        writeManifest('second', {
-            orchestrator: { name: nombreHostil, appliesWhen: 'segundo', terminatesTo: 'b' },
-        });
-        writeSkill('first', nombreHostil);
+        writeSkill('first', 'real-skill');
 
         const { diagnostics } = collectDeclaredOrchestrators();
 
         expect(diagnostics).toHaveLength(1);
-        // eslint-disable-next-line no-control-regex -- verificamos la ausencia deliberada de C0
-        expect(diagnostics[0]).not.toMatch(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/);
-        expect(diagnostics[0]).toContain('shared[31m');
+        // eslint-disable-next-line no-control-regex -- diagnostic must contain no terminal controls or line separators
+        expect(diagnostics[0]).not.toMatch(/[\x00-\x1f\x7f-\x9f\u2028\u2029]/);
+        expect(diagnostics[0]).toContain('shared');
+        expect(diagnostics[0]).toContain('forged');
+        expect(diagnostics[0]).toContain('declaration dropped');
+    });
+
+    it('keeps discovery diagnostics single-line for hostile override metadata', () => {
+        writeRegistriesConfig([{ name: 'hostile', remote: 'unused' }]);
+        writeManifest('hostile', { overrides: ['../forged\r\nwarning:\t\x1b[31m\x85\u2028'] });
+        writeSkill('hostile', 'real-skill');
+
+        const { diagnostics } = collectDeclaredOrchestrators();
+
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]).toContain('discovery unavailable');
+        expect(diagnostics[0]).toContain('forged');
+        // eslint-disable-next-line no-control-regex -- diagnostic must contain no terminal controls or line separators
+        expect(diagnostics[0]).not.toMatch(/[\x00-\x1f\x7f-\x9f\u2028\u2029]/);
+    });
+
+    it('excludes a later colliding root without losing earlier or subsequent healthy roots', () => {
+        writeRegistriesConfig(['first', 'collision', 'last'].map((name) => ({ name, remote: 'unused' })));
+        for (const name of ['first', 'collision', 'last']) {
+            writeManifest(name, { orchestrator: { name: `${name}-process`, appliesWhen: 'x', terminatesTo: 'none' } });
+            writeSkill(name, `${name}-process`);
+        }
+        writeSkill('first', 'shared');
+        writeSkill('collision', 'shared');
+        // This name belongs only to the excluded root and must not poison later admission.
+        writeSkill('collision', 'last-process');
+
+        const { declared, diagnostics } = collectDeclaredOrchestrators();
+
+        expect(declared.map((d) => d.name)).toEqual(['first-process', 'last-process']);
+        expect(diagnostics).toHaveLength(2);
+        expect(diagnostics[0]).toMatch(/collision.*discovery unavailable.*Artifact name collision/);
+        expect(diagnostics[1]).toMatch(/collision-process.*not discoverable/);
+    });
+
+    it('admits a later root with a declared override', () => {
+        writeRegistriesConfig(['first', 'override'].map((name) => ({ name, remote: 'unused' })));
+        writeSkill('first', 'shared');
+        writeSkill('override', 'shared');
+        writeSkill('override', 'override-process');
+        writeManifest('override', {
+            overrides: ['shared'],
+            orchestrator: { name: 'override-process', appliesWhen: 'x', terminatesTo: 'none' },
+        });
+
+        const { declared, diagnostics } = collectDeclaredOrchestrators();
+
+        expect(declared.map((d) => d.name)).toEqual(['override-process']);
+        expect(diagnostics).toEqual([]);
     });
 
     it('emite un diagnostico de colision post-saneo entre nombres crudos distintos, sin descartar ninguno', () => {  // verifies confirmed Finding 4

--- a/cli/tests/core/text.test.ts
+++ b/cli/tests/core/text.test.ts
@@ -1,4 +1,15 @@
-import { stripControlChars, sanitizeDeclaredField } from '../../src/core/text';
+import { stripControlChars, sanitizeDeclaredField, sanitizeDiagnosticText } from '../../src/core/text';
+
+describe('sanitizeDiagnosticText', () => {
+    it.each([
+        ['a\r\nb\rc\nd\te', 'a b c d e'],
+        ['a\x00\x07\x1b[31m\x7f\x85\x9bz', 'a[31mz'],
+        ['a\u2028b\u2029c', 'a b c'],
+        ['plain *markdown* — café', 'plain *markdown* — café'],
+    ])('sanitizes a single diagnostic field: %j', (input, expected) => {
+        expect(sanitizeDiagnosticText(input)).toBe(expected);
+    });
+});
 
 describe('stripControlChars', () => {
     it('elimina ESC y demas bytes de control C0', () => {                        // verifies R5.4

--- a/cli/tests/integration/context-orchestrators-e2e.test.ts
+++ b/cli/tests/integration/context-orchestrators-e2e.test.ts
@@ -181,3 +181,32 @@ describe('awm context orchestrators -- declaracion phantom (binario real)', () =
         expect(r.stderr).toMatch(/declaration dropped|skill/i);
     });
 });
+
+describe('awm context orchestrators -- dropped sanitized collision (real binary)', () => {
+    let home: string;
+    beforeAll(() => {
+        home = seedPhantomRegistry();
+        const awmHome = path.join(home, '.awm');
+        const phantomRoot = path.join(awmHome, 'registries', 'test-registry');
+        const retainedRoot = path.join(awmHome, 'registries', 'retained');
+        fs.writeFileSync(path.join(awmHome, 'registries.json'), JSON.stringify([
+            { name: 'test-registry', remote: 'unused' }, { name: 'retained', remote: 'unused' },
+        ]));
+        fs.writeFileSync(path.join(phantomRoot, 'awm-registry.json'), JSON.stringify({
+            orchestrator: { name: 'foo_bar', appliesWhen: 'x', terminatesTo: 'none' },
+        }));
+        fs.mkdirSync(path.join(retainedRoot, 'skills', 'foobar'), { recursive: true });
+        fs.writeFileSync(path.join(retainedRoot, 'skills', 'foobar', 'SKILL.md'), '# foobar\n');
+        fs.writeFileSync(path.join(retainedRoot, 'awm-registry.json'), JSON.stringify({
+            orchestrator: { name: 'foobar', appliesWhen: 'x', terminatesTo: 'none' },
+        }));
+    });
+    afterAll(() => fs.rmSync(home, { recursive: true, force: true }));
+
+    it('verifies the retained raw name and rejects the dropped raw name', () => {
+        expect(run(home, 'context', 'orchestrators', '--verify', 'foobar').status).toBe(0);
+        const dropped = run(home, 'context', 'orchestrators', '--verify', 'foo_bar');
+        expect(dropped.status).toBe(2);
+        expect(dropped.stderr).toContain('declaration dropped');
+    });
+});

--- a/cli/tests/integration/context-orchestrators-e2e.test.ts
+++ b/cli/tests/integration/context-orchestrators-e2e.test.ts
@@ -11,14 +11,14 @@ function seedRegistry(): string {
     const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'awm-ctx-e2e-')));
     const awmHome = path.join(home, '.awm');
     const root = path.join(awmHome, 'registries', 'test-registry');
-    fs.mkdirSync(path.join(root, 'skills', 'using-awm'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'skills', 'ejemplo-proceso'), { recursive: true });
     fs.writeFileSync(path.join(awmHome, 'registries.json'),
         JSON.stringify([{ name: 'test-registry', remote: 'https://example.invalid/test.git' }]));
     fs.writeFileSync(path.join(root, 'awm-registry.json'), JSON.stringify({
         minCliVersion: '8.5.0',
         orchestrator: { name: 'ejemplo-proceso', appliesWhen: 'cuando hay una tarea sin plan', terminatesTo: 'development-process' },
     }));
-    fs.writeFileSync(path.join(root, 'skills', 'using-awm', 'SKILL.md'), '---\nname: using-awm\nversion: "1.0.0"\n---\n\n# using-awm\n');
+    fs.writeFileSync(path.join(root, 'skills', 'ejemplo-proceso', 'SKILL.md'), '---\nname: ejemplo-proceso\nversion: "1.0.0"\n---\n\n# ejemplo-proceso\n');
     return home;
 }
 
@@ -35,7 +35,7 @@ function seedRealisticRegistry(): string {
     const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'awm-ctx-e2e-real-')));
     const awmHome = path.join(home, '.awm');
     const root = path.join(awmHome, 'registries', 'test-registry');
-    fs.mkdirSync(path.join(root, 'skills', 'using-awm'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'skills', 'task_capture_process'), { recursive: true });
     fs.writeFileSync(path.join(awmHome, 'registries.json'),
         JSON.stringify([{ name: 'test-registry', remote: 'https://example.invalid/test.git' }]));
     fs.writeFileSync(path.join(root, 'awm-registry.json'), JSON.stringify({
@@ -46,7 +46,7 @@ function seedRealisticRegistry(): string {
             terminatesTo: 'development-process',
         },
     }));
-    fs.writeFileSync(path.join(root, 'skills', 'using-awm', 'SKILL.md'), '---\nname: using-awm\nversion: "1.0.0"\n---\n\n# using-awm\n');
+    fs.writeFileSync(path.join(root, 'skills', 'task_capture_process', 'SKILL.md'), '---\nname: task_capture_process\nversion: "1.0.0"\n---\n\n# task_capture_process\n');
     return home;
 }
 
@@ -64,7 +64,7 @@ function seedMixedRegistries(): string {
     const awmHome = path.join(home, '.awm');
     const sanoRoot = path.join(awmHome, 'registries', 'sano-registry');
     const rotoRoot = path.join(awmHome, 'registries', 'roto-registry');
-    fs.mkdirSync(path.join(sanoRoot, 'skills', 'using-awm'), { recursive: true });
+    fs.mkdirSync(path.join(sanoRoot, 'skills', 'proceso-sano'), { recursive: true });
     fs.mkdirSync(path.join(rotoRoot, 'skills', 'using-awm'), { recursive: true });
     fs.writeFileSync(path.join(awmHome, 'registries.json'), JSON.stringify([
         { name: 'sano-registry', remote: 'https://example.invalid/sano.git' },
@@ -80,8 +80,22 @@ function seedMixedRegistries(): string {
         minCliVersion: '8.5.0',
         orchestrator: { name: 'proceso-roto', appliesWhen: 'cuando algo pasa' },
     }));
-    fs.writeFileSync(path.join(sanoRoot, 'skills', 'using-awm', 'SKILL.md'), '---\nname: using-awm\nversion: "1.0.0"\n---\n\n# using-awm\n');
-    fs.writeFileSync(path.join(rotoRoot, 'skills', 'using-awm', 'SKILL.md'), '---\nname: using-awm\nversion: "1.0.0"\n---\n\n# using-awm\n');
+    fs.writeFileSync(path.join(sanoRoot, 'skills', 'proceso-sano', 'SKILL.md'), '---\nname: proceso-sano\nversion: "1.0.0"\n---\n\n# proceso-sano\n');
+    return home;
+}
+
+function seedPhantomRegistry(): string {
+    const home = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'awm-ctx-e2e-phantom-')));
+    const awmHome = path.join(home, '.awm');
+    const root = path.join(awmHome, 'registries', 'test-registry');
+    fs.mkdirSync(path.join(root, 'skills', 'real-skill'), { recursive: true });
+    fs.writeFileSync(path.join(awmHome, 'registries.json'),
+        JSON.stringify([{ name: 'test-registry', remote: 'https://example.invalid/test.git' }]));
+    fs.writeFileSync(path.join(root, 'awm-registry.json'), JSON.stringify({
+        minCliVersion: '8.5.0',
+        orchestrator: { name: 'phantom-process', appliesWhen: 'cuando hay una tarea sin plan', terminatesTo: 'development-process' },
+    }));
+    fs.writeFileSync(path.join(root, 'skills', 'real-skill', 'SKILL.md'), '---\nname: real-skill\nversion: "1.0.0"\n---\n\n# real-skill\n');
     return home;
 }
 
@@ -152,5 +166,18 @@ describe('awm context orchestrators -- diagnosticos + sanos mezclados (binario r
         expect(r.stderr).toContain('warning:');
         expect(r.stderr).toContain('roto-registry');
         expect(r.stderr).toContain('terminatesTo');
+    });
+});
+
+describe('awm context orchestrators -- declaracion phantom (binario real)', () => {
+    let home: string;
+    beforeAll(() => { home = seedPhantomRegistry(); });
+    afterAll(() => fs.rmSync(home, { recursive: true, force: true }));
+
+    it('--verify devuelve 2 y diagnostica una declaracion sin skill resoluble', () => {
+        const r = run(home, 'context', 'orchestrators', '--verify', 'phantom-process');
+        expect(r.status).toBe(2);
+        expect(r.stderr).toMatch(/phantom-process/);
+        expect(r.stderr).toMatch(/declaration dropped|skill/i);
     });
 });

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -241,7 +241,7 @@ awm context orchestrators --json       # composed list as JSON
 awm context orchestrators --verify my-process   # exit 0 if composed, 2 if not
 ```
 
-Emits only the declared fields (`name`, `appliesWhen`, `terminatesTo`), not the full payload — that includes raw registry content. Invalid declarations are reported as `warning:` lines on stderr without blocking the healthy ones from being listed.
+Emits only the declared fields (`name`, `appliesWhen`, `terminatesTo`), not the full payload — that includes raw registry content. Invalid declarations, including an orchestrator whose `name` does not resolve to a discoverable skill in any configured safe registry, are reported as `warning:` lines on stderr and omitted without blocking healthy ones from being listed.
 
 `--verify` is what closes `process-lifecycle`'s verification cycle: it confirms a freshly-generated process actually appears composed in a real installation, not just that the registry installed.
 

--- a/docs/harness-retros.md
+++ b/docs/harness-retros.md
@@ -1,5 +1,10 @@
 # Harness Retros
 
+## 2026-09-04 — Issue #110: resolución de skills de orquestador
+
+- **Hallazgos:** la resolución semántica inicial expuso casos de identidad saneada, diagnósticos de una línea y seguridad de lectura de `SKILL.md` (archivo, descriptor y directorios padre). Cada caso quedó cubierto por regresiones unitarias y E2E, incluida una sustitución real de directorio padre.
+- **Decisión desatendida:** no se añadió una regla de harness nueva. El contrato existente `CTX-CONSTITUTION-052` ya define la lectura segura de archivos de registry; el remedio fue aplicarlo correctamente y probarlo. Los wins repetidos de aislamiento y resolución cross-registry son evidencia del mismo patrón, no reglas independientes.
+
 ## 2026-08-28 — Publication B QA boundaries
 
 - **Clase:** seguridad, lógica y proceso; QA identificó y cerró el bypass de lectura nativa por variable de entorno y la resolución desde `packageRoot`.

--- a/docs/plans/2026-09-04-orchestrator-skill-resolution-design.md
+++ b/docs/plans/2026-09-04-orchestrator-skill-resolution-design.md
@@ -1,0 +1,35 @@
+# Resolución de `orchestrator.name` contra skills configurados — Diseño
+
+Issue: GitHub #110
+Estado: aprobado
+
+## Decisión
+
+Una declaración de orquestador puede resolver a un skill de cualquier registry
+configurado y seguro. La existencia se obtiene de la unión de skills descubiertos
+en cada `contentRoot()` por separado. No se exige que el skill esté materializado
+para un proveedor: el contexto compuesto es global y agnóstico del proveedor.
+
+## Requisitos
+
+- **R110-1** — SI `orchestrator.name` no coincide con ningún skill descubierto
+  en los registries configurados y seguros, ENTONCES AWM SHALL omitir la
+  declaración y emitir un diagnóstico accionable.
+- **R110-2** — SI el nombre coincide con un skill de cualquier registry
+  configurado y seguro, ENTONCES AWM SHALL conservar la declaración.
+- **R110-3** — SI falla el discovery de un root, ENTONCES AWM SHALL
+  diagnosticarlo y continuar con los restantes.
+- **R110-4** — `readDeclaredOrchestrators()` SHALL seguir validando sólo la
+  forma; `collectDeclaredOrchestrators()` SHALL resolver semánticamente el nombre.
+- **R110-5** — SI `terminatesTo` no está disponible, ENTONCES AWM SHALL
+  conservar el orquestador y degradar al ruteo normal conforme a R3.3.
+- **R110-6** — SI `--verify <name>` recibe una declaración omitida por R110-1,
+  ENTONCES SHALL devolver código 2.
+- **R110-7** — SI una declaración inválida convive con sanas, ENTONCES AWM
+  SHALL componer las sanas sin abortar.
+
+## Límites
+
+No cambia la instalación de bundles, `artifact-state`, perfiles ni la semántica
+de `terminatesTo`. El discovery se ejecuta por root para conservar la degradación
+fail-safe existente en `core/process/discover.ts`.

--- a/docs/plans/2026-09-04-orchestrator-skill-resolution.md
+++ b/docs/plans/2026-09-04-orchestrator-skill-resolution.md
@@ -77,3 +77,23 @@ _Requirements: R110-1, R110-2, R110-3, R110-4, R110-5, R110-6, R110-7_
 | R110-5 | T1-T3 | Unit successor inexistente preservado |
 | R110-6 | T1, T3 | E2E `--verify` 2 |
 | R110-7 | T1-T3 | Unit y E2E mixtos |
+
+## Amendment A1 — Fixtures de consumidores de contexto
+
+**Motivo:** La primera corrida de la suite completa reveló cuatro tests existentes
+que declaran `mi-proceso` o `proceso-valido` y afirman que llegan al contexto,
+pero crean solamente `skills/using-awm`. Bajo R110-1 esas fixtures representan
+declaraciones no resolubles y deben materializar el skill que afirman usar.
+
+**Alcance:**
+
+- `cli/tests/commands/hooks/install.test.ts`: crear `skills/mi-proceso/SKILL.md`
+  y `skills/proceso-valido/SKILL.md` en los dos fixtures de declaración válida.
+- `cli/tests/commands/hooks/resync.test.ts`: crear `skills/mi-proceso/SKILL.md`
+  en el fixture de resync materializado.
+- `cli/tests/core/context/orchestrator.test.ts`: crear
+  `skills/mi-proceso/SKILL.md` en la fixture que verifica estado inyectado.
+
+**Aceptación:** las cuatro aserciones existentes vuelven a pasar sin relajar
+R110-1; el test de nombre fantasma continúa demostrando que una declaración sin
+skill se descarta.

--- a/docs/plans/2026-09-04-orchestrator-skill-resolution.md
+++ b/docs/plans/2026-09-04-orchestrator-skill-resolution.md
@@ -1,4 +1,7 @@
 # Orchestrator Skill Resolution Implementation Plan
+<!-- awm-qa-complete: 2026-09-04 -->
+<!-- awm-docs-complete: 2026-09-04 -->
+<!-- awm-retro-complete: 2026-09-04 -->
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development`
 > (recommended) or `executing-plans` to implement this plan task-by-task. Steps
@@ -97,3 +100,56 @@ declaraciones no resolubles y deben materializar el skill que afirman usar.
 **Aceptación:** las cuatro aserciones existentes vuelven a pasar sin relajar
 R110-1; el test de nombre fantasma continúa demostrando que una declaración sin
 skill se descarta.
+
+## Amendment A2 — Correcciones encontradas por QA global
+
+**Motivo:** QA encontró cuatro casos que la implementación inicial no cubría:
+una identidad descartada podía coincidir con otra compuesta tras saneamiento;
+los diagnósticos nuevos aceptaban CR/LF; una fixture creaba un directorio con
+ESC inválido en Windows; y el discovery por root ocultaba colisiones globales
+de skills sin override. También se confirmó que `discoverSkills` aceptaba
+artefactos `SKILL.md` no regulares, lo cual puede bloquear la colección síncrona.
+
+**Alcance:**
+
+- Conservar las identidades crudas descartadas para que `--verify` rechace una
+  entrada descartada aun si su forma saneada coincide con una compuesta.
+- Saneamiento de una sola línea para todo texto no confiable que entre en los
+  diagnósticos de esta ruta.
+- Reemplazar la fixture de nombre hostil por metadata hostil sin nombre de
+  directorio no portable.
+- Descubrir incrementalmente los roots previamente aceptados más el root actual;
+  si aparece una colisión sin override, diagnosticar y excluir ese root sin
+  invalidar los anteriores.
+- Exigir que `SKILL.md` sea un archivo regular no enlazado antes de leerlo.
+
+**Aceptación:** regresiones RED/GREEN para los cuatro casos; suites focalizadas,
+sensores y verificación completa verdes; no se relajan R110-1 a R110-7.
+
+## Amendment A3 — Cierre de saneamiento y lectura segura
+
+**Motivo:** la re-lectura de QA comprobó que los diagnósticos estructurales del
+parser seguían reenviando U+2028/U+0085 y que el chequeo `lstat` de `SKILL.md`
+tenía una ventana TOCTOU antes de su lectura.
+
+**Alcance:**
+
+- Pasar todos los diagnósticos de `readDeclaredOrchestrators()` por el saneador
+  de una sola línea antes de que lleguen a `diagnosticsToStderr`.
+- Inspeccionar `SKILL.md`, abrirlo con `O_NOFOLLOW` cuando exista, comprobar en
+  el descriptor `dev`/`ino`, tipo regular y tamaño contra la inspección, y leer
+  desde ese descriptor; fallar cerrado si cambia o no es regular.
+
+**Aceptación:** regresiones RED/GREEN para clave de metadata Unicode y sustitución
+de `SKILL.md` tras `lstat`; las rutas inseguras no se leen ni bloquean el
+collector.
+
+## Amendment A4 — Sustitución concurrente de directorio padre
+
+**Motivo:** QA reprodujo que sustituir un directorio padre por un symlink antes
+de la inspección de la hoja podía autorizar un `SKILL.md` externo.
+
+**Alcance y aceptación:** inspeccionar los componentes observables del path de
+skill, rechazar symlinks y comprobar que la hoja abierta permanece bajo la
+cadena inspeccionada; una regresión de filesystem real debe demostrar que el
+reemplazo de padre no lee contenido externo.

--- a/docs/plans/2026-09-04-orchestrator-skill-resolution.md
+++ b/docs/plans/2026-09-04-orchestrator-skill-resolution.md
@@ -1,0 +1,79 @@
+# Orchestrator Skill Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development`
+> (recommended) or `executing-plans` to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Evitar que AWM componga declaraciones de orquestador sin un skill resoluble en registries configurados y seguros.
+
+**Architecture:** El parser permanece estructural. El collector obtiene los nombres de `discoverSkills([root])` para cada `contentRoots()` y filtra nombres no resolubles antes del dedupe existente.
+
+**Tech Stack:** TypeScript, Jest, Node.js, dependency-cruiser.
+
+**Modo de ejecución:** desatendido
+
+> Mandato de ejecución desatendida: ejecución completa sin pausas de check-in
+> entre tareas, ni de confirmación entre fases (development-process rutea
+> automáticamente y subagent-driven-development no pregunta si continuar con
+> el cierre). harness-retro triagea con criterio propio del agente (solo valor
+> real, recurrente o sistémico — descarta el resto sin preguntar).
+> post-implementation-qa corrige TODOS los hallazgos que surjan, no solo algunos.
+> finishing-a-development-branch crea el PR directamente (opción "push + PR"),
+> sin presentar el menú de 4 opciones.
+
+---
+
+### Task 1: Especificar la resolución semántica en tests
+
+_Requirements: R110-1, R110-2, R110-3, R110-5, R110-6, R110-7_
+
+**Files:**
+- Modify: `cli/tests/core/orchestrators.test.ts`
+- Modify: `cli/tests/integration/context-orchestrators-e2e.test.ts`
+
+- [ ] Agregar `writeSkill(registryName, skillName)` a los tests core; crea `skills/<name>/SKILL.md` con frontmatter mínimo.
+- [ ] Actualizar fixtures existentes que esperan composición para crear skills de `shared`, `uno`, `dos`, `ejemplo-proceso`, `task_capture_process` y `proceso-sano`.
+- [ ] Cambiar la prueba de colisión post-saneamiento para usar `foo_bar` y `foobar`, ambos nombres válidos en Windows.
+- [ ] Escribir primero los tests: nombre fantasma se omite y diagnostica; nombre declarado en un registry resuelve contra un skill de otro; root con discovery roto diagnostica pero conserva una declaración sana; `terminatesTo` inexistente se conserva.
+- [ ] Agregar fixture E2E con `phantom-process`, sólo `skills/real-skill/SKILL.md`, y comprobar que `awm context orchestrators --verify phantom-process` devuelve código 2 y diagnóstico.
+- [ ] Ejecutar los dos suites focalizados y comprobar RED: phantom sigue compuesto, `--verify` devuelve 0 y no existe diagnóstico de discovery roto.
+
+### Task 2: Implementar la resolución global fail-safe
+
+_Requirements: R110-1, R110-2, R110-3, R110-4, R110-5, R110-7_
+
+**Files:**
+- Modify: `cli/src/core/orchestrators.ts`
+- Test: `cli/tests/core/orchestrators.test.ts`
+
+- [ ] Importar `contentRoots` desde `./registries` y `discoverSkills` desde `./discovery`; mantener `readDeclaredOrchestrators()` sin discovery.
+- [ ] Añadir un helper privado que itere `contentRoots()`, ejecute `discoverSkills([root])`, acumule `skill.name` en un `Set<string>` y convierta cada excepción en un diagnóstico sanitizado con `stripControlChars`.
+- [ ] Al inicio de `collectDeclaredOrchestrators()`, obtener el set disponible; antes de `seenNames`, omitir cada `orch.name` ausente y diagnosticar `declaration dropped` sin caracteres de control.
+- [ ] Mantener dedupe, colisión post-saneamiento y `terminatesTo` sin cambios.
+- [ ] Ejecutar RED/GREEN con `npm test -- --runInBand tests/core/orchestrators.test.ts`, después `npm run typecheck`.
+
+### Task 3: Verificar binario, gates y commit
+
+_Requirements: R110-1, R110-2, R110-3, R110-4, R110-5, R110-6, R110-7_
+
+**Files:**
+- Verify: `cli/src/core/orchestrators.ts`
+- Verify: `cli/tests/core/orchestrators.test.ts`
+- Verify: `cli/tests/integration/context-orchestrators-e2e.test.ts`
+
+- [ ] Ejecutar `npm run build`, luego los E2E focalizados y ambos suites focalizados.
+- [ ] Ejecutar `npm test -- --runInBand`, `npm run typecheck`, `npm run build`, `npm run lint` y `awm sensors run`; todos deben informar PASS/`overall: pass`.
+- [ ] Ejecutar dependency-cruiser focalizado sobre `orchestrators`, `discovery`, `registries`, `frontmatter` y `text`; no debe aparecer ciclo. Registrar, sin ampliar alcance, el ciclo preexistente de `npm run depcheck` si continúa limitado a `watch`.
+- [ ] Confirmar `git diff --check`; hacer commit de código, tests y estos dos documentos con `fix(orchestrators): require declared skill resolution`.
+
+## Matriz de trazabilidad
+
+| Requisito | Tareas | Evidencia |
+|---|---|---|
+| R110-1 | T1-T3 | Unit phantom y E2E `--verify` 2 |
+| R110-2 | T1-T3 | Unit cross-registry |
+| R110-3 | T1-T3 | Unit root roto + sano |
+| R110-4 | T2-T3 | Parser existente + typecheck |
+| R110-5 | T1-T3 | Unit successor inexistente preservado |
+| R110-6 | T1, T3 | E2E `--verify` 2 |
+| R110-7 | T1-T3 | Unit y E2E mixtos |


### PR DESCRIPTION
Closes #110\n\n## Summary\n- resolve declared orchestrator names against configured safe registries and omit unresolved declarations\n- preserve raw verification identity, per-root failure isolation, collision semantics, and safe SKILL.md discovery\n- add unit/E2E regressions, portability coverage, and registry read-hardening\n\n## Verification\n- npm test -- --runInBand (3487 passed, 16 skipped)\n- npm run lint\n- npm run typecheck\n- npm run build\n- awm sensors run (overall: pass)