### PR TITLE
docs: document orchestrator registry manifest

### DIFF
--- a/docs/guides/authoring-a-registry-with-an-orchestrator.md
+++ b/docs/guides/authoring-a-registry-with-an-orchestrator.md
@@ -24,13 +24,27 @@ mi-registry/
 
 ## 2. `awm-registry.json`
 
-Declara la versión mínima de CLI que tu contenido necesita:
+Declara la versión mínima de CLI que tu contenido necesita y el orquestador que querés aportar:
 
 ```json
 {
-  "minCliVersion": "8.1.5"
+  "minCliVersion": "8.1.5",
+  "orchestrator": {
+    "name": "mi-proceso",
+    "appliesWhen": "cuando una sesión debe seguir mi proceso propio",
+    "terminatesTo": "development-process"
+  }
 }
 ```
+
+El bloque `orchestrator` tiene contrato cerrado:
+
+- Debe tener exactamente tres campos: `name`, `appliesWhen` y `terminatesTo`. Cualquier campo extra se diagnostica y esa declaración se descarta.
+- Los tres valores deben ser strings no vacíos de hasta 500 caracteres cada uno.
+- `appliesWhen` no debe terminar con punto: el renderer agrega el punto cuando compone el contexto.
+- `name` debe coincidir con el nombre del directorio `skills/<name>/SKILL.md`. En este ejemplo, `name: "mi-proceso"` apunta a `skills/mi-proceso/SKILL.md`. El `name` del frontmatter de `SKILL.md` no controla discovery.
+
+Si el bloque `orchestrator` es inválido, AWM emite un diagnóstico y descarta solo esa declaración; no aborta la instalación del registry ni invalida sus otros contenidos.
 
 ## 3. `catalog.json`
 
@@ -107,9 +121,12 @@ Instalalo desde la ruta local, sin publicar nada. `--name` es el nombre del *reg
 ```bash
 awm registry add /ruta/a/mi-registry --name mi-proceso --install-all
 awm registry list
+awm context orchestrators --verify mi-proceso
 ```
 
 `awm registry list` confirma que instaló: imprime una línea por registry con nombre, remote, y el conteo de contenido descubierto (`N skills, M bundles, K workflows, L agents`).
+
+`awm context orchestrators --verify mi-proceso` confirma que el orquestador está compuesto en el contexto real de sesión. Sale `0` si está compuesto y `2` si no lo está; un `2` suele indicar que el `orchestrator.name` no coincide con un directorio discoverable bajo `skills/`, que la declaración fue inválida, o que el registry no quedó instalado.
 
 Si el layout está mal o hay colisión de nombres, el comando falla y revierte el clon. Para volver atrás:
 

--- a/docs/guides/authoring-a-registry-with-an-orchestrator.md
+++ b/docs/guides/authoring-a-registry-with-an-orchestrator.md
@@ -28,7 +28,7 @@ Declara la versión mínima de CLI que tu contenido necesita y el orquestador qu
 
 ```json
 {
-  "minCliVersion": "8.1.5",
+  "minCliVersion": "9.2.0",
   "orchestrator": {
     "name": "mi-proceso",
     "appliesWhen": "cuando una sesión debe seguir mi proceso propio",
@@ -41,7 +41,7 @@ El bloque `orchestrator` tiene contrato cerrado:
 
 - Debe tener exactamente tres campos: `name`, `appliesWhen` y `terminatesTo`. Cualquier campo extra se diagnostica y esa declaración se descarta.
 - Los tres valores deben ser strings no vacíos de hasta 500 caracteres cada uno.
-- `appliesWhen` no debe terminar con punto: el renderer agrega el punto cuando compone el contexto.
+- Como convención de autoría, escribí `appliesWhen` sin punto final para evitar puntuación duplicada: el renderer agrega el punto cuando compone el contexto. El parser no diagnostica un punto final.
 - `name` debe coincidir con el nombre del directorio `skills/<name>/SKILL.md`. En este ejemplo, `name: "mi-proceso"` apunta a `skills/mi-proceso/SKILL.md`. El `name` del frontmatter de `SKILL.md` no controla discovery.
 
 Si el bloque `orchestrator` es inválido, AWM emite un diagnóstico y descarta solo esa declaración; no aborta la instalación del registry ni invalida sus otros contenidos.

--- a/docs/guides/authoring-a-registry-with-an-orchestrator.md
+++ b/docs/guides/authoring-a-registry-with-an-orchestrator.md
@@ -40,7 +40,7 @@ Declara la versión mínima de CLI que tu contenido necesita y el orquestador qu
 El bloque `orchestrator` tiene contrato cerrado:
 
 - Debe tener exactamente tres campos: `name`, `appliesWhen` y `terminatesTo`. Cualquier campo extra se diagnostica y esa declaración se descarta.
-- Los tres valores deben ser strings no vacíos de hasta 500 caracteres cada uno.
+- Los tres valores deben ser strings no vacíos de hasta 500 unidades UTF-16 cada uno, medidas por la CLI con `String.length`; por ejemplo, un emoji fuera del BMP cuenta como dos.
 - Como convención de autoría, escribí `appliesWhen` sin punto final para evitar puntuación duplicada: el renderer agrega el punto cuando compone el contexto. El parser no diagnostica un punto final.
 - `name` debe coincidir con el nombre del directorio `skills/<name>/SKILL.md`. En este ejemplo, `name: "mi-proceso"` apunta a `skills/mi-proceso/SKILL.md`. El `name` del frontmatter de `SKILL.md` no controla discovery.
 

--- a/docs/harness-retros.md
+++ b/docs/harness-retros.md
@@ -1,5 +1,17 @@
 # Harness Retros
 
+## 2026-09-05 — Issue #111: contrato del orquestador en la guía de authoring
+
+- **Class:** process / structural documentation
+- **Occurrences (ledger count):** 5 findings válidos; el reporte de recurrencia agrupó un clúster convergente de 3 verificaciones de documentación contra el contrato real.
+- **Hallazgo raíz:** la guía se escribió inicialmente con una versión mínima de CLI incompatible con el comando documentado, presentó una convención editorial como validación del parser y no precisó que `String.length` cuenta unidades UTF-16. Todos fueron corregidos y revisados nuevamente.
+- **Rule:** se reutiliza `AGENTS.md` → `verify-cmd-source-before-documenting`; no se agrega una regla duplicada ni se amplía el alcance de esta issue documental.
+- **Sensor:** ninguno mecánico específico para drift documental; `awm sensors run` terminó en `overall: pass` (lint/typecheck/depcheck, 0 hallazgos nuevos). `awm sensors coverage --json` fue `inconclusive`/`partial` porque varios detectores no aplican o faltan en este proyecto.
+- **Wins:** las revisiones independientes y la ejecución contra el CLI detectaron y cerraron las divergencias antes del PR; no se duplica en `AGENTS.md`.
+- **Recomendaciones (sin aplicar):** evaluar un contrato estructural futuro para ejemplos JSON de guías; requiere alcance de mantenimiento separado y no pertenece a #111.
+- **Descartes (modo desatendido):** `guide-min-cli-version`, `guide-applies-when`, `plan-punctuation-validation-drift`, `orchestrator-length-counts-utf16` y `docs-units-match-cli-string-length` — todos corregidos en la rama; no queda una regla nueva autorizada que aplicar.
+- **Journal:** `.awm/journal/` no está inicializado; se omite `awm evidence capture` según el camino no journal-first y se archiva el ledger activo directamente.
+
 ## 2026-09-04 — Issue #110: resolución de skills de orquestador
 
 - **Hallazgos:** la resolución semántica inicial expuso casos de identidad saneada, diagnósticos de una línea y seguridad de lectura de `SKILL.md` (archivo, descriptor y directorios padre). Cada caso quedó cubierto por regresiones unitarias y E2E, incluida una sustitución real de directorio padre.

--- a/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
+++ b/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
@@ -30,7 +30,7 @@
 ## Task 1: Document the declaration contract and verify composition
 
 - [x] Replace the minimal `awm-registry.json` example with the complete three-field `orchestrator` object.
-- [x] State the exact validation constraints: three fields only, non-empty strings, maximum 500 characters, and no trailing period in `appliesWhen`.
+- [x] State the exact parser-validated constraints: three fields only, non-empty strings, and maximum 500 characters; separately document the authoring convention to omit a final period in `appliesWhen` so the renderer does not duplicate punctuation.
 - [x] Explain that `orchestrator.name` must match the `skills/<name>/SKILL.md` directory name; frontmatter `name` does not control discovery.
 - [x] Add `awm context orchestrators --verify mi-proceso` to the local validation flow and explain its exit behavior.
 - [x] Run `git diff --check`, validate the JSON example, build the CLI, and run the targeted context-orchestrator integration test.

--- a/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
+++ b/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
@@ -30,7 +30,7 @@
 ## Task 1: Document the declaration contract and verify composition
 
 - [x] Replace the minimal `awm-registry.json` example with the complete three-field `orchestrator` object.
-- [x] State the exact parser-validated constraints: three fields only, non-empty strings, and maximum 500 characters; separately document the authoring convention to omit a final period in `appliesWhen` so the renderer does not duplicate punctuation.
+- [x] State the exact parser-validated constraints: three fields only, non-empty strings, and maximum 500 UTF-16 units as measured by `String.length`; separately document the authoring convention to omit a final period in `appliesWhen` so the renderer does not duplicate punctuation.
 - [x] Explain that `orchestrator.name` must match the `skills/<name>/SKILL.md` directory name; frontmatter `name` does not control discovery.
 - [x] Add `awm context orchestrators --verify mi-proceso` to the local validation flow and explain its exit behavior.
 - [x] Run `git diff --check`, validate the JSON example, build the CLI, and run the targeted context-orchestrator integration test.

--- a/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
+++ b/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
@@ -2,6 +2,7 @@
 
 <!-- awm-qa-complete: 2026-09-05 -->
 <!-- awm-docs-complete: 2026-09-05 -->
+<!-- awm-retro-complete: 2026-09-05 -->
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development`
 > (recommended) or `executing-plans` to implement this plan task-by-task. Steps

--- a/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
+++ b/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
@@ -1,5 +1,8 @@
 # Issue #111: Orchestrator Authoring Guide Implementation Plan
 
+<!-- awm-qa-complete: 2026-09-05 -->
+<!-- awm-docs-complete: 2026-09-05 -->
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development`
 > (recommended) or `executing-plans` to implement this plan task-by-task. Steps
 > use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
+++ b/docs/plans/2026-09-05-issue-111-authoring-guide-plan.md
@@ -1,0 +1,50 @@
+# Issue #111: Orchestrator Authoring Guide Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development`
+> (recommended) or `executing-plans` to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document the real `orchestrator` block contract and its composition verification in the registry authoring guide.
+
+**Architecture:** Keep the change documentation-only. The guide will show the manifest declaration, explain validation and skill-directory resolution, and add a read-only CLI verification to the existing local-install flow.
+
+**Tech Stack:** Markdown, JSON examples, AWM CLI.
+
+**Modo de ejecución:** desatendido
+
+> Mandato de ejecución desatendida: ejecución completa sin pausas de check-in
+> entre tareas, ni de confirmación entre fases (development-process rutea
+> automáticamente y subagent-driven-development no pregunta si continuar con
+> el cierre). harness-retro triagea con criterio propio del agente (solo valor
+> real, recurrente o sistémico — descarta el resto sin preguntar).
+> post-implementation-qa corrige TODOS los hallazgos que surjan, no solo algunos.
+> finishing-a-development-branch crea el PR directamente (opción "push + PR"),
+> sin presentar el menú de 4 opciones.
+
+## Scope
+
+- Update only `docs/guides/authoring-a-registry-with-an-orchestrator.md` for the user-facing fix.
+- Do not change CLI behavior or add the future contract test proposed by the issue; that broader guard belongs with the related process-lifecycle work.
+- Preserve the guide's existing registry layout, installation, publishing, and isolation sections.
+
+## Task 1: Document the declaration contract and verify composition
+
+- [x] Replace the minimal `awm-registry.json` example with the complete three-field `orchestrator` object.
+- [x] State the exact validation constraints: three fields only, non-empty strings, maximum 500 characters, and no trailing period in `appliesWhen`.
+- [x] Explain that `orchestrator.name` must match the `skills/<name>/SKILL.md` directory name; frontmatter `name` does not control discovery.
+- [x] Add `awm context orchestrators --verify mi-proceso` to the local validation flow and explain its exit behavior.
+- [x] Run `git diff --check`, validate the JSON example, build the CLI, and run the targeted context-orchestrator integration test.
+- [x] Commit the guide and plan with `docs: document orchestrator registry manifest`.
+
+## Verification
+
+Run from the repository root:
+
+```bash
+git diff --check
+node -e 'const fs=require("fs"); const text=fs.readFileSync("docs/guides/authoring-a-registry-with-an-orchestrator.md","utf8"); const heading="## 2. `awm-registry.json`"; const start=text.indexOf(heading); if(start<0) throw new Error("awm-registry.json section not found"); const tail=text.slice(start); const fence="```json\n"; const fenceStart=tail.indexOf(fence); if(fenceStart<0) throw new Error("JSON fence not found"); const jsonStart=fenceStart+fence.length; const jsonEnd=tail.indexOf("\n```", jsonStart); if(jsonEnd<0) throw new Error("JSON fence close not found"); JSON.parse(tail.slice(jsonStart,jsonEnd));'
+npm --prefix cli run build
+npm --prefix cli test -- --runInBand tests/integration/context-orchestrators-e2e.test.ts
+```
+
+The JSON check is expected to be run against the extracted manifest block after the guide is edited; if the guide contains other JSON examples, validate the specific `awm-registry.json` block manually as part of review.


### PR DESCRIPTION
## Summary
- Document the complete `orchestrator` block in `awm-registry.json`.
- Clarify parser constraints, skill-directory resolution, tolerant diagnostics, and UTF-16 length counting.
- Add the real composition verification command to the authoring flow.

Closes #111

## Test Plan
- `git diff --check`
- Manifest example JSON parse
- `npm --prefix cli run build`
- `npm --prefix cli test` — 281 suites passed, 2 skipped; 3487 tests passed, 16 skipped
- `awm sensors run` — overall: pass